### PR TITLE
Add envvar config parsing

### DIFF
--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -33,7 +33,7 @@ schema = "{}""#,
 
     // Ignore the "in-memory object store / persistent catalog" error in e2e tests (we'll discard
     // the PG instance anyway)
-    let config = load_config_from_string(&config_text, true).unwrap();
+    let config = load_config_from_string(&config_text, true, None).unwrap();
     build_context(&config).await.unwrap()
 }
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -55,7 +55,7 @@ dsn = ":memory:"
 # sha hash of "write_password"
 write_access = "b786e07f52fc72d32b2163b6f63aa16344fd8d2d84df87b6c231ab33cd5aa125""#;
 
-    let config = load_config_from_string(config_text, false).unwrap();
+    let config = load_config_from_string(config_text, false, None).unwrap();
     let context = Arc::from(build_context(&config).await.unwrap());
 
     let filters = filters(


### PR DESCRIPTION
Use e.g. `SEAFOWL__FRONTEND__HTTP__WRITE_ACCESS` as an envvar to
partially override the config.