### PR TITLE
Add binary version info and nightly release builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,63 @@
+name: Build nightly binaries
+
+on:
+  push:
+
+jobs:
+  build_binary:
+    name: Build the binaries
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        build: [linux, macos, win-msvc]
+        include:
+          - build: linux
+            os: ubuntu-18.04
+            target: x86_64-unknown-linux-gnu
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: win-msvc
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # shared-key: ""
+          # key: ""
+          # env-vars: ""
+          # workspaces: ""
+
+          # Determines if the cache should be saved even when the workflow has failed.
+          cache-on-failure: "true"
+
+      - name: Build the release binary
+        run: cargo build --release
+
+      - name: Strip release binary (linux and macos)
+        if: matrix.build == 'linux' || matrix.build == 'macos'
+        run: strip "target/release/seafowl"
+
+      - name: Build artifact name
+        shell: bash
+        run: |
+          artifact_name="seafowl-nightly-$(echo ${GITHUB_SHA} | cut -c1-8)-${{ matrix.target }}"
+
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            echo "SOURCE=target/release/seafowl.exe" >> $GITHUB_ENV
+            echo "ARTIFACT=$artifact_name.exe" >> $GITHUB_ENV
+          else
+            echo "SOURCE=target/release/seafowl" >> $GITHUB_ENV
+            echo "ARTIFACT=$artifact_name" >> $GITHUB_ENV
+          fi
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: ${{ env.SOURCE }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,8 @@ name: Build nightly binaries
 
 on:
   push:
+    branches:
+      - main
 
 jobs:
   build_binary:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,17 +44,15 @@ jobs:
         if: matrix.build == 'linux' || matrix.build == 'macos'
         run: strip "target/release/seafowl"
 
-      - name: Build artifact name
+      - name: Prepare artifact name
         shell: bash
         run: |
-          artifact_name="seafowl-nightly-$(echo ${GITHUB_SHA} | cut -c1-8)-${{ matrix.target }}"
+          echo "ARTIFACT=seafowl-nightly-${{ matrix.target }}" >> $GITHUB_ENV
 
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             echo "SOURCE=target/release/seafowl.exe" >> $GITHUB_ENV
-            echo "ARTIFACT=$artifact_name.exe" >> $GITHUB_ENV
           else
             echo "SOURCE=target/release/seafowl" >> $GITHUB_ENV
-            echo "ARTIFACT=$artifact_name" >> $GITHUB_ENV
           fi
 
       - uses: actions/upload-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "seafowl"
+build = "build.rs"
 version = "0.1.0"
 edition = "2021"
 
@@ -53,3 +54,7 @@ wasmtime = "0.38.1"
 [dev-dependencies]
 mockall = "0.11.1"
 test-case = "*"
+
+[build-dependencies]
+anyhow = "1.0.60"  # for build.rs
+vergen = "7"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 [Home page](https://seafowl.io) |
 [Documentation](https://www.splitgraph.com/docs/seafowl/getting-started/introduction) |
-[Nightly builds](https://nightly.link/splitgraph/seafowl/workflows/nightly/main)
+[Nightly builds](https://nightly.link/splitgraph/seafowl/workflows/nightly/main) |
 [Download](https://github.com/splitgraph/seafowl/releases)
 
-Seafowl is an analytical database designed for modern data-driven Web applications.
+Seafowl is an analytical database for modern data-driven Web applications.
+
+It lets you deliver data to your visualizations, dashboards and notebooks by running SQL straight
+from the user's browser, without having to write custom API endpoints.
 
 ## Work in progress
 
@@ -25,38 +28,39 @@ see [this issue](https://github.com/actions/upload-artifact/issues/51)) or **via
 
 ## Initial release roadmap
 
-### Fast analytical queries
+### Fast analytics...
 
-Seafowl is built around [Apache DataFusion](https://github.com/apache/arrow-datafusion), a powerful
-and extensible SQL query engine that uses Apache Arrow and Apache Parquet.
+Seafowl is built around
+[Apache DataFusion](https://arrow.apache.org/datafusion/user-guide/introduction.html), a fast and
+extensible query execution framework. It uses [Apache Parquet](https://parquet.apache.org/) columnar
+storage, making it perfect for analytical workloads.
 
-Besides fast analytical `SELECT` queries, Seafowl also supports writes and `CREATE TABLE AS`
-statements, making it easy to ingest your data into it.
+For `SELECT` queries, Seafowl supports a large subset of the PostgreSQL dialect. If there's
+something missing, you can
+[write a user-defined function](https://splitgraph.com/docs/seafowl/guides/custom-udf-wasi) for
+Seafowl in anything that compiles to WebAssembly.
 
-Seafowl's architecture is inspired by modern cloud data warehouses like Snowflake and Google
-BigQuery, as well as the lessons we learned over the past few years of working on
-[Splitgraph](https://www,splitgraph.com/) and [sgr](https://github.com/splitgraph/sgr/):
+In addition, you can write data to Seafowl by
+[uploading a CSV or a Parquet file](https://splitgraph.com/docs/seafowl/guides/uploading-csv-parquet),
+creating an external table or using
+[standard SQL statements](https://splitgraph.com/docs/seafowl/guides/writing-sql-queries).
 
-- **Separation of storage and compute**. You can store Seafowl data in object storage or on a
-  persistent volume and spin up Seafowl instances on-demand to satisfy incoming queries.
-- **Partition pruning**. Seafowl splits tables into partitions (stored as Parquet files) and indexes
-  them to satisfy filter queries without scanning through the whole table.
-- **Extensibility**. You can write user-defined-functions (UDFs) in any language that compiles to
-  WebAssembly (WASM) and add them to Seafowl.
+### ...at the edge
 
-### Designed for data-driven Web applications
+Seafowl is designed to be deployed to modern serverless environments. It ships as a single binary,
+making it simple to run anywhere.
 
-Seafowl lets you provide data for your dashboards and visualizations without building complex API
-endpoints, just by executing SQL straight from the user's browser.
+Seafowl's architecture is inspired by modern cloud data warehouses like Snowflake or BigQuery,
+letting you separate storage and compute. You can store Seafowl data in an object storage like S3 or
+Minio and scale to zero. Or, you can
+[build a self-contained Docker image](https://splitgraph.com/docs/seafowl/guides/baking-dataset-docker-image)
+with Seafowl and your data, letting you deploy your data to any platform that supports Docker.
 
-Seafowl's query execution endpoint is HTTP cache and CDN-friendly. You can put Seafowl behind a
-cache like Varnish or a CDN like Cloudflare and have query results cached globally and delivered to
-your users in milliseconds.
-
-### Runnable on serverless providers
-
-We're intending for Seafowl to be runnable on modern serverless platforms like Fly.io, Cloudflare
-Workers and Deno Deploy.
+Seafowl's query execution API follows HTTP cache semantics. This means you can
+[put Seafowl behind a CDN](https://splitgraph.com/docs/seafowl/guides/querying-cache-cdn) like
+Cloudflare or a cache like Varnish and have query results cached and delivered to your users in
+milliseconds. Even without a cache, you can get the benefits of caching query results in your user's
+browser.
 
 ## Post-initial release roadmap
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,26 @@
 
 [Home page](https://seafowl.io) |
 [Documentation](https://www.splitgraph.com/docs/seafowl/getting-started/introduction) |
+[Nightly builds](https://nightly.link/splitgraph/seafowl/workflows/nightly/main)
 [Download](https://github.com/splitgraph/seafowl/releases)
 
 Seafowl is an analytical database designed for modern data-driven Web applications.
 
 ## Work in progress
 
-**This repository is an active work in progress and we do not yet provide pre-compiled builds or
-build instructions.**
+**This repository is an active work in progress. Read on to find out more about our goals for the
+initial release or star/watch this repository to stay informed on our progress!**
 
-**Read on to find out more about our goals for the initial release or star/watch this repository to
-stay informed on our progress!**
+### Nightly builds
+
+While we do not yet provide official release builds or build instructions, we produce nightly builds
+after each merge to `main`. You can find them in GitHub Actions artifacts (only if you're logged in,
+see [this issue](https://github.com/actions/upload-artifact/issues/51)) or **via
+[nightly.link](https://nightly.link/splitgraph/seafowl/workflows/nightly/main)**:
+
+- [Linux (x86_64-unknown-linux-gnu)](https://nightly.link/splitgraph/seafowl/workflows/nightly/main/seafowl-nightly-x86_64-unknown-linux-gnu.zip)
+- [OSX (x86_64-apple-darwin)](https://nightly.link/splitgraph/seafowl/workflows/nightly/main/seafowl-nightly-x86_64-apple-darwin.zip)
+- [Windows (x86_64-pc-windows-msvc)](https://nightly.link/splitgraph/seafowl/workflows/nightly/main/seafowl-nightly-x86_64-pc-windows-msvc.zip)
 
 ## Initial release roadmap
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+use vergen::{vergen, Config, ShaKind};
+
+fn main() -> Result<()> {
+    // Generate the default 'cargo:' instruction output
+    let mut config = Config::default();
+    // Change the SHA output to the short variant
+    *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    // Add a `-dirty` flag to the SEMVER output
+    *config.git_mut().semver_dirty_mut() = Some("-dirty");
+
+    vergen(Config::default())
+}

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -70,9 +70,11 @@ read_access = "any"
 # startup of Seafowl to get the password or set this to a different hash.
 write_access = "{}"
 "#,
-        DEFAULT_DATA_DIR,
-        dsn,
-        random_password()
+        // Use `escape_default` here since on Windows, these paths
+        // use backslashes which toml treats as escapes.
+        DEFAULT_DATA_DIR.escape_default(),
+        dsn.escape_default(),
+        random_password().escape_default()
     );
 
     let config = load_config_from_string(&config_str, false).unwrap();


### PR DESCRIPTION
Closes https://github.com/splitgraph/seafowl/issues/46
Partially relates to https://github.com/splitgraph/seafowl/issues/45 (yes compile, no release)

Use https://crates.io/crates/vergen to add some basic build info to the Seafowl binary:

```bash
$ ./seafowl -V
Seafowl 0.1.0 (aa8c19cbc54c612733068b3c497f61cbb57905fe 2022-08-17T16:56:40Z)

Built by rustc 1.63.0 on x86_64-unknown-linux-gnu at 2022-08-17T16:57:27.702859916Z
Target: release x86_64-unknown-linux-gnu
Features: catalog_postgres,convergence,convergence_arrow,default,frontend_postgres,object_store_s3
```

Add GHA release builds (OSX, Linux, Windows) for pushes to the main branch, available as GHA artifacts to logged-in users or on https://nightly.link: https://nightly.link/splitgraph/seafowl/workflows/nightly/feature%2Fauto-binary-vergen (see https://github.com/actions/upload-artifact/issues/51 for the context).