### PR TITLE
Implement min/max/null-count partition pruning

### DIFF
--- a/migrations/postgres/20220705072248_create_tables.up.sql
+++ b/migrations/postgres/20220705072248_create_tables.up.sql
@@ -43,7 +43,8 @@ CREATE TABLE physical_partition_column (
     name VARCHAR NOT NULL,
     type VARCHAR NOT NULL,
     min_value BYTEA,
-    max_value BYTEA
+    max_value BYTEA,
+    null_count INTEGER
 );
 
 CREATE TABLE table_partition (

--- a/migrations/sqlite/20220728071524_create_tables.sql
+++ b/migrations/sqlite/20220728071524_create_tables.sql
@@ -50,7 +50,8 @@ CREATE TABLE physical_partition_column (
     name VARCHAR NOT NULL,
     type VARCHAR NOT NULL,
     min_value BLOB,
-    max_value BLOB
+    max_value BLOB,
+    null_count INTEGER(4)
 );
 
 CREATE TABLE table_partition (

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -136,6 +136,7 @@ impl DefaultCatalog {
                     r#type: Arc::from(partition.column_type.clone()),
                     min_value: Arc::new(partition.min_value.clone()),
                     max_value: Arc::new(partition.max_value.clone()),
+                    null_count: None, // TODO: set this from partition object
                 })
                 .collect(),
             ),

--- a/src/context.rs
+++ b/src/context.rs
@@ -178,7 +178,7 @@ fn build_partition_columns(
                     r#type: Arc::from(column.data_type().to_json().to_string()),
                     min_value: Arc::new(min_value),
                     max_value: Arc::new(max_value),
-                    null_count: stats.null_count.map(|nc| nc as i128),
+                    null_count: stats.null_count.map(|nc| nc as u64),
                 }
             })
             .collect(),
@@ -793,7 +793,7 @@ impl SeafowlContext for DefaultSeafowlContext {
 
                     Ok(LogicalPlan::Extension(Extension {
                         node: Arc::new(SeafowlExtensionNode::Delete(Delete {
-                            name: table_name.to_string(),
+                            name: table_name,
                             selection: selection_expr,
                             output_schema: Arc::new(DFSchema::empty())
                         })),
@@ -1406,7 +1406,8 @@ mod tests {
                             name: Arc::from("timestamp".to_string()),
                             r#type: Arc::from("{\"name\":\"utf8\"}".to_string()),
                             min_value: Arc::new(None),
-                            max_value: Arc::new(None)
+                            max_value: Arc::new(None),
+                            null_count: Some(0),
                         },
                         PartitionColumn {
                             name: Arc::from("integer".to_string()),
@@ -1416,12 +1417,14 @@ mod tests {
                             ),
                             min_value: to_min_max_value(12),
                             max_value: to_min_max_value(42),
+                            null_count: Some(0),
                         },
                         PartitionColumn {
                             name: Arc::from("varchar".to_string()),
                             r#type: Arc::from("{\"name\":\"utf8\"}".to_string()),
                             min_value: Arc::new(None),
-                            max_value: Arc::new(None)
+                            max_value: Arc::new(None),
+                            null_count: Some(0),
                         }
                     ])
                 },
@@ -1433,7 +1436,8 @@ mod tests {
                             name: Arc::from("timestamp".to_string()),
                             r#type: Arc::from("{\"name\":\"utf8\"}".to_string()),
                             min_value: Arc::new(None),
-                            max_value: Arc::new(None)
+                            max_value: Arc::new(None),
+                            null_count: Some(0),
                         },
                         PartitionColumn {
                             name: Arc::from("integer".to_string()),
@@ -1443,12 +1447,14 @@ mod tests {
                             ),
                             min_value: to_min_max_value(22),
                             max_value: to_min_max_value(32),
+                            null_count: Some(0),
                         },
                         PartitionColumn {
                             name: Arc::from("varchar".to_string()),
                             r#type: Arc::from("{\"name\":\"utf8\"}".to_string()),
                             min_value: Arc::new(None),
-                            max_value: Arc::new(None)
+                            max_value: Arc::new(None),
+                            null_count: Some(0),
                         }
                     ])
                 },
@@ -1570,6 +1576,7 @@ mod tests {
                         max_value: to_min_max_value(
                             output_partitions[i].iter().max().unwrap()
                         ),
+                        null_count: Some(0),
                     }])
                 },
             )
