### PR TITLE
Implement CSV/Parquet upload endpoint

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -875,9 +875,8 @@ impl SeafowlContext for DefaultSeafowlContext {
                 // This is actually CREATE TABLE AS
                 let physical = self.create_physical_plan(&input).await?;
 
-                let _res = self
-                    .execute_plan_to_table(&physical, Some(name), None)
-                    .await;
+                self.execute_plan_to_table(&physical, Some(name), None)
+                    .await?;
 
                 Ok(make_dummy_exec())
             }
@@ -911,13 +910,12 @@ impl SeafowlContext for DefaultSeafowlContext {
                         SeafowlExtensionNode::Insert(Insert { table, input, .. }) => {
                             let physical = self.create_physical_plan(input).await?;
 
-                            let _res = self
-                                .execute_plan_to_table(
-                                    &physical,
-                                    None,
-                                    Some(table.table_version_id),
-                                )
-                                .await;
+                            self.execute_plan_to_table(
+                                &physical,
+                                None,
+                                Some(table.table_version_id),
+                            )
+                            .await?;
 
                             Ok(make_dummy_exec())
                         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1054,11 +1054,8 @@ impl SeafowlContext for DefaultSeafowlContext {
             }
         };
 
-        let res = self
-            .execute_plan_to_table(&plan, full_table_name, from_table_version)
-            .await;
-
-        res
+        self.execute_plan_to_table(&plan, full_table_name, from_table_version)
+            .await
     }
 }
 

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -278,8 +278,7 @@ fn load_csv_bytes(
     let schema = csv_reader.schema().as_ref().clone();
     let partition: Vec<RecordBatch> = csv_reader
         .into_iter()
-        .collect::<Result<Vec<RecordBatch>, ArrowError>>()
-        .unwrap();
+        .collect::<Result<Vec<RecordBatch>, ArrowError>>()?;
 
     Ok((schema, partition))
 }
@@ -293,8 +292,8 @@ fn load_parquet_bytes(source: Vec<u8>) -> Result<(Schema, Vec<RecordBatch>), Arr
     let partition: Vec<RecordBatch> = parquet_reader
         .get_record_reader(1024)
         .unwrap()
-        .collect::<Result<Vec<RecordBatch>, ArrowError>>()
-        .unwrap();
+        .collect::<Result<Vec<RecordBatch>, ArrowError>>(
+    )?;
 
     Ok((schema, partition))
 }


### PR DESCRIPTION
This addresses the issue #40, by providing a POST endpoint `/upload/[schema]/[table]`, whereby the provided file contents are parsed and used to create/append to table.