### PR TITLE
HTTP API implementation

### DIFF
--- a/seafowl.toml
+++ b/seafowl.toml
@@ -5,8 +5,8 @@ type = "local"
 data_dir = "../seafowl-data"
 
 [catalog]
-type = "postgres"
-dsn = "postgresql://sgr:password@localhost:7432/seafowl"
+type = "sqlite"
+dsn = "../seafowl-data/seafowl.sqlite"
 
 [frontend.postgres]
 bind_port = 6432

--- a/src/context.rs
+++ b/src/context.rs
@@ -399,6 +399,9 @@ pub trait SeafowlContext: Send + Sync {
     async fn reload_schema(&self);
     async fn create_logical_plan(&self, sql: &str) -> Result<LogicalPlan>;
     async fn plan_query(&self, sql: &str) -> Result<Arc<dyn ExecutionPlan>>;
+
+    // TODO: context.create_physical_plan shouldn't be exposed in the interface, since
+    // it bypasses our special way of executing Inserts etc
     async fn create_physical_plan(
         &self,
         plan: &LogicalPlan,

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -187,10 +187,8 @@ mod tests {
 
     use crate::{
         context::{test_utils::in_memory_context, SeafowlContext},
-        frontend::http::ETAG,
+        frontend::http::{filters, ETAG, QUERY_HEADER},
     };
-
-    use super::{cached_read_query, QUERY_HEADER};
 
     /// Build an in-memory context with a single table
     /// We implicitly assume here that this table is the only one in this context
@@ -251,7 +249,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_cached_hash_mismatch() {
         let context = in_memory_context_with_single_table().await;
-        let handler = cached_read_query(context);
+        let handler = filters(context);
 
         let resp = request()
             .method("GET")
@@ -266,7 +264,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_cached_write_query_error() {
         let context = in_memory_context_with_single_table().await;
-        let handler = cached_read_query(context);
+        let handler = filters(context);
 
         let resp = request()
             .method("GET")
@@ -281,7 +279,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_cached_no_etag() {
         let context = in_memory_context_with_single_table().await;
-        let handler = cached_read_query(context);
+        let handler = filters(context);
 
         let resp = request()
             .method("GET")
@@ -297,7 +295,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_cached_no_query() {
         let context = in_memory_context_with_single_table().await;
-        let handler = cached_read_query(context);
+        let handler = filters(context);
 
         let resp = request()
             .method("GET")
@@ -313,7 +311,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_cached_no_etag_query_in_body() {
         let context = in_memory_context_with_single_table().await;
-        let handler = cached_read_query(context);
+        let handler = filters(context);
 
         let resp = request()
             .method("GET")
@@ -329,7 +327,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_cached_no_etag_extension() {
         let context = in_memory_context_with_single_table().await;
-        let handler = cached_read_query(context);
+        let handler = filters(context);
 
         let resp = request()
             .method("GET")
@@ -347,7 +345,7 @@ mod tests {
         // Pass the same ETag as If-None-Match, should return a 301
 
         let context = in_memory_context_with_single_table().await;
-        let handler = cached_read_query(context);
+        let handler = filters(context);
 
         let resp = request()
             .method("GET")
@@ -365,7 +363,7 @@ mod tests {
         // Pass the same ETag as If-None-Match, but the table version changed -> reruns the query
 
         let context = in_memory_context_with_modified_table().await;
-        let handler = cached_read_query(context);
+        let handler = filters(context);
 
         let resp = request()
             .method("GET")

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -69,6 +69,7 @@ pub fn cached_read_query(
     context: Arc<dyn SeafowlContext>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("q" / String)
+        .and(warp::get())
         .and(
             // Extract the query either from the header or from the JSON body
             warp::header::<String>(QUERY_HEADER)

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -143,7 +143,12 @@ pub fn cached_read_query(
 pub fn filters(
     context: Arc<dyn SeafowlContext>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    cached_read_query(context)
+    let cors = warp::cors()
+        .allow_any_origin()
+        .allow_headers(vec!["X-Seafowl-Query", "Authorization"])
+        .allow_methods(vec!["GET", "POST"]);
+
+    cached_read_query(context).with(cors)
 }
 
 pub async fn run_server(context: Arc<dyn SeafowlContext>, config: HttpFrontend) {

--- a/src/wasm_udf/data_types.rs
+++ b/src/wasm_udf/data_types.rs
@@ -22,7 +22,7 @@ pub fn get_volatility(t: &CreateFunctionVolatility) -> Volatility {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, EnumString, Display)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, EnumString, Display, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum CreateFunctionWASMType {
     I32,
@@ -31,7 +31,7 @@ pub enum CreateFunctionWASMType {
     F64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, EnumString, Display)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, EnumString, Display, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum CreateFunctionVolatility {
     Immutable,
@@ -44,7 +44,7 @@ impl Default for CreateFunctionVolatility {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, EnumString, Display)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, EnumString, Display, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum CreateFunctionLanguage {
     Wasm,
@@ -55,7 +55,7 @@ impl Default for CreateFunctionLanguage {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct CreateFunctionDetails {
     pub entrypoint: String,
     #[serde(default)]


### PR DESCRIPTION
Some more implementation for https://github.com/splitgraph/seafowl/issues/20 and other fixes:

  - add CORS
  - add optional `.extension` to `GET /q/hash[.extension` (ignored by us, but used by Cloudflare to see if it's a cacheable asset)
  - add support for query in the `GET` body
  - add `POST /q` to execute uncached RW queries (no authz until https://github.com/splitgraph/seafowl/issues/11)
  - replace mock context with in-memory SQLite (does mean we end up relying on some parts of the context's implementation but is much more concise than using mocks)
  - simplify some routing/parsing