@@ -1695,6 +1702,7 @@ mod tests {
                                         r#type: Arc::from("{\"name\":\"date\",\"unit\":\"MILLISECOND\"}"),
                                         min_value: Arc::new(None),
                                         max_value: Arc::new(None),
+                                        null_count: Some(0),
                                     },
                                     PartitionColumn {
                                         name: Arc::from("value"),
@@ -1711,6 +1719,7 @@ mod tests {
                                                 50,
                                             ],
                                         )),
+                                        null_count: Some(0),
                                     },
                                 ],)
                             },]

--- a/src/context.rs
+++ b/src/context.rs
@@ -184,7 +184,7 @@ fn build_partition_columns(
                     r#type: Arc::from(column.data_type().to_json().to_string()),
                     min_value: Arc::new(min_value),
                     max_value: Arc::new(max_value),
-                    null_count: stats.null_count.map(|nc| nc as u64),
+                    null_count: stats.null_count.map(|nc| nc as i32),
                 }
             })
             .collect(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -160,6 +160,9 @@ fn build_partition_columns(
 ) -> Vec<PartitionColumn> {
     // TODO PartitionColumn might not be the right data structure here (lacks ID etc)
     match &partition_stats.column_statistics {
+        // NB: Here we may end up with `null_count` being None, but DF pruning algorithm demands that
+        // the null count field be not nullable itself, and consequently for any such cases the
+        // pruning will fail, and we will default to using all partitions.
         Some(column_statistics) => zip(column_statistics, schema.fields())
             .map(|(stats, column)| {
                 // TODO: the to_string will discard the timezone for Timestamp* values, and will

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 pub mod auth;
 pub mod catalog;
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 pub mod auth;
 pub mod catalog;
 pub mod config;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -265,15 +265,20 @@ impl SeafowlPruningStatistics {
     /// use datafusion::scalar::ScalarValue;
     /// use seafowl::provider::SeafowlPruningStatistics;
     ///
-    /// // Parse missing value into a corresponding None
-    /// let value = Arc::new(None);
-    /// assert_eq!(SeafowlPruningStatistics::parse_bytes_value(&value, &DataType::Int16).unwrap(), ScalarValue::Int16(None));
-    /// assert_eq!(SeafowlPruningStatistics::parse_bytes_value(&value, &DataType::Boolean).unwrap(), ScalarValue::Boolean(None));
+    /// fn parse(value: &Arc<Option<Vec<u8>>>, dt: &DataType) -> ScalarValue {
+    ///     SeafowlPruningStatistics::parse_bytes_value(&value, &dt).unwrap()
+    /// }
     ///
-    /// let value = Arc::from(Some(30.to_string().as_bytes().to_vec()));
-    /// assert_eq!(SeafowlPruningStatistics::parse_bytes_value(&value, &DataType::Int32).unwrap(), ScalarValue::Int32(Some(30)));
-    /// assert_eq!(SeafowlPruningStatistics::parse_bytes_value(&value, &DataType::Float32).unwrap(), ScalarValue::Float32(Some(30.0)));
-    /// assert_eq!(SeafowlPruningStatistics::parse_bytes_value(&value, &DataType::Utf8).unwrap(), ScalarValue::Utf8(Some("30".to_string())));
+    /// // Parse missing value into a corresponding None
+    /// let val = Arc::new(None);
+    /// assert_eq!(parse(&val, &DataType::Int16), ScalarValue::Int16(None));
+    /// assert_eq!(parse(&val, &DataType::Boolean), ScalarValue::Boolean(None));
+    ///
+    /// // Parse some actual value
+    /// let val = Arc::from(Some(42.to_string().as_bytes().to_vec()));
+    /// assert_eq!(parse(&val, &DataType::Int32), ScalarValue::Int32(Some(42)));
+    /// assert_eq!(parse(&val, &DataType::Float32), ScalarValue::Float32(Some(42.0)));
+    /// assert_eq!(parse(&val, &DataType::Utf8), ScalarValue::Utf8(Some("42".to_string())));
     /// ```
     pub fn parse_bytes_value(
         bytes_value: &Arc<Option<Vec<u8>>>,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -228,14 +228,13 @@ impl SeafowlPruningStatistics {
         let mut null_counts = HashMap::new();
 
         for field in schema.fields() {
+            let null_value = Self::parse_bytes_value(&Arc::new(None), field.data_type())?;
+
             min_values.insert(
                 field.name().clone(),
-                vec![ScalarValue::Utf8(None); partition_count],
+                vec![null_value.clone(); partition_count],
             );
-            max_values.insert(
-                field.name().clone(),
-                vec![ScalarValue::Utf8(None); partition_count],
-            );
+            max_values.insert(field.name().clone(), vec![null_value; partition_count]);
             null_counts.insert(field.name().clone(), vec![None; partition_count]);
         }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -7,6 +7,7 @@ use std::{any::Any, collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 
 use datafusion::common::Column;
+use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
 use datafusion::scalar::ScalarValue;
 use datafusion::{
@@ -195,6 +196,13 @@ impl TableProvider for SeafowlTable {
             partitions: Arc::new(partitions),
             inner: plan,
         }))
+    }
+
+    fn supports_filter_pushdown(
+        &self,
+        _filter: &Expr,
+    ) -> Result<TableProviderFilterPushDown> {
+        Ok(TableProviderFilterPushDown::Inexact)
     }
 }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use datafusion::common::Column;
 use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
+use datafusion::physical_plan::DisplayFormatType;
 use datafusion::scalar::ScalarValue;
 use datafusion::{
     arrow::datatypes::SchemaRef as ArrowSchemaRef,
@@ -426,6 +427,14 @@ impl ExecutionPlan for SeafowlBaseTableScanNode {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         self.inner.execute(partition, context)
+    }
+
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        self.inner.fmt_as(t, f)
     }
 
     fn statistics(&self) -> Statistics {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -99,7 +99,7 @@ pub struct PartitionColumn {
     pub r#type: Arc<str>,
     pub min_value: Arc<Option<Vec<u8>>>,
     pub max_value: Arc<Option<Vec<u8>>>,
-    pub null_count: Option<u64>,
+    pub null_count: Option<i32>,
 }
 
 #[derive(Debug, Clone)]
@@ -251,7 +251,7 @@ impl SeafowlPruningStatistics {
                 max_values.get_mut(column.name.as_ref()).unwrap()[ind] =
                     Self::parse_bytes_value(&column.max_value, data_type)?;
                 null_counts.get_mut(column.name.as_ref()).unwrap()[ind] =
-                    column.null_count;
+                    column.null_count.map(|nc| nc as u64);
             }
         }
 
@@ -628,7 +628,7 @@ mod tests {
     ]
     #[tokio::test]
     async fn test_partition_pruning(
-        part_stats: Vec<(Option<i32>, Option<i32>, Option<u64>)>,
+        part_stats: Vec<(Option<i32>, Option<i32>, Option<i32>)>,
         filters: Vec<Expr>,
         expected: Vec<usize>,
     ) {

--- a/src/repository/default.rs
+++ b/src/repository/default.rs
@@ -87,6 +87,7 @@ impl Repository for $repo {
         &self,
         table_version_id: TableVersionId,
     ) -> Result<Vec<AllTablePartitionsResult>, Error> {
+        // TODO: fetch null count as well
         let partitions = sqlx::query_as(
             r#"SELECT
             physical_partition.id AS table_partition_id,
@@ -241,6 +242,7 @@ impl Repository for $repo {
             })
             .collect();
 
+        // TODO: insert null_count too
         let mut builder: QueryBuilder<_> =
         QueryBuilder::new("INSERT INTO physical_partition_column(physical_partition_id, name, type, min_value, max_value) ");
         builder.push_values(columns, |mut b, (rid, c)| {

--- a/src/repository/default.rs
+++ b/src/repository/default.rs
@@ -92,7 +92,6 @@ impl Repository for $repo {
         &self,
         table_version_id: TableVersionId,
     ) -> Result<Vec<AllTablePartitionsResult>, Error> {
-        // TODO: fetch null count as well
         let partitions = sqlx::query_as(
             r#"SELECT
             physical_partition.id AS table_partition_id,
@@ -101,7 +100,8 @@ impl Repository for $repo {
             physical_partition_column.name AS column_name,
             physical_partition_column.type AS column_type,
             physical_partition_column.min_value,
-            physical_partition_column.max_value
+            physical_partition_column.max_value,
+            physical_partition_column.null_count
         FROM table_partition
         INNER JOIN physical_partition ON physical_partition.id = table_partition.physical_partition_id
         -- TODO left join?
@@ -249,15 +249,15 @@ impl Repository for $repo {
             })
             .collect();
 
-        // TODO: insert null_count too
         let mut builder: QueryBuilder<_> =
-        QueryBuilder::new("INSERT INTO physical_partition_column(physical_partition_id, name, type, min_value, max_value) ");
+        QueryBuilder::new("INSERT INTO physical_partition_column(physical_partition_id, name, type, min_value, max_value, null_count) ");
         builder.push_values(columns, |mut b, (rid, c)| {
             b.push_bind(rid)
                 .push_bind(c.name.as_ref())
                 .push_bind(c.r#type.as_ref())
                 .push_bind(c.min_value.as_ref())
-                .push_bind(c.max_value.as_ref());
+                .push_bind(c.max_value.as_ref())
+                .push_bind(c.null_count);
         });
 
         let query = builder.build();

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -31,6 +31,7 @@ pub struct AllTablePartitionsResult {
     pub row_count: i32,
     pub min_value: Option<Vec<u8>>,
     pub max_value: Option<Vec<u8>>,
+    pub null_count: Option<i32>,
 }
 
 #[derive(sqlx::FromRow, Debug, PartialEq, Eq)]
@@ -172,7 +173,7 @@ pub mod tests {
                     r#type: Arc::from("{\"name\":\"utf8\"}".to_string()),
                     min_value: Arc::new(None),
                     max_value: Arc::new(None),
-                    null_count: None,
+                    null_count: Some(1),
                 },
                 PartitionColumn {
                     name: Arc::from("integer".to_string()),
@@ -182,7 +183,7 @@ pub mod tests {
                     ),
                     min_value: Arc::new(Some([49, 50].to_vec())),
                     max_value: Arc::new(Some([52, 50].to_vec())),
-                    null_count: None,
+                    null_count: Some(0),
                 },
                 PartitionColumn {
                     name: Arc::from("varchar".to_string()),
@@ -353,6 +354,7 @@ pub mod tests {
                 row_count: 2,
                 min_value: None,
                 max_value: None,
+                null_count: Some(1),
             },
             AllTablePartitionsResult {
                 table_partition_id: *partition_id,
@@ -363,6 +365,7 @@ pub mod tests {
                 row_count: 2,
                 min_value: Some([49, 50].to_vec()),
                 max_value: Some([52, 50].to_vec()),
+                null_count: Some(0),
             },
             AllTablePartitionsResult {
                 table_partition_id: *partition_id,
@@ -372,6 +375,7 @@ pub mod tests {
                 row_count: 2,
                 min_value: None,
                 max_value: None,
+                null_count: None,
             },
         ];
         assert_eq!(all_partitions, expected_partitions);

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -162,6 +162,7 @@ pub mod tests {
                     r#type: Arc::from("{\"name\":\"utf8\"}".to_string()),
                     min_value: Arc::new(None),
                     max_value: Arc::new(None),
+                    null_count: None,
                 },
                 PartitionColumn {
                     name: Arc::from("integer".to_string()),
@@ -171,12 +172,14 @@ pub mod tests {
                     ),
                     min_value: Arc::new(Some([49, 50].to_vec())),
                     max_value: Arc::new(Some([52, 50].to_vec())),
+                    null_count: None,
                 },
                 PartitionColumn {
                     name: Arc::from("varchar".to_string()),
                     r#type: Arc::from("{\"name\":\"utf8\"}".to_string()),
                     min_value: Arc::new(None),
                     max_value: Arc::new(None),
+                    null_count: None,
                 },
             ]),
         }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -317,7 +317,7 @@ async fn test_table_partitioning_and_rechunking() {
     // Test partition pruning during scans works
     //
 
-    // Assert that only a single partition is goind to be used
+    // Assert that only a single partition is going to be used
     let plan = context
         .plan_query(
             "EXPLAIN SELECT some_value, some_int_value FROM test_table WHERE some_value > 45",

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -318,6 +318,24 @@ async fn test_table_partitioning_and_rechunking() {
     //
     let plan = context
         .plan_query(
+            "EXPLAIN SELECT some_value, some_int_value FROM test_table WHERE some_value > 45",
+        )
+        .await
+        .unwrap();
+    let results = context.collect(plan).await.unwrap();
+
+    let expected = vec![
+        "+------------+----------------+",
+        "| some_value | some_int_value |",
+        "+------------+----------------+",
+        "| 46         | 5555           |",
+        "| 47         | 6666           |",
+        "+------------+----------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    let plan = context
+        .plan_query(
             "SELECT some_value, some_int_value FROM test_table WHERE some_value > 45",
         )
         .await


### PR DESCRIPTION
Instead of defaulting to scanning all of the partitions, the goal here is to use the statistical summary for each column in each partition, and based on the filter/qualifier used in the query determine whether some of the partitions are superfluous for getting a correct result. If this determination succeeds simply scope the scan down only to partitions which are relevant to the query. 