### PR TITLE
Add V0 AuthZ and basic HTTP error handling

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,307 @@
+use crate::config::schema::{str_to_hex_hash, AccessSettings, HttpFrontend};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Principal {
+    Anonymous,
+    Writer,
+    Reader,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resource {
+    Database,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Action {
+    Read,
+    Write,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccessPolicy {
+    pub read: AccessSettings,
+    pub write: AccessSettings,
+}
+
+impl AccessPolicy {
+    pub fn from_config(config: &HttpFrontend) -> Self {
+        Self {
+            read: config.read_access.clone(),
+            write: config.write_access.clone(),
+        }
+    }
+}
+
+pub fn token_to_principal(
+    token: Option<String>,
+    policy: &AccessPolicy,
+    // TODO: error enums instead of strings
+) -> Result<Principal, String> {
+    match (token, &policy.write, &policy.read) {
+        // If both read and write require a password and the user didn't pass a token: error
+        (
+            None,
+            AccessSettings::Off | AccessSettings::Password { sha256_hash: _ },
+            AccessSettings::Off | AccessSettings::Password { sha256_hash: _ },
+        ) => Err("UNAUTHORIZED".to_string()),
+        (None, _, _) => Ok(Principal::Anonymous),
+        // If password auth is disabled and the user passed a token: error
+        (
+            Some(_),
+            AccessSettings::Any | AccessSettings::Off,
+            AccessSettings::Any | AccessSettings::Off,
+        ) => Err("TOKEN_NOT_NEEDED".to_string()),
+
+        (Some(t), AccessSettings::Password { sha256_hash }, _)
+            if str_to_hex_hash(&t) == sha256_hash.as_str() =>
+        {
+            Ok(Principal::Writer)
+        }
+        (Some(t), _, AccessSettings::Password { sha256_hash })
+            if str_to_hex_hash(&t) == sha256_hash.as_str() =>
+        {
+            Ok(Principal::Reader)
+        }
+        // If the token's hash didn't match: error (TODO 401?)
+        (Some(_), _, _) => Err("WRONG_PASSWORD".to_string()),
+    }
+}
+
+pub fn can_perform_action(
+    principal: &Principal,
+    action: Action,
+    _: Resource,
+    policy: &AccessPolicy,
+) -> bool {
+    matches!(
+        (principal, action, &policy.read, &policy.write),
+        // Writer can do anything (note we don't issue Writer/Reader if the policy for Write/Read doesn't have a password)
+        (Principal::Writer, _, _, _)
+        // Reader can always read
+            | (Principal::Reader, Action::Read, _, _)
+        // Anyone can read if we enabled reads for everyone
+            | (_, Action::Read, AccessSettings::Any, _)
+        // Anyone can write if we enabled writes for everyone
+            | (_, Action::Write, _, AccessSettings::Any)
+    )
+}
+
+pub struct UserContext {
+    pub principal: Principal,
+    pub policy: AccessPolicy,
+}
+
+impl UserContext {
+    pub fn can_perform_action(&self, action: Action) -> bool {
+        can_perform_action(&self.principal, action, Resource::Database, &self.policy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        auth::{Action, UserContext},
+        config::schema::AccessSettings,
+    };
+
+    use super::{token_to_principal, AccessPolicy, Principal};
+
+    const READ_PW: &str = "read_password";
+    const WRITE_PW: &str = "write_password";
+
+    const READ_SHA: &str =
+        "e604c988653812541f3ea980d29d3109cbe8fc1b0fb64edb71d17a8a8efd409d";
+    const WRITE_SHA: &str =
+        "b786e07f52fc72d32b2163b6f63aa16344fd8d2d84df87b6c231ab33cd5aa125";
+
+    fn free_for_all() -> AccessPolicy {
+        AccessPolicy {
+            read: AccessSettings::Any,
+            write: AccessSettings::Any,
+        }
+    }
+
+    fn need_write_pw() -> AccessPolicy {
+        AccessPolicy {
+            read: AccessSettings::Any,
+            write: AccessSettings::Password {
+                sha256_hash: WRITE_SHA.to_string(),
+            },
+        }
+    }
+
+    fn read_only_write_off() -> AccessPolicy {
+        AccessPolicy {
+            read: AccessSettings::Any,
+            write: AccessSettings::Off,
+        }
+    }
+
+    fn read_pw_write_off() -> AccessPolicy {
+        AccessPolicy {
+            read: AccessSettings::Password {
+                sha256_hash: READ_SHA.to_string(),
+            },
+            write: AccessSettings::Off,
+        }
+    }
+
+    fn read_pw_write_pw() -> AccessPolicy {
+        AccessPolicy {
+            read: AccessSettings::Password {
+                sha256_hash: READ_SHA.to_string(),
+            },
+            write: AccessSettings::Password {
+                sha256_hash: WRITE_SHA.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_all_allowed_disallows_token() {
+        assert_eq!(
+            token_to_principal(Some(READ_PW.to_string()), &free_for_all()),
+            Err("TOKEN_NOT_NEEDED".to_string())
+        )
+    }
+
+    #[test]
+    fn test_all_allowed_anon() {
+        let policy = free_for_all();
+        assert_eq!(token_to_principal(None, &policy), Ok(Principal::Anonymous));
+
+        let context = UserContext {
+            principal: Principal::Anonymous,
+            policy,
+        };
+
+        assert!(context.can_perform_action(Action::Read));
+        assert!(context.can_perform_action(Action::Write));
+    }
+
+    #[test]
+    fn test_write_pw_wrong_token() {
+        let policy = need_write_pw();
+        assert_eq!(
+            token_to_principal(Some(READ_PW.to_string()), &policy),
+            Err("WRONG_PASSWORD".to_string())
+        );
+    }
+
+    #[test]
+    fn test_write_pw_correct_token_can_read_write() {
+        let policy = need_write_pw();
+        assert_eq!(
+            token_to_principal(Some(WRITE_PW.to_string()), &policy),
+            Ok(Principal::Writer)
+        );
+
+        let context = UserContext {
+            principal: Principal::Writer,
+            policy,
+        };
+        assert!(context.can_perform_action(Action::Read));
+        assert!(context.can_perform_action(Action::Write));
+    }
+
+    #[test]
+    fn test_write_pw_anonymous_only_read() {
+        let policy = need_write_pw();
+        assert_eq!(token_to_principal(None, &policy), Ok(Principal::Anonymous));
+
+        let context = UserContext {
+            principal: Principal::Anonymous,
+            policy,
+        };
+
+        assert!(context.can_perform_action(Action::Read));
+        assert!(!context.can_perform_action(Action::Write));
+    }
+
+    #[test]
+    fn test_read_only_disallows_token() {
+        assert_eq!(
+            token_to_principal(Some(READ_PW.to_string()), &read_only_write_off()),
+            Err("TOKEN_NOT_NEEDED".to_string())
+        )
+    }
+
+    #[test]
+    fn test_read_only_can_read_cant_write() {
+        let policy = read_only_write_off();
+        assert_eq!(token_to_principal(None, &policy), Ok(Principal::Anonymous));
+
+        let context = UserContext {
+            principal: Principal::Anonymous,
+            policy,
+        };
+
+        assert!(context.can_perform_action(Action::Read));
+        assert!(!context.can_perform_action(Action::Write));
+    }
+
+    #[test]
+    fn test_read_pw_write_off_disallows_anon() {
+        assert_eq!(
+            token_to_principal(None, &read_pw_write_off()),
+            Err("UNAUTHORIZED".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_pw_write_off_only_read() {
+        let policy = read_pw_write_off();
+        assert_eq!(
+            token_to_principal(Some(READ_PW.to_string()), &policy),
+            Ok(Principal::Reader)
+        );
+        let context = UserContext {
+            principal: Principal::Reader,
+            policy,
+        };
+
+        assert!(context.can_perform_action(Action::Read));
+        assert!(!context.can_perform_action(Action::Write));
+    }
+
+    #[test]
+    fn test_read_write_pw_disallows_anon() {
+        assert_eq!(
+            token_to_principal(None, &read_pw_write_pw()),
+            Err("UNAUTHORIZED".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_write_pw_reader_can_only_read() {
+        let policy = read_pw_write_pw();
+        assert_eq!(
+            token_to_principal(Some(READ_PW.to_string()), &policy),
+            Ok(Principal::Reader)
+        );
+        let context = UserContext {
+            principal: Principal::Reader,
+            policy,
+        };
+
+        assert!(context.can_perform_action(Action::Read));
+        assert!(!context.can_perform_action(Action::Write));
+    }
+
+    #[test]
+    fn test_read_write_pw_writer_can_read_write() {
+        let policy = read_pw_write_pw();
+        assert_eq!(
+            token_to_principal(Some(WRITE_PW.to_string()), &policy),
+            Ok(Principal::Writer)
+        );
+        let context = UserContext {
+            principal: Principal::Writer,
+            policy,
+        };
+
+        assert!(context.can_perform_action(Action::Read));
+        assert!(context.can_perform_action(Action::Write));
+    }
+}

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -152,6 +152,8 @@ mod tests {
                 http: Some(schema::HttpFrontend {
                     bind_host: "127.0.0.1".to_string(),
                     bind_port: 80,
+                    read_access: schema::AccessSettings::Any,
+                    write_access: schema::AccessSettings::Any,
                 }),
             },
             misc: schema::Misc {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -113,12 +113,16 @@ impl<'de> Deserialize<'de> for AccessSettings {
     }
 }
 
+pub fn str_to_hex_hash(input: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input);
+    encode(hasher.finalize())
+}
+
 impl AccessSettings {
     pub fn with_random_password() -> Self {
         let password = Alphanumeric.sample_string(&mut rand::thread_rng(), 32);
-        let mut hasher = Sha256::new();
-        hasher.update(&password);
-        let sha256_hash = encode(hasher.finalize());
+        let sha256_hash = str_to_hex_hash(&password);
 
         info!("Writing to Seafowl will require a password. Randomly generated password: {:}", password);
         info!("The SHA-256 hash will be stored in the config as follows:");

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -213,31 +213,14 @@ bind_port = 80
         let config = load_config_from_string(TEST_CONFIG_S3, false).unwrap();
 
         assert_eq!(
-            config,
-            SeafowlConfig {
-                object_store: ObjectStore::S3(S3 {
-                    access_key_id: "AKI...".to_string(),
-                    secret_access_key: "ABC...".to_string(),
-                    endpoint: "https://s3.amazonaws.com:9000".to_string(),
-                    bucket: "seafowl".to_string()
-                }),
-                catalog: Catalog::Postgres(Postgres {
-                    dsn: "postgresql://user:pass@localhost:5432/somedb".to_string(),
-                    schema: "public".to_string()
-                }),
-                frontend: Frontend {
-                    #[cfg(feature = "frontend-postgres")]
-                    postgres: None,
-                    http: Some(HttpFrontend {
-                        bind_host: "0.0.0.0".to_string(),
-                        bind_port: 80
-                    })
-                },
-                misc: Misc {
-                    max_partition_size: 1048576
-                },
-            }
-        )
+            config.object_store,
+            ObjectStore::S3(S3 {
+                access_key_id: "AKI...".to_string(),
+                secret_access_key: "ABC...".to_string(),
+                endpoint: "https://s3.amazonaws.com:9000".to_string(),
+                bucket: "seafowl".to_string()
+            })
+        );
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -893,7 +893,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                 // This is actually CREATE TABLE AS
                 let physical = self.create_physical_plan(input).await?;
 
-                self.execute_plan_to_table(&physical, Some(name), None)
+                self.execute_plan_to_table(&physical, Some(name.to_string()), None)
                     .await?;
 
                 Ok(make_dummy_exec())

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -36,6 +36,8 @@ use crate::{
 const QUERY_HEADER: &str = "X-Seafowl-Query";
 const IF_NONE_MATCH: &str = "If-None-Match";
 const ETAG: &str = "ETag";
+const AUTHORIZATION: &str = "Authorization";
+const BEARER_PREFIX: &str = "Bearer ";
 
 #[derive(Default)]
 struct ETagBuilderVisitor {
@@ -127,15 +129,15 @@ pub async fn uncached_read_write_query(
 pub fn with_auth(
     policy: AccessPolicy,
 ) -> impl Filter<Extract = (UserContext,), Error = Rejection> + Clone {
-    warp::header::optional::<String>("Authorization").and_then(
+    warp::header::optional::<String>(AUTHORIZATION).and_then(
         move |header: Option<String>| {
             let token = match header {
                 Some(h) => {
-                    if !h.starts_with("Bearer ") {
+                    if !h.starts_with(BEARER_PREFIX) {
                         return future::err(warp::reject::reject());
                     };
 
-                    Some(h.trim_start_matches("Bearer ").to_string())
+                    Some(h.trim_start_matches(BEARER_PREFIX).to_string())
                 }
                 None => None,
             };

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -35,7 +35,7 @@ use crate::{
     provider::SeafowlTable,
 };
 
-use super::http_utils::{into_response, ApiError};
+use super::http_utils::{handle_rejection, into_response, ApiError};
 
 const QUERY_HEADER: &str = "X-Seafowl-Query";
 const IF_NONE_MATCH: &str = "If-None-Match";
@@ -417,6 +417,7 @@ pub fn filters(
         .or(uncached_read_write_query_route)
         .or(upload_route)
         .with(cors)
+        .recover(handle_rejection)
 }
 
 pub async fn run_server(context: Arc<dyn SeafowlContext>, config: HttpFrontend) {

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -1152,7 +1152,6 @@ SELECT
         add_headers: Option<bool>,
     ) {
         let context = in_memory_context_with_single_table().await;
-        let _handler = filters(context.clone(), free_for_all());
 
         let table_name = format!("{}_table", file_format);
 

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -452,7 +452,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::auth::AccessPolicy;
-    use crate::config::schema::AccessSettings;
+
     use crate::{
         context::{test_utils::in_memory_context, SeafowlContext},
         frontend::http::{filters, ETAG, QUERY_HEADER},
@@ -504,10 +504,7 @@ mod tests {
     }
 
     fn free_for_all() -> AccessPolicy {
-        AccessPolicy {
-            read: AccessSettings::Any,
-            write: AccessSettings::Any,
-        }
+        AccessPolicy::free_for_all()
     }
 
     const SELECT_QUERY: &str = "SELECT COUNT(*) AS c FROM test_table";

--- a/src/frontend/http_utils.rs
+++ b/src/frontend/http_utils.rs
@@ -51,6 +51,7 @@ pub enum ApiError {
     DataFusionError(DataFusionError),
     HashMismatch(String, String),
     NotReadOnlyQuery,
+    ReadOnlyEndpointDisabled,
 }
 
 // Wrap DataFusion errors so that we can automagically return an
@@ -72,6 +73,7 @@ impl ApiError {
             // Mismatched hash
             ApiError::HashMismatch(expected, got) => (StatusCode::BAD_REQUEST, format!("Invalid hash: expected {0:?}, got {1:?}. Resend your query with {0:?}", expected, got)),
             ApiError::NotReadOnlyQuery => (StatusCode::METHOD_NOT_ALLOWED, "NOT_READ_ONLY_QUERY".to_string()),
+            ApiError::ReadOnlyEndpointDisabled => (StatusCode::METHOD_NOT_ALLOWED, "READ_ONLY_ENDPOINT_DISABLED".to_string())
         }
     }
 

--- a/src/frontend/http_utils.rs
+++ b/src/frontend/http_utils.rs
@@ -1,0 +1,82 @@
+// Warp error handling and propagation
+// Courtesy of https://github.com/seanmonstar/warp/pull/909#issuecomment-1184854848
+//
+// Usage:
+//
+//   1) A handler function, instead of returning a Warp reply/rejection, returns a
+//   `Result<Reply, ApiError>.`
+//
+//   This is because rejections are meant to say "this filter can't handle this request, but maybe
+//   some other can" (see https://github.com/seanmonstar/warp/issues/388#issuecomment-576453485).
+//   A rejection means Warp will fall through to another filter and ultimately hit a rejection
+//   handler, with people reporting rejections take way too long to process with more routes.
+//
+//   In our case, the error in our handler function is final and we also would like to be able
+//   to use the ? operator to bail out of the handler if an error exists, which using a Result type
+//   handles for us.
+//
+//   2) ApiError knows how to convert itself to an HTTP response + status code (error-specific), allowing
+//   us to implement Reply for ApiError.
+//
+//   3) We can't implement Reply for Result<Reply, Reply> (we don't control Result), so we have to
+//   add a final function `into_response` that converts our Result into a Response. We won't need
+//   to do this when https://github.com/seanmonstar/warp/pull/909 is merged:
+//
+//   ```
+//   .then(my_handler_func)
+//   .map(into_response)
+//   ```
+//
+
+use datafusion::error::DataFusionError;
+
+use warp::hyper::{Body, Response, StatusCode};
+use warp::Reply;
+
+#[derive(Debug)]
+pub enum ApiError {
+    Forbidden,
+    DataFusionError(DataFusionError),
+    HashMismatch(String, String),
+    NotReadOnlyQuery,
+}
+
+// Wrap DataFusion errors so that we can automagically return an
+// `ApiError(DataFusionError)` by using the `?` operator
+impl From<DataFusionError> for ApiError {
+    fn from(err: DataFusionError) -> Self {
+        ApiError::DataFusionError(err)
+    }
+}
+
+impl ApiError {
+    fn status_code_body(self: ApiError) -> (StatusCode, String) {
+        match self {
+            ApiError::Forbidden => (StatusCode::FORBIDDEN, "FORBIDDEN".to_string()),
+            // TODO: figure out which DF errors to propagate, we have ones that are the server's fault
+            // here too (e.g. ResourcesExhaused) and potentially some that leak internal information
+            // (e.g. ObjectStore?)
+            ApiError::DataFusionError(e) => (StatusCode::BAD_REQUEST, e.to_string()),
+            // Mismatched hash
+            ApiError::HashMismatch(expected, got) => (StatusCode::BAD_REQUEST, format!("Invalid hash: expected {0:?}, got {1:?}. Resend your query with {0:?}", expected, got)),
+            ApiError::NotReadOnlyQuery => (StatusCode::METHOD_NOT_ALLOWED, "NOT_READ_ONLY_QUERY".to_string()),
+        }
+    }
+}
+
+impl Reply for ApiError {
+    fn into_response(self) -> Response<Body> {
+        let (status, body) = self.status_code_body();
+        Response::builder()
+            .status(status)
+            .body(body.into())
+            .expect("Could not construct Response")
+    }
+}
+
+pub fn into_response<S: Reply, E: Reply>(reply_res: Result<S, E>) -> Response<Body> {
+    match reply_res {
+        Ok(resp) => resp.into_response(),
+        Err(err) => err.into_response(),
+    }
+}

--- a/src/frontend/http_utils.rs
+++ b/src/frontend/http_utils.rs
@@ -52,6 +52,10 @@ pub enum ApiError {
     HashMismatch(String, String),
     NotReadOnlyQuery,
     ReadOnlyEndpointDisabled,
+    NeedAccessToken,
+    UselessAccessToken,
+    WrongAccessToken,
+    InvalidAuthorizationHeader,
 }
 
 // Wrap DataFusion errors so that we can automagically return an
@@ -73,7 +77,11 @@ impl ApiError {
             // Mismatched hash
             ApiError::HashMismatch(expected, got) => (StatusCode::BAD_REQUEST, format!("Invalid hash: expected {0:?}, got {1:?}. Resend your query with {0:?}", expected, got)),
             ApiError::NotReadOnlyQuery => (StatusCode::METHOD_NOT_ALLOWED, "NOT_READ_ONLY_QUERY".to_string()),
-            ApiError::ReadOnlyEndpointDisabled => (StatusCode::METHOD_NOT_ALLOWED, "READ_ONLY_ENDPOINT_DISABLED".to_string())
+            ApiError::ReadOnlyEndpointDisabled => (StatusCode::METHOD_NOT_ALLOWED, "READ_ONLY_ENDPOINT_DISABLED".to_string()),
+            ApiError::NeedAccessToken => (StatusCode::UNAUTHORIZED, "NEED_ACCESS_TOKEN".to_string()),
+            ApiError::UselessAccessToken => (StatusCode::BAD_REQUEST, "USELESS_ACCESS_TOKEN".to_string()),
+            ApiError::WrongAccessToken => (StatusCode::FORBIDDEN, "INVALID_ACCESS_TOKEN".to_string()),
+            ApiError::InvalidAuthorizationHeader => (StatusCode::UNAUTHORIZED, "INVALID_AUTHORIZATION_HEADER".to_string()),
         }
     }
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1,3 +1,4 @@
 pub mod http;
+pub mod http_utils;
 #[cfg(feature = "frontend-postgres")]
 pub mod postgres;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod catalog;
 pub mod config;
 pub mod context;

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1,0 +1,164 @@
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::Future;
+use futures::FutureExt;
+use seafowl::auth::AccessPolicy;
+use seafowl::config::context::build_context;
+use seafowl::config::schema::load_config_from_string;
+
+use seafowl::frontend::http::filters;
+use warp::hyper::body::to_bytes;
+use warp::hyper::client::HttpConnector;
+use warp::hyper::Body;
+use warp::hyper::Client;
+use warp::hyper::Method;
+use warp::hyper::Request;
+use warp::hyper::Response;
+use warp::hyper::StatusCode;
+
+use std::net::SocketAddr;
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::Sender;
+
+/// Make an HTTP server that listens on a random free port,
+/// uses an in-memory SQLite and requires a password ("write_password") for writes
+/// Returns the server's address, the actual server Future and a channel to stop the server
+async fn make_read_only_http_server() -> (
+    SocketAddr,
+    Pin<Box<dyn Future<Output = ()> + Send>>,
+    Sender<()>,
+) {
+    let config_text = r#"
+[object_store]
+type = "memory"
+
+[catalog]
+type = "sqlite"
+dsn = ":memory:"
+
+[frontend.http]
+# sha hash of "write_password"
+write_access = "b786e07f52fc72d32b2163b6f63aa16344fd8d2d84df87b6c231ab33cd5aa125""#;
+
+    let config = load_config_from_string(config_text, false).unwrap();
+    let context = build_context(&config).await;
+
+    let filters = filters(
+        Arc::from(context),
+        AccessPolicy::from_config(&config.frontend.http.unwrap()),
+    );
+    let (tx, rx) = oneshot::channel();
+    let (addr, server) = warp::serve(filters).bind_with_graceful_shutdown(
+        // Pass port :0 to pick a random free port
+        "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        async {
+            rx.await.ok();
+        },
+    );
+
+    dbg!(format!("Starting the server on {:?}", addr));
+    (addr, server.boxed(), tx)
+}
+
+async fn response_text(response: Response<Body>) -> String {
+    let body_bytes = to_bytes(response.into_body()).await.unwrap();
+    String::from_utf8(body_bytes.to_vec()).unwrap()
+}
+
+fn query_body(query: &str) -> Body {
+    Body::from(serde_json::to_string(&HashMap::from([("query", query)])).unwrap())
+}
+
+async fn post_query(
+    client: &Client<HttpConnector>,
+    uri: &str,
+    query: &str,
+    token: Option<&str>,
+) -> Response<Body> {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header("content-type", "application/json");
+
+    if let Some(t) = token {
+        builder = builder.header("Authorization", format!("Bearer {}", t));
+    }
+
+    let req = builder.body(query_body(query)).unwrap();
+    client.request(req).await.unwrap()
+}
+
+#[tokio::test]
+async fn test_http_server_reader_writer() {
+    // It's questionable how much value this testing adds on top of the tests in http.rs, but we do:
+    //   - test the code consumes the config correctly, which we don't do in HTTP tests
+    //   - hit the server that's actually listening on a port instead of calling warp routines directly.
+    // Still, this test is mostly to make sure the whole thing roughly does what is intended by the config.
+
+    let (addr, server, terminate) = make_read_only_http_server().await;
+
+    tokio::task::spawn(server);
+    let client = Client::new();
+    let uri = format!("http://{}/q", addr);
+
+    // POST SELECT 1 as a read-only user
+    let resp = post_query(&client, &uri, "SELECT 1", None).await;
+    dbg!(&resp);
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(response_text(resp).await, "{\"Int64(1)\":1}\n");
+
+    // POST CREATE TABLE as a read-only user
+    let resp =
+        post_query(&client, &uri, "CREATE TABLE test_table (col INTEGER)", None).await;
+    dbg!(&resp);
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response_text(resp).await, "WRITE_FORBIDDEN");
+
+    // Same, wrong token
+    let resp = post_query(
+        &client,
+        &uri,
+        "CREATE TABLE test_table (col INTEGER)",
+        Some("wrongpw"),
+    )
+    .await;
+    dbg!(&resp);
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(response_text(resp).await, "INVALID_ACCESS_TOKEN");
+
+    // Perform a write correctly
+    let resp = post_query(
+        &client,
+        &uri,
+        "CREATE TABLE test_table (col INTEGER)",
+        Some("write_password"),
+    )
+    .await;
+    dbg!(&resp);
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // TODO use single statement when https://github.com/splitgraph/seafowl/issues/48 lands
+    let resp = post_query(
+        &client,
+        &uri,
+        "INSERT INTO test_table VALUES(1)",
+        Some("write_password"),
+    )
+    .await;
+    dbg!(&resp);
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // SELECT from the table as a read-only user
+    let resp = post_query(&client, &uri, "SELECT * FROM test_table", None).await;
+    dbg!(&resp);
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(response_text(resp).await, "{\"col\":1}\n");
+
+    // Stop the server
+    // NB this won't run if the test fails, but at that point we're terminating the process
+    // anyway. Maybe it'll become a problem if we have a bunch of tests running that all
+    // start servers and don't stop them.
+    terminate.send(()).unwrap();
+}


### PR DESCRIPTION
- See `src/frontend/http_utils.rs` for errors that are now raised/returned
- See `src/auth.rs` for the auth policy (which now matches https://www.splitgraph.com/docs/seafowl/reference/seafowl-toml-configuration#frontendhttp-section)