### PR TITLE
Add ability to run a one-off command from the CLI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,5 @@ pub mod nodes;
 pub mod provider;
 pub mod repository;
 pub mod schema;
+pub mod utils;
 pub mod wasm_udf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::AppSettings::NoAutoVersion;
 use std::{
-    env, fs,
+    env, fs, io,
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
@@ -18,6 +18,7 @@ use seafowl::{
     },
     context::SeafowlContext,
     frontend::http::run_server,
+    utils::run_one_off_command,
 };
 
 #[cfg(feature = "frontend-postgres")]
@@ -42,6 +43,9 @@ struct Args {
         takes_value = false
     )]
     version: bool,
+
+    #[clap(short, long, help = "Run a one-off command and exit")]
+    one_off: Option<String>,
 }
 
 fn prepare_frontends(
@@ -149,6 +153,11 @@ async fn main() {
     };
 
     let context = Arc::new(build_context(&config).await);
+
+    if let Some(one_off_cmd) = args.one_off {
+        run_one_off_command(context, &one_off_cmd, io::stdout()).await;
+        return;
+    };
 
     let frontends = prepare_frontends(context, &config);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,53 @@
+use std::{io::Write, sync::Arc};
+
+use arrow::json::LineDelimitedWriter;
+
+use crate::context::SeafowlContext;
+
+// Run a one-off command and output its results to a writer
+pub async fn run_one_off_command<W>(
+    context: Arc<dyn SeafowlContext>,
+    command: &str,
+    mut output: W,
+) where
+    W: Write,
+{
+    // TODO when https://github.com/splitgraph/seafowl/issues/48 is implemented: run this
+    // without splitting on the semicolon (which can also be a legitimate part of a query)
+    for s in command.split(';') {
+        if s.trim() == "" {
+            continue;
+        }
+        async {
+            let physical = context.plan_query(s).await?;
+            let batches = context.collect(physical).await?;
+
+            let mut writer = LineDelimitedWriter::new(&mut output);
+            writer.write_batches(&batches)?;
+            writer.finish()
+        }
+        .await
+        .unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::run_one_off_command;
+    use crate::context::test_utils::in_memory_context;
+
+    #[tokio::test]
+    async fn test_command_splitting() {
+        let mut buf = Vec::new();
+        let context = in_memory_context().await;
+
+        run_one_off_command(Arc::from(context), "SELECT 1; SELECT 1", &mut buf).await;
+
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "{\"Int64(1)\":1}\n{\"Int64(1)\":1}\n"
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/splitgraph/seafowl/issues/39

Supports multiple commands but hackily (splits on `;`).