### PR TITLE
CLI niceties

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -358,11 +358,6 @@ write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c
     fn test_parse_config_basic() {
         let config = load_config_from_string(TEST_CONFIG_BASIC, false).unwrap();
 
-        let sha256_hash = match &config.frontend.http.as_ref().unwrap().write_access {
-            AccessSettings::Password { sha256_hash } => sha256_hash.clone(),
-            _ => panic!("write_access didn't default to a password!"),
-        };
-
         assert_eq!(
             config,
             SeafowlConfig {
@@ -380,7 +375,7 @@ write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c
                         bind_host: "0.0.0.0".to_string(),
                         bind_port: 80,
                         read_access: AccessSettings::Any,
-                        write_access: AccessSettings::Password { sha256_hash }
+                        write_access: AccessSettings::Off,
                     })
                 },
                 misc: Misc {
@@ -425,7 +420,13 @@ write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c
 
     #[test]
     fn test_default_config() {
-        // Just run the default config builder to make sure the config parses
-        let (_config_str, _config) = build_default_config();
+        // Run the default config builder to make sure the config parses
+        let (_config_str, config) = build_default_config();
+
+        // Make sure we default to requiring a password for writes
+        match &config.frontend.http.as_ref().unwrap().write_access {
+            AccessSettings::Password { sha256_hash: _ } => (),
+            _ => panic!("write_access didn't default to a password!"),
+        };
     }
 }

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -42,6 +42,9 @@ const IF_NONE_MATCH: &str = "If-None-Match";
 const ETAG: &str = "ETag";
 const AUTHORIZATION: &str = "Authorization";
 const BEARER_PREFIX: &str = "Bearer ";
+// We have a very lax CORS on this, so we don't mind browsers
+// caching it for as long as possible.
+const CORS_MAXAGE: u32 = 86400;
 
 #[derive(Default)]
 struct ETagBuilderVisitor {
@@ -378,7 +381,8 @@ pub fn filters(
     let cors = warp::cors()
         .allow_any_origin()
         .allow_headers(vec!["X-Seafowl-Query", "Authorization", "Content-Type"])
-        .allow_methods(vec!["GET", "POST"]);
+        .allow_methods(vec!["GET", "POST"])
+        .max_age(CORS_MAXAGE);
 
     let log = warp::log(module_path!());
 

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -380,6 +380,8 @@ pub fn filters(
         .allow_headers(vec!["X-Seafowl-Query", "Authorization", "Content-Type"])
         .allow_methods(vec!["GET", "POST"]);
 
+    let log = warp::log(module_path!());
+
     // Cached read query
     let ctx = context.clone();
     let cached_read_query_route = warp::path!("q" / String)
@@ -423,6 +425,7 @@ pub fn filters(
         .or(uncached_read_write_query_route)
         .or(upload_route)
         .with(cors)
+        .with(log)
         .recover(handle_rejection)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-use std::{path::PathBuf, pin::Pin, sync::Arc};
+use std::{env, path::PathBuf, pin::Pin, sync::Arc};
 
 use clap::Parser;
 
 use futures::{future::join_all, Future, FutureExt};
 
+use pretty_env_logger::env_logger;
 use seafowl::{
     config::{
         context::build_context,
@@ -56,7 +57,15 @@ fn prepare_frontends(
 
 #[tokio::main]
 async fn main() {
-    pretty_env_logger::init_timed();
+    let mut builder = pretty_env_logger::formatted_timed_builder();
+
+    builder
+        .parse_filters(
+            env::var(env_logger::DEFAULT_FILTER_ENV)
+                .unwrap_or_else(|_| "sqlx=warn,info".to_string())
+                .as_str(),
+        )
+        .init();
 
     info!("Starting Seafowl");
     let args = Args::parse();


### PR DESCRIPTION
- Set logging to INFO by default (except for sqlx which logs too much at INFO, so downgrade it to WARN)
  - users can override logging using the `RUST_LOG` envvar (https://docs.rs/env_logger/latest/env_logger/#enabling-logging)
- Log warp access at INFO level (things like `2022-08-17T10:43:40.224Z INFO  seafowl::frontend::http > 127.0.0.1:55508 "OPTIONS /q/ HTTP/1.1" 405 "-" "curl/7.68.0" 98.455µs`)
- Generate a default config and output it to `seafowl.toml` on first run / if it doesn't exist
- Add `access-control-max-age: 86400` to CORS preflights so that they're cached by the browser for more than 5 seconds