### PR TITLE
Serialise min/max partition stats into protobufs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
       - name: Install cmake
-        run: apt-get install -y cmake
+        run: apt-get update && apt-get install -y cmake
 
       # Use https://github.com/marketplace/actions/rust-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+      - name: Install cmake
+        run: sudo apt-get install -y cmake
 
       # Use https://github.com/marketplace/actions/rust-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
       - name: Install cmake
-        run: sudo apt-get install -y cmake
+        run: apt-get install -y cmake
 
       # Use https://github.com/marketplace/actions/rust-cache
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ convergence-arrow = { git = "https://github.com/returnString/convergence", rev =
 datafusion = "10"
 datafusion-proto = "10"
 futures = "0.3"
-prost = "0.10"
 
 # passing to DF's query planner
 hashbrown = { version = "0.12", features = ["raw"] }
@@ -37,6 +36,7 @@ mimalloc = { version = "*", default-features = false }
 moka = { version = "0.9.3", default_features = false, features = ["future", "atomic64", "quanta"] }
 object_store = "0.3.0"
 pretty_env_logger = "0.4"
+prost = "0.10"
 
 # Needs to be in non-dev because repository::testutils can't be
 # imported by tests::end_to_end if it's cfg(test).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ config = "0.13.1"
 convergence = { git = "https://github.com/returnString/convergence", rev = "500ea8e1f03f63f20effb9b93cf414c1c6711515", optional = true }
 convergence-arrow = { git = "https://github.com/returnString/convergence", rev = "500ea8e1f03f63f20effb9b93cf414c1c6711515", package = "convergence-arrow", optional = true }
 datafusion = "10"
+datafusion-proto = "10"
 futures = "0.3"
+prost = "0.10"
 
 # passing to DF's query planner
 hashbrown = { version = "0.12", features = ["raw"] }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -296,6 +296,7 @@ impl SeafowlPruningStatistics {
     /// use arrow::datatypes::DataType;
     /// use datafusion::scalar::ScalarValue;
     /// use seafowl::provider::SeafowlPruningStatistics;
+    /// use seafowl::context::scalar_value_to_bytes;
     ///
     /// fn parse(value: &Arc<Option<Vec<u8>>>, dt: &DataType) -> ScalarValue {
     ///     SeafowlPruningStatistics::parse_bytes_value(&value, &dt).unwrap()
@@ -307,9 +308,13 @@ impl SeafowlPruningStatistics {
     /// assert_eq!(parse(&val, &DataType::Boolean), ScalarValue::Boolean(None));
     ///
     /// // Parse some actual value
-    /// let val = Arc::from(Some(42.to_string().as_bytes().to_vec()));
+    /// let val = Arc::from(scalar_value_to_bytes(&ScalarValue::Int32(Some(42))));
     /// assert_eq!(parse(&val, &DataType::Int32), ScalarValue::Int32(Some(42)));
+    ///
+    /// let val = Arc::from(scalar_value_to_bytes(&ScalarValue::Float32(Some(42.0))));
     /// assert_eq!(parse(&val, &DataType::Float32), ScalarValue::Float32(Some(42.0)));
+    ///
+    /// let val = Arc::from(scalar_value_to_bytes(&ScalarValue::Utf8(Some("42".to_string()))));
     /// assert_eq!(parse(&val, &DataType::Utf8), ScalarValue::Utf8(Some("42".to_string())));
     /// ```
     pub fn parse_bytes_value(


### PR DESCRIPTION
Instead of using the string as an intermediary for persisting min/max partition stats, use Datafusion protobufs, which are more adequate for serde into a DB. One big benefit is that Timestamp* types get to keep the timezone info after a round trip, and can therefore be used for partition pruning.