### PR TITLE
Remove most unwrap()s and propagate errors up to the caller

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "sqlite" ] }
 strum = ">=0.24"
 strum_macros = ">=0.24"
 tempfile = "3"
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "signal"] }
 url = "2.2"
 warp = "0.3"
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     repository::interface::{
         AllDatabaseColumnsResult, AllDatabaseFunctionsResult, AllTablePartitionsResult,
-        Repository,
+        Error as RepositoryError, Repository,
     },
     schema::Schema,
 };
@@ -252,7 +252,7 @@ impl TableCatalog for DefaultCatalog {
             .await
         {
             Ok(id) => Some(id),
-            Err(sqlx::error::Error::RowNotFound) => None,
+            Err(RepositoryError::SqlxError(sqlx::error::Error::RowNotFound)) => None,
             Err(e) => panic!("TODO SQL error: {:?}", e),
         }
     }
@@ -260,7 +260,7 @@ impl TableCatalog for DefaultCatalog {
     async fn get_database_id_by_name(&self, database_name: &str) -> Option<DatabaseId> {
         match self.repository.get_database_id_by_name(database_name).await {
             Ok(id) => Some(id),
-            Err(sqlx::error::Error::RowNotFound) => None,
+            Err(RepositoryError::SqlxError(sqlx::error::Error::RowNotFound)) => None,
             Err(e) => panic!("TODO SQL error: {:?}", e),
         }
     }

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -55,7 +55,7 @@ pub trait TableCatalog: Sync + Send + Debug {
         &self,
         collection_id: CollectionId,
         table_name: &str,
-        schema: Schema,
+        schema: &Schema,
     ) -> (TableId, TableVersionId);
 
     async fn create_new_table_version(
@@ -233,7 +233,7 @@ impl TableCatalog for DefaultCatalog {
         &self,
         collection_id: CollectionId,
         table_name: &str,
-        schema: Schema,
+        schema: &Schema,
     ) -> (TableId, TableVersionId) {
         self.repository
             .create_table(collection_id, table_name, schema)

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -122,8 +122,8 @@ pub async fn build_context(cfg: &schema::SeafowlConfig) -> DefaultSeafowlContext
     // Convergence doesn't support connecting to different DB names. We are supposed
     // to do one context per query (as we need to load the schema before executing every
     // query) and per database (since the context is supposed to be limited to the database
-    // the user is connected to), but in this case we can just use the same context everywhere, but reload
-    // it before we run the query.
+    // the user is connected to), but in this case we can just use the same context everywhere
+    // (it will reload its schema before running the query)
 
     DefaultSeafowlContext {
         inner: context,

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -94,14 +94,21 @@ pub async fn build_context(cfg: &schema::SeafowlConfig) -> DefaultSeafowlContext
     let (tables, partitions, functions) = build_catalog(cfg).await;
 
     // Create default DB/collection
-    let default_db = match tables.get_database_id_by_name("default").await {
+    let default_db = match tables.get_database_id_by_name("default").await.unwrap() {
         Some(id) => id,
-        None => tables.create_database("default").await,
+        None => tables.create_database("default").await.unwrap(),
     };
 
-    match tables.get_collection_id_by_name("default", "public").await {
+    match tables
+        .get_collection_id_by_name("default", "public")
+        .await
+        .unwrap()
+    {
         Some(id) => id,
-        None => tables.create_collection(default_db, "public").await,
+        None => tables
+            .create_collection(default_db, "public")
+            .await
+            .unwrap(),
     };
 
     // Register the datafusion catalog (in-memory)

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     catalog::{DefaultCatalog, FunctionCatalog, PartitionCatalog, TableCatalog},
-    context::{DefaultSeafowlContext, SeafowlContext},
+    context::DefaultSeafowlContext,
     repository::{interface::Repository, sqlite::SqliteRepository},
 };
 use datafusion::{
@@ -124,7 +124,8 @@ pub async fn build_context(cfg: &schema::SeafowlConfig) -> DefaultSeafowlContext
     // query) and per database (since the context is supposed to be limited to the database
     // the user is connected to), but in this case we can just use the same context everywhere, but reload
     // it before we run the query.
-    let context = DefaultSeafowlContext {
+
+    DefaultSeafowlContext {
         inner: context,
         table_catalog: tables,
         partition_catalog: partitions,
@@ -132,15 +133,13 @@ pub async fn build_context(cfg: &schema::SeafowlConfig) -> DefaultSeafowlContext
         database: "default".to_string(),
         database_id: default_db,
         max_partition_size: cfg.misc.max_partition_size,
-    };
-
-    // Register our database with DataFusion
-    context.reload_schema().await;
-    context
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::context::SeafowlContext;
+
     use super::*;
 
     #[tokio::test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -455,7 +455,7 @@ impl DefaultSeafowlContext {
             })?;
         Ok(self
             .table_catalog
-            .create_table(collection_id, table_name, sf_schema)
+            .create_table(collection_id, table_name, &sf_schema)
             .await)
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1129,6 +1129,11 @@ impl SeafowlContext for DefaultSeafowlContext {
         schema_name: String,
         table_name: String,
     ) -> Result<bool> {
+        // Reload the schema since `try_get_seafowl_table` relies on using DataFusion's
+        // TableProvider interface (which we need to pre-populate with up to date
+        // information on our tables)
+        self.reload_schema().await?;
+
         // Ensure the schema exists prior to creating the table
         let (full_table_name, from_table_version) = {
             let new_table_name = format!("{}.{}", schema_name, table_name);

--- a/src/context.rs
+++ b/src/context.rs
@@ -576,15 +576,10 @@ impl DefaultSeafowlContext {
         }
 
         // Attach the partitions to the table
-        let partition_ids = self
-            .partition_catalog
-            .create_partitions(partitions)
-            .await
-            .unwrap();
+        let partition_ids = self.partition_catalog.create_partitions(partitions).await?;
         self.partition_catalog
             .append_partitions_to_table(partition_ids, new_table_version_id)
-            .await
-            .unwrap();
+            .await?;
 
         Ok(true)
     }
@@ -926,8 +921,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                 // Create a schema and register it
                 self.table_catalog
                     .create_collection(self.database_id, schema_name)
-                    .await
-                    .unwrap();
+                    .await?;
                 Ok(make_dummy_exec())
             }
             LogicalPlan::CreateCatalog(CreateCatalog {
@@ -962,7 +956,7 @@ impl SeafowlContext for DefaultSeafowlContext {
             }) => {
                 // DROP TABLE
                 let table = self.try_get_seafowl_table(name)?;
-                self.table_catalog.drop_table(table.table_id).await.unwrap();
+                self.table_catalog.drop_table(table.table_id).await?;
                 Ok(make_dummy_exec())
             }
             LogicalPlan::CreateView(_) => {
@@ -1056,8 +1050,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                             // Persist the function in the metadata storage
                             self.function_catalog
                                 .create_function(self.database_id, name, details)
-                                .await
-                                .unwrap();
+                                .await?;
 
                             Ok(make_dummy_exec())
                         }
@@ -1076,8 +1069,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                                     let collection_id = self
                                         .table_catalog
                                         .get_collection_id_by_name(&self.database, schema)
-                                        .await
-                                        .unwrap()
+                                        .await?
                                         .ok_or_else(|| {
                                             Error::Plan(format!(
                                                 "Schema {:?} does not exist!",
@@ -1098,8 +1090,7 @@ impl SeafowlContext for DefaultSeafowlContext {
 
                             self.table_catalog
                                 .move_table(table.table_id, new_table_name, new_schema_id)
-                                .await
-                                .unwrap();
+                                .await?;
 
                             Ok(make_dummy_exec())
                         }
@@ -1107,13 +1098,9 @@ impl SeafowlContext for DefaultSeafowlContext {
                             if let Some(collection_id) = self
                                 .table_catalog
                                 .get_collection_id_by_name(&self.database, name)
-                                .await
-                                .unwrap()
+                                .await?
                             {
-                                self.table_catalog
-                                    .drop_collection(collection_id)
-                                    .await
-                                    .unwrap()
+                                self.table_catalog.drop_collection(collection_id).await?
                             };
 
                             Ok(make_dummy_exec())

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -289,10 +289,11 @@ pub async fn upload(
             };
 
             // Create an execution plan for yielding the record batches we just generated
-            let execution_plan = Arc::new(
-                MemoryExec::try_new(&[partition], Arc::new(schema.clone()), None)
-                    .unwrap(),
-            );
+            let execution_plan = Arc::new(MemoryExec::try_new(
+                &[partition],
+                Arc::new(schema.clone()),
+                None,
+            )?);
 
             // Execute the plan and persist objects as well as table/partition metadata
             if let Err(error) = context

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -124,7 +124,6 @@ pub async fn uncached_read_write_query(
     query: String,
     context: Arc<dyn SeafowlContext>,
 ) -> Result<Vec<u8>, ApiError> {
-    context.reload_schema().await;
     let logical = context.create_logical_plan(&query).await?;
 
     if !user_context.can_perform_action(if is_read_only(&logical) {
@@ -196,7 +195,6 @@ pub async fn cached_read_query(
     // Ignore dots at the end
     let query_hash = query_hash.split('.').next().unwrap();
 
-    context.reload_schema().await;
     let hash_str = str_to_hex_hash(&query);
 
     debug!(
@@ -483,7 +481,6 @@ mod tests {
             )
             .await
             .unwrap();
-        context.reload_schema().await;
 
         context
             .collect(
@@ -494,7 +491,6 @@ mod tests {
             )
             .await
             .unwrap();
-        context.reload_schema().await;
         context
     }
 
@@ -509,7 +505,6 @@ mod tests {
             )
             .await
             .unwrap();
-        context.reload_schema().await;
         context
     }
 

--- a/src/frontend/postgres.rs
+++ b/src/frontend/postgres.rs
@@ -34,8 +34,6 @@ impl Portal for SeafowlPortal {
         {
             record_batch_to_rows(&arrow_batch, batch)?;
         }
-        // Reload the schema after every query
-        self.context.reload_schema().await;
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ async fn main() {
         config
     };
 
-    let context = Arc::new(build_context(&config).await);
+    let context = Arc::new(build_context(&config).await.unwrap());
 
     if let Some(one_off_cmd) = args.one_off {
         run_one_off_command(context, &one_off_cmd, io::stdout()).await;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -131,8 +131,7 @@ impl TableProvider for SeafowlTable {
         let partitions = self
             .catalog
             .load_table_partitions(self.table_version_id)
-            .await
-            .unwrap();
+            .await?;
 
         // This code is partially taken from ListingTable but adapted to use an arbitrary
         // list of Parquet URLs rather than all files in a given directory.
@@ -153,8 +152,7 @@ impl TableProvider for SeafowlTable {
                     range: None,
                 }]) as Result<_>
             }))
-            .await
-            .expect("general error with partitioned file lists");
+            .await?;
 
         let config = FileScanConfig {
             object_store_url,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -131,7 +131,8 @@ impl TableProvider for SeafowlTable {
         let partitions = self
             .catalog
             .load_table_partitions(self.table_version_id)
-            .await;
+            .await
+            .unwrap();
 
         // This code is partially taken from ListingTable but adapted to use an arbitrary
         // list of Parquet URLs rather than all files in a given directory.
@@ -298,11 +299,11 @@ mod tests {
             .expect_load_table_partitions()
             .with(predicate::eq(1))
             .returning(|_| {
-                vec![SeafowlPartition {
+                Ok(vec![SeafowlPartition {
                     object_storage_id: Arc::from("some-file.parquet"),
                     row_count: 3,
                     columns: Arc::new(vec![]),
-                }]
+                }])
             });
 
         let table = SeafowlTable {

--- a/src/repository/default.rs
+++ b/src/repository/default.rs
@@ -177,7 +177,7 @@ impl Repository for $repo {
         &self,
         collection_id: CollectionId,
         table_name: &str,
-        schema: Schema,
+        schema: &Schema,
     ) -> Result<(TableId, TableVersionId), Error> {
         // Create new (empty) table
         let new_table_id: i64 = sqlx::query(

--- a/src/repository/default.rs
+++ b/src/repository/default.rs
@@ -200,16 +200,18 @@ impl Repository for $repo {
 
         // Create columns
         // TODO this breaks if we have more than (bind limit) columns
-        let mut builder: QueryBuilder<_> =
-            QueryBuilder::new("INSERT INTO table_column(table_version_id, name, type) ");
-        builder.push_values(schema.to_column_names_types(), |mut b, col| {
-            b.push_bind(new_version_id)
-                .push_bind(col.0)
-                .push_bind(col.1);
-        });
+        if !schema.arrow_schema.fields().is_empty() {
+            let mut builder: QueryBuilder<_> =
+                QueryBuilder::new("INSERT INTO table_column(table_version_id, name, type) ");
+            builder.push_values(schema.to_column_names_types(), |mut b, col| {
+                b.push_bind(new_version_id)
+                    .push_bind(col.0)
+                    .push_bind(col.1);
+            });
 
-        let query = builder.build();
-        query.execute(&self.executor).await.map_err($repo::interpret_error)?;
+            let query = builder.build();
+            query.execute(&self.executor).await.map_err($repo::interpret_error)?;
+        }
 
         Ok((new_table_id, new_version_id))
     }

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -2,8 +2,6 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 
-use sqlx::Error;
-
 use crate::wasm_udf::data_types::CreateFunctionDetails;
 use crate::{
     data_types::{
@@ -46,6 +44,18 @@ pub struct AllDatabaseFunctionsResult {
     pub data: String,
     pub volatility: String,
 }
+
+/// Wrapper for conversion of database-specific error codes into actual errors
+#[derive(Debug)]
+pub enum Error {
+    UniqueConstraintViolation(sqlx::Error),
+    FKConstraintViolation(sqlx::Error),
+
+    // All other errors
+    SqlxError(sqlx::Error),
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[async_trait]
 pub trait Repository: Send + Sync + Debug {

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -99,7 +99,7 @@ pub trait Repository: Send + Sync + Debug {
         &self,
         collection_id: CollectionId,
         table_name: &str,
-        schema: Schema,
+        schema: &Schema,
     ) -> Result<(TableId, TableVersionId), Error>;
 
     async fn create_partitions(
@@ -213,7 +213,7 @@ pub mod tests {
         };
 
         let (table_id, table_version_id) = repository
-            .create_table(collection_id, "testtable", schema)
+            .create_table(collection_id, "testtable", &schema)
             .await
             .expect("Error creating table");
 

--- a/src/repository/sqlite.rs
+++ b/src/repository/sqlite.rs
@@ -5,7 +5,7 @@ use futures::TryStreamExt;
 use sqlx::{
     migrate::Migrator,
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
-    Error, Pool, QueryBuilder, Row, Sqlite,
+    Pool, QueryBuilder, Row, Sqlite,
 };
 
 use crate::{
@@ -23,7 +23,9 @@ use crate::implement_repository;
 
 use super::{
     default::RepositoryQueries,
-    interface::{AllDatabaseColumnsResult, AllDatabaseFunctionsResult, Repository},
+    interface::{
+        AllDatabaseColumnsResult, AllDatabaseFunctionsResult, Error, Repository, Result,
+    },
 };
 
 #[derive(Debug)]
@@ -64,13 +66,27 @@ impl SqliteRepository {
         "#,
     };
 
-    pub async fn try_new(dsn: String) -> Result<Self, Error> {
+    pub async fn try_new(dsn: String) -> std::result::Result<Self, sqlx::Error> {
         let options = SqliteConnectOptions::from_str(&dsn)?.create_if_missing(true);
 
         let pool = SqlitePoolOptions::new().connect_with(options).await?;
         let repo = Self { executor: pool };
         repo.setup().await;
         Ok(repo)
+    }
+
+    pub fn interpret_error(error: sqlx::Error) -> Error {
+        if let sqlx::Error::Database(ref d) = error {
+            // Reference: https://www.sqlite.org/rescode.html
+            if let Some(code) = d.code() {
+                if code == "2067" {
+                    return Error::UniqueConstraintViolation(error);
+                } else if code == "787" {
+                    return Error::FKConstraintViolation(error);
+                }
+            }
+        }
+        Error::SqlxError(error)
     }
 }
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -93,7 +93,6 @@ async fn create_table_and_insert(context: &DefaultSeafowlContext, table_name: &s
     context.collect(plan).await.unwrap();
 
     // reregister / reload the catalog
-    context.reload_schema().await;
 
     // Insert some data (with some columns missing, different order)
     let plan = context
@@ -110,8 +109,6 @@ async fn create_table_and_insert(context: &DefaultSeafowlContext, table_name: &s
         .await
         .unwrap();
     context.collect(plan).await.unwrap();
-
-    context.reload_schema().await;
 }
 
 #[tokio::test]
@@ -158,7 +155,6 @@ async fn test_create_table() {
     context.collect(plan).await.unwrap();
 
     // reregister / reload the catalog
-    context.reload_schema().await;
 
     // Check table columns
     let results = list_columns_query(&context).await;
@@ -254,8 +250,6 @@ async fn test_insert_two_different_schemas() {
         .unwrap();
     context.collect(plan).await.unwrap();
 
-    context.reload_schema().await;
-
     let plan = context
         .plan_query("SELECT * FROM test_table")
         .await
@@ -323,8 +317,6 @@ async fn test_table_partitioning_and_rechunking() {
     assert_eq!(partitions[1].row_count, 3);
     assert_eq!(partitions[1].columns.len(), 2);
 
-    context.reload_schema().await;
-
     let plan = context
         .plan_query("CREATE TABLE table_rechunked AS SELECT * FROM test_table")
         .await
@@ -350,7 +342,6 @@ async fn test_table_partitioning_and_rechunking() {
     assert_eq!(partitions[0].columns.len(), 5);
 
     // Ensure table contents
-    context.reload_schema().await;
     let plan = context
         .plan_query("SELECT some_value, some_int_value FROM table_rechunked")
         .await
@@ -396,8 +387,6 @@ async fn test_create_table_as() {
         .unwrap();
     context.collect(plan).await.unwrap();
 
-    context.reload_schema().await;
-
     let plan = context.plan_query("SELECT * FROM test_ctas").await.unwrap();
     let results = context.collect(plan).await.unwrap();
 
@@ -422,8 +411,6 @@ async fn test_create_table_move_and_drop() {
     for table_name in ["test_table_1", "test_table_2"] {
         create_table_and_insert(&context, table_name).await;
     }
-
-    context.reload_schema().await;
 
     let results = list_columns_query(&context).await;
 
@@ -464,7 +451,6 @@ async fn test_create_table_move_and_drop() {
         )
         .await
         .unwrap();
-    context.reload_schema().await;
 
     let results = list_tables_query(&context).await;
 
@@ -498,7 +484,6 @@ async fn test_create_table_move_and_drop() {
         )
         .await
         .unwrap();
-    context.reload_schema().await;
 
     context
         .collect(
@@ -509,7 +494,6 @@ async fn test_create_table_move_and_drop() {
         )
         .await
         .unwrap();
-    context.reload_schema().await;
 
     let results = list_tables_query(&context).await;
 
@@ -531,7 +515,6 @@ async fn test_create_table_move_and_drop() {
         .await
         .unwrap();
     context.collect(plan).await.unwrap();
-    context.reload_schema().await;
 
     let results = list_columns_query(&context).await;
 
@@ -554,8 +537,6 @@ async fn test_create_table_move_and_drop() {
     let plan = context.plan_query("DROP TABLE test_table_2").await.unwrap();
     context.collect(plan).await.unwrap();
 
-    context.reload_schema().await;
-
     let results = list_columns_query(&context).await;
 
     let expected = vec!["++", "++"];
@@ -571,8 +552,6 @@ async fn test_create_table_drop_schema() {
         create_table_and_insert(&context, table_name).await;
     }
 
-    context.reload_schema().await;
-
     // Create a schema and move the table to it
     context
         .collect(
@@ -583,7 +562,6 @@ async fn test_create_table_drop_schema() {
         )
         .await
         .unwrap();
-    context.reload_schema().await;
 
     context
         .collect(
@@ -594,7 +572,6 @@ async fn test_create_table_drop_schema() {
         )
         .await
         .unwrap();
-    context.reload_schema().await;
 
     let results = list_tables_query(&context).await;
 
@@ -615,7 +592,6 @@ async fn test_create_table_drop_schema() {
         .collect(context.plan_query("DROP SCHEMA public").await.unwrap())
         .await
         .unwrap();
-    context.reload_schema().await;
 
     let results = list_tables_query(&context).await;
 
@@ -635,7 +611,6 @@ async fn test_create_table_drop_schema() {
         .collect(context.plan_query("DROP SCHEMA new_schema").await.unwrap())
         .await
         .unwrap();
-    context.reload_schema().await;
 
     let results = list_tables_query(&context).await;
 
@@ -654,7 +629,6 @@ async fn test_create_table_drop_schema() {
         .collect(context.plan_query("CREATE SCHEMA public").await.unwrap())
         .await
         .unwrap();
-    context.reload_schema().await;
 
     context
         .collect(
@@ -665,7 +639,6 @@ async fn test_create_table_drop_schema() {
         )
         .await
         .unwrap();
-    context.reload_schema().await;
 
     let results = list_tables_query(&context).await;
 
@@ -701,7 +674,6 @@ async fn test_create_and_reload_function() {
     context.collect(plan).await.unwrap();
 
     // Reload to make sure we picked up the stored function from the metadata store
-    context.reload_schema().await;
 
     let results = context
         .collect(

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -34,7 +34,7 @@ schema = "{}""#,
     // Ignore the "in-memory object store / persistent catalog" error in e2e tests (we'll discard
     // the PG instance anyway)
     let config = load_config_from_string(&config_text, true).unwrap();
-    build_context(&config).await
+    build_context(&config).await.unwrap()
 }
 
 /// Get a batch of results with all tables and columns in a database

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -299,7 +299,8 @@ async fn test_table_partitioning_and_rechunking() {
     let partitions = context
         .partition_catalog
         .load_table_partitions(3 as TableVersionId)
-        .await;
+        .await
+        .unwrap();
 
     // Ensure we have 2 partitions, originating from 2 INSERTS
     assert_eq!(partitions.len(), 2);
@@ -333,7 +334,8 @@ async fn test_table_partitioning_and_rechunking() {
     let partitions = context
         .partition_catalog
         .load_table_partitions(4 as TableVersionId)
-        .await;
+        .await
+        .unwrap();
 
     // Ensure we have re-chunked the 2 partitions into 1
     assert_eq!(partitions.len(), 1);

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -312,8 +312,6 @@ async fn test_upload_base(
     let status = child.wait().await.unwrap();
     dbg!("Upload status is {}", status);
 
-    context.reload_schema().await;
-
     // Verify the newly created table contents
     let plan = context
         .plan_query(format!("SELECT * FROM test_upload.{}", table_name).as_str())
@@ -357,7 +355,6 @@ async fn test_upload_to_existing_table() {
         )
         .await
         .unwrap();
-    context.reload_schema().await;
     context
         .collect(
             context
@@ -367,7 +364,6 @@ async fn test_upload_to_existing_table() {
         )
         .await
         .unwrap();
-    context.reload_schema().await;
 
     // Prepare the schema that matches the existing table + some data
     let schema = Arc::new(Schema::new(vec![Field::new(
@@ -402,8 +398,6 @@ async fn test_upload_to_existing_table() {
         .unwrap();
     let status = child.wait().await.unwrap();
     dbg!("Upload status is {}", status);
-
-    context.reload_schema().await;
 
     // Verify the newly created table contents
     let plan = context

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -56,7 +56,7 @@ dsn = ":memory:"
 write_access = "b786e07f52fc72d32b2163b6f63aa16344fd8d2d84df87b6c231ab33cd5aa125""#;
 
     let config = load_config_from_string(config_text, false).unwrap();
-    let context = Arc::from(build_context(&config).await);
+    let context = Arc::from(build_context(&config).await.unwrap());
 
     let filters = filters(
         context.clone(),


### PR DESCRIPTION
Fixes #22 
Fixes #53 

- Add code for converting PG/SQLite errors into certain generic DB errors (FK/Unique violation): sqlx doesn't do that already for us, maybe we should have used an orm 👀 
- Define an error type for catalog-specific errors (e.g. table/schema/database doesn't exist/already exists)
- Add some logic in the catalog that converts from DB errors to catalog errors (remove unwrap()s)
- Handle and propagate Warp errors in the upload endpoint to HTTP errors
- Propagate errors as DataFusion errors:
   - X doesn't exist: internal error (these functions are only called by ID and the user only references tables by their name, so wrong IDs means something has gone wrong internally)
   - X already exists: user-level error (target for a table rename / create function already exists)
   - other sqlx errors become an internal DataFusion error
- We still send all DF errors back to the HTTP caller (even though some of them might have sensitive contents).

Other fixes that don't have an attached issue:

Add graceful shutdown on SIGINT/SIGTERM/Ctrl+C (some things in https://tokio.rs/tokio/topics/shutdown apply here but we wait for frontends to terminate normally after sending the shutdown request instead of ). This should fix the issue in Docker where the process seems to be ignoring SIGTERM (even though it's run with ENTRYPOINT), causing the shutdown to take 10s as Docker needs to realize the container isn't exiting and SIGKILL it.

Run `reload_schema` before every query / `plan_to_table`. We expect the caller to do it anyway if they changed the database schema in some way / added a new version of a table and we do it before every query in HTTP/PG, so might as well do it automatically and remove `reload_schema()` everywhere else.