### PR TITLE
Make upload endpoint max data length configurable

### DIFF
--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -159,10 +159,11 @@ mod tests {
                     bind_port: 80,
                     read_access: schema::AccessSettings::Any,
                     write_access: schema::AccessSettings::Any,
+                    upload_data_max_length: 256 * 1024 * 1024,
                 }),
             },
             misc: schema::Misc {
-                max_partition_size: 1048576,
+                max_partition_size: 1024 * 1024,
             },
         };
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -212,6 +212,7 @@ pub struct HttpFrontend {
     pub bind_port: u16,
     pub read_access: AccessSettings,
     pub write_access: AccessSettings,
+    pub upload_data_max_length: u64,
 }
 
 impl Default for HttpFrontend {
@@ -221,6 +222,7 @@ impl Default for HttpFrontend {
             bind_port: 8080,
             read_access: AccessSettings::Any,
             write_access: AccessSettings::Off,
+            upload_data_max_length: 256 * 1024 * 1024,
         }
     }
 }
@@ -234,7 +236,7 @@ pub struct Misc {
 impl Default for Misc {
     fn default() -> Self {
         Self {
-            max_partition_size: 1048576,
+            max_partition_size: 1024 * 1024,
         }
     }
 }
@@ -338,6 +340,7 @@ bind_host = "0.0.0.0"
 bind_port = 80
 read_access = "any"
 write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c"
+upload_data_max_length = 1024
 "#;
 
     const TEST_CONFIG_ERROR: &str = r#"
@@ -391,10 +394,11 @@ write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c
                         bind_port: 80,
                         read_access: AccessSettings::Any,
                         write_access: AccessSettings::Off,
+                        upload_data_max_length: 268435456
                     })
                 },
                 misc: Misc {
-                    max_partition_size: 1048576
+                    max_partition_size: 1024 * 1024
                 },
             }
         )
@@ -415,6 +419,7 @@ write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c
                         "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c"
                             .to_string()
                 },
+                upload_data_max_length: 1024
             }
         );
     }
@@ -474,10 +479,11 @@ write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c
                             "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c"
                                 .to_string()
                         },
+                        upload_data_max_length: 268435456
                     })
                 },
                 misc: Misc {
-                    max_partition_size: 1048576
+                    max_partition_size: 1024 * 1024
                 },
             }
         )

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -5,7 +5,6 @@ use tokio::process::Command;
 
 use futures::Future;
 use futures::FutureExt;
-use seafowl::auth::AccessPolicy;
 use seafowl::config::context::build_context;
 use seafowl::config::schema::load_config_from_string;
 
@@ -58,10 +57,7 @@ write_access = "b786e07f52fc72d32b2163b6f63aa16344fd8d2d84df87b6c231ab33cd5aa125
     let config = load_config_from_string(config_text, false, None).unwrap();
     let context = Arc::from(build_context(&config).await.unwrap());
 
-    let filters = filters(
-        context.clone(),
-        AccessPolicy::from_config(&config.frontend.http.unwrap()),
-    );
+    let filters = filters(context.clone(), config.frontend.http.unwrap());
     let (tx, rx) = oneshot::channel();
     let (addr, server) = warp::serve(filters).bind_with_graceful_shutdown(
         // Pass port :0 to pick a random free port


### PR DESCRIPTION
In order to circumvent the default max form data length of 2MB, we need to have this property configurable. For now, make it default to 256 MB.