### PR TITLE
Add delete statement support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.21"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -807,7 +807,7 @@ dependencies = [
  "log",
  "num_cpus",
  "object_store",
- "ordered-float 3.0.0",
+ "ordered-float 3.1.0",
  "parking_lot 0.12.1",
  "parquet",
  "paste",
@@ -830,7 +830,7 @@ checksum = "7721fd550f6a28ad7235b62462aa51e9a43b08f8346d5cbe4d61f1e83f5df511"
 dependencies = [
  "arrow",
  "object_store",
- "ordered-float 3.0.0",
+ "ordered-float 3.1.0",
  "parquet",
  "serde_json",
  "sqlparser",
@@ -881,7 +881,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lazy_static",
  "md-5",
- "ordered-float 3.0.0",
+ "ordered-float 3.1.0",
  "paste",
  "rand 0.8.5",
  "regex",
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime 2.1.0",
@@ -1158,7 +1158,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
- "env_logger 0.9.0",
+ "env_logger 0.9.1",
  "log",
 ]
 
@@ -1694,14 +1694,13 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1762,9 +1761,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1803,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
@@ -1908,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libgit2-sys"
@@ -1961,9 +1960,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2009,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b48670c893079d3c2ed79114e3644b7004df1c361a4e0ad52e2e6940d07c3d"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
  "digest 0.10.5",
 ]
@@ -2357,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "opaque-debug"
@@ -2423,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2"
+checksum = "98ffdb14730ed2ef599c65810c15b000896e21e8776b512de0db0c3d7335cc2a"
 dependencies = [
  "num-traits",
 ]
@@ -2738,9 +2737,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
  "unicode-ident",
 ]
@@ -2800,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f446d0a6efba22928558c4fb4ce0b3fd6c89b0061343e390bf01a703742b8125"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
 ]
@@ -3029,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64",
  "bytes",
@@ -3046,10 +3045,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.6",
@@ -3066,7 +3065,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.22.4",
+ "webpki-roots 0.22.5",
  "winreg",
 ]
 
@@ -3129,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.9"
+version = "0.35.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
+checksum = "af895b90e5c071badc3136fc10ff0bcfc98747eadbaf43ed8f214e07ba8f8477"
 dependencies = [
  "bitflags",
  "errno",
@@ -3339,18 +3338,18 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3718,9 +3717,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3729,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae2421f3e16b3afd4aa692d23b83d0ba42ee9b0081d5deeb7d21428d7195fb1"
+checksum = "49086f670c15221b510c3f8c47e04e49714c56820d5ca78e2f58419e9fbb0f1b"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -3812,18 +3811,18 @@ checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "0a99cb8c4b9a8ef0e7907cd3b617cc8dc04d571c4e73c8ae403d80ac160bb122"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "3a891860d3c8d66fec8e73ddb3765f90082374dbaaa833407b904a94f1a7eb43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3963,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4136,9 +4135,9 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -4367,9 +4366,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d443c5a7daae71697d97ec12ad70b4fe8766d3a0f4db16158ac8b781365892f7"
+checksum = "7e7ca71c70a6de5b10968ae4d298e548366d9cd9588176e6ff8866f3c49c96ee"
 dependencies = [
  "leb128",
 ]
@@ -4573,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0ab19660e3ea6891bba69167b9be40fad00fb1fe3dd39c5eebcee15607131b"
+checksum = "117ccfc4262e62a28a13f0548a147f19ffe71e8a08be802af23ae4ea0bedad73"
 dependencies = [
  "leb128",
  "memchr",
@@ -4585,9 +4584,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f775282def4d5bffd94d60d6ecd57bfe6faa46171cdbf8d32bd5458842b1e3e"
+checksum = "7aab4e20c60429fbba9670a6cae0fff9520046ba0aa3e6d0b1cd2653bea14898"
 dependencies = [
  "wast",
 ]
@@ -4633,9 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki 0.22.0",
 ]

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -282,6 +282,9 @@ impl DefaultCatalog {
         let mut iter = partition_columns.peekable();
 
         SeafowlPartition {
+            partition_id: Some(
+                iter.peek().unwrap().table_partition_id as PhysicalPartitionId,
+            ),
             object_storage_id: Arc::from(iter.peek().unwrap().object_storage_id.clone()),
             row_count: iter.peek().unwrap().row_count,
             columns: Arc::new(

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -189,6 +189,7 @@ pub trait TableCatalog: Sync + Send {
     async fn create_new_table_version(
         &self,
         from_version: TableVersionId,
+        inherit_partitions: bool,
     ) -> Result<TableVersionId>;
 
     async fn move_table(
@@ -493,9 +494,10 @@ impl TableCatalog for DefaultCatalog {
     async fn create_new_table_version(
         &self,
         from_version: TableVersionId,
+        inherit_partitions: bool,
     ) -> Result<TableVersionId> {
         self.repository
-            .create_new_table_version(from_version)
+            .create_new_table_version(from_version, inherit_partitions)
             .await
             .map_err(|e| match e {
                 RepositoryError::FKConstraintViolation(_) => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1333,19 +1333,18 @@ impl SeafowlContext for DefaultSeafowlContext {
                                             );
 
                                         // Group adjacent partitions eligible for filtering
-                                        let mut partitions_grouped: Vec<(
+                                        let partitions_grouped: Vec<(
                                             bool,
                                             Vec<SeafowlPartition>,
-                                        )> = Vec::new();
-                                        for (keep, group) in
-                                            &partitions.into_iter().group_by(|p| {
+                                        )> = partitions
+                                            .into_iter()
+                                            .group_by(|p| {
                                                 !partitions_to_filter
                                                     .contains(&p.partition_id.unwrap())
                                             })
-                                        {
-                                            partitions_grouped
-                                                .push((keep, group.collect()))
-                                        }
+                                            .into_iter()
+                                            .map(|(keep, group)| (keep, group.collect()))
+                                            .collect();
 
                                         for (keep, group) in partitions_grouped {
                                             if keep {
@@ -1381,9 +1380,9 @@ impl SeafowlContext for DefaultSeafowlContext {
                                     }
                                     Err(error) => {
                                         warn!(
-                                                "Failed constructing pruning statistics for table {} (version: {}) during DELETE execution: {}",
-                                                table.name, table.table_version_id, error
-                                            );
+                                            "Failed constructing pruning statistics for table {} (version: {}) during DELETE execution: {}",
+                                            table.name, table.table_version_id, error
+                                        );
 
                                         // Fallback to scan + filter across all partitions
                                         let filter_plan = table

--- a/src/context.rs
+++ b/src/context.rs
@@ -1364,6 +1364,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                                                 .partition_filter_plan(
                                                     group,
                                                     filter.clone(),
+                                                    &[expr.clone()],
                                                     self.internal_object_store
                                                         .inner
                                                         .clone(),
@@ -1389,6 +1390,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                                             .partition_filter_plan(
                                                 partitions,
                                                 filter.clone(),
+                                                &[expr.clone()],
                                                 self.internal_object_store.inner.clone(),
                                             )
                                             .await?;

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -50,8 +50,8 @@ pub struct Update {
 
 #[derive(Debug, Clone)]
 pub struct Delete {
-    /// The table name (TODO: should this be a table ref?)
-    pub name: String,
+    /// The table to delete from
+    pub table: Arc<SeafowlTable>,
     /// WHERE clause
     pub selection: Option<Expr>,
     /// Dummy result schema for the plan (empty)
@@ -171,8 +171,8 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
             SeafowlExtensionNode::Update(Update { name, .. }) => {
                 write!(f, "Update: {}", name)
             }
-            SeafowlExtensionNode::Delete(Delete { name, .. }) => {
-                write!(f, "Delete: {}", name)
+            SeafowlExtensionNode::Delete(Delete { table, .. }) => {
+                write!(f, "Delete: {}", table.name)
             }
             SeafowlExtensionNode::CreateFunction(CreateFunction { name, .. }) => {
                 write!(f, "CreateFunction: {}", name)

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -181,6 +181,8 @@ impl SeafowlTable {
         };
 
         let format = ParquetFormat::default();
+        // TODO: filters here probably does nothing, since we handle pruning explicitly ourselves via
+        // `partitions` param
         format.create_physical_plan(config, filters).await
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -183,8 +183,6 @@ impl SeafowlTable {
         };
 
         let format = ParquetFormat::default();
-        // TODO: filters here probably does nothing, since we handle pruning explicitly ourselves via
-        // `partitions` param
         format.create_physical_plan(config, filters).await
     }
 
@@ -193,10 +191,11 @@ impl SeafowlTable {
         &self,
         partitions: Vec<SeafowlPartition>,
         filter: Arc<dyn PhysicalExpr>,
+        scan_filters: &[Expr],
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let base_scan = self
-            .partition_scan_plan(&None, partitions, &[], None, object_store)
+            .partition_scan_plan(&None, partitions, scan_filters, None, object_store)
             .await?;
 
         Ok(Arc::new(FilterExec::try_new(filter, base_scan)?))

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -36,10 +36,12 @@ use datafusion_proto::protobuf;
 
 use futures::future;
 use log::warn;
+use object_store::ObjectStore;
 use prost::Message;
 
 use object_store::path::Path;
 
+use crate::data_types::PhysicalPartitionId;
 use crate::{
     catalog::PartitionCatalog,
     data_types::{TableId, TableVersionId},
@@ -101,6 +103,7 @@ impl SchemaProvider for SeafowlCollection {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SeafowlPartition {
+    pub partition_id: Option<PhysicalPartitionId>,
     pub object_storage_id: Arc<str>,
     pub row_count: i32,
     pub columns: Arc<Vec<PartitionColumn>>,
@@ -139,6 +142,46 @@ impl std::fmt::Debug for SeafowlTable {
             .field("table_id", &self.table_id)
             .field("table_version_id", &self.table_version_id)
             .finish()
+    }
+}
+
+impl SeafowlTable {
+    // This code is partially taken from ListingTable but adapted to use an arbitrary
+    // list of Parquet URLs rather than all files in a given directory.
+    pub async fn partition_scan_plan(
+        &self,
+        projection: &Option<Vec<usize>>,
+        partitions: Vec<SeafowlPartition>,
+        filters: &[Expr],
+        limit: Option<usize>,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Build a list of lists of PartitionedFile groups (one file = one partition for the scan)
+        let partitioned_file_lists: Vec<Vec<PartitionedFile>> =
+            future::try_join_all(partitions.iter().map(|p| async {
+                let path = Path::parse(&p.object_storage_id)?;
+                let meta = object_store.head(&path).await?;
+                Ok(vec![PartitionedFile {
+                    object_meta: meta,
+                    partition_values: vec![],
+                    range: None,
+                    extensions: None,
+                }]) as Result<_>
+            }))
+            .await?;
+
+        let config = FileScanConfig {
+            object_store_url: internal_object_store_url(),
+            file_schema: self.schema(),
+            file_groups: partitioned_file_lists,
+            statistics: Statistics::default(),
+            projection: projection.clone(),
+            limit,
+            table_partition_cols: vec![],
+        };
+
+        let format = ParquetFormat::default();
+        format.create_physical_plan(config, filters).await
     }
 }
 
@@ -184,43 +227,15 @@ impl TableProvider for SeafowlTable {
             };
         }
 
-        // This code is partially taken from ListingTable but adapted to use an arbitrary
-        // list of Parquet URLs rather than all files in a given directory.
-
         // Get our object store (with a hardcoded scheme)
         let object_store_url = internal_object_store_url();
         let store = ctx.runtime_env.object_store(object_store_url.clone())?;
 
-        // Build a list of lists of PartitionedFile groups (one file = one partition for the scan)
-        let partitioned_file_lists: Vec<Vec<PartitionedFile>> =
-            future::try_join_all(partitions.iter().map(|p| async {
-                let path = Path::parse(&p.object_storage_id)?;
-                let meta = store.head(&path).await?;
-                Ok(vec![PartitionedFile {
-                    object_meta: meta,
-                    partition_values: vec![],
-                    range: None,
-                    extensions: None,
-                }]) as Result<_>
-            }))
-            .await?;
-
-        let config = FileScanConfig {
-            object_store_url,
-            file_schema: self.schema(),
-            file_groups: partitioned_file_lists,
-            statistics: Statistics::default(),
-            projection: projection.clone(),
-            limit,
-            table_partition_cols: vec![],
-        };
-
-        let format = ParquetFormat::default();
-        let plan = format.create_physical_plan(config, filters).await?;
-
         Ok(Arc::new(SeafowlBaseTableScanNode {
-            partitions: Arc::new(partitions),
-            inner: plan,
+            partitions: Arc::new(partitions.clone()),
+            inner: self
+                .partition_scan_plan(projection, partitions, filters, limit, store)
+                .await?,
         }))
     }
 
@@ -244,7 +259,7 @@ pub struct SeafowlPruningStatistics {
 
 impl SeafowlPruningStatistics {
     // Generate maps of min/max/null stats per column, parsing the serialized values stored in partitions
-    fn from_partitions(
+    pub fn from_partitions(
         partitions: Vec<SeafowlPartition>,
         schema: SchemaRef,
     ) -> Result<Self> {
@@ -353,7 +368,7 @@ impl SeafowlPruningStatistics {
     }
 
     // Prune away partitions that are refuted by the provided filter expressions
-    async fn prune(&self, filters: &[Expr]) -> Vec<SeafowlPartition> {
+    pub async fn prune(&self, filters: &[Expr]) -> Vec<SeafowlPartition> {
         let mut partition_mask = vec![true; self.partition_count];
 
         if !filters.is_empty() {
@@ -513,6 +528,7 @@ mod tests {
     use object_store::{memory::InMemory, path::Path, ObjectStore};
     use test_case::test_case;
 
+    use crate::data_types::PhysicalPartitionId;
     use crate::provider::{PartitionColumn, SeafowlPruningStatistics};
     use crate::{
         catalog::MockPartitionCatalog,
@@ -565,6 +581,7 @@ mod tests {
             .with(predicate::eq(1))
             .returning(|_| {
                 Ok(vec![SeafowlPartition {
+                    partition_id: Some(1),
                     object_storage_id: Arc::from("some-file.parquet"),
                     row_count: 3,
                     columns: Arc::new(vec![]),
@@ -690,6 +707,7 @@ mod tests {
             );
 
             partitions.push(SeafowlPartition {
+                partition_id: Some(ind as PhysicalPartitionId),
                 object_storage_id: Arc::from(format!("par{}.parquet", ind)),
                 row_count: 3,
                 columns: Arc::new(vec![PartitionColumn {

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -177,6 +177,7 @@ pub mod tests {
 
     fn get_test_partition() -> SeafowlPartition {
         SeafowlPartition {
+            partition_id: Some(1),
             object_storage_id: Arc::from(EXPECTED_FILE_NAME.to_string()),
             row_count: 2,
             columns: Arc::new(vec![

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -129,6 +129,7 @@ pub trait Repository: Send + Sync + Debug {
     async fn create_new_table_version(
         &self,
         from_version: TableVersionId,
+        inherit_partitions: bool,
     ) -> Result<TableVersionId, Error>;
 
     async fn move_table(
@@ -305,7 +306,7 @@ pub mod tests {
 
         // Duplicate the table
         let new_version_id = repository
-            .create_new_table_version(table_version_id)
+            .create_new_table_version(table_version_id, true)
             .await
             .unwrap();
 
@@ -395,7 +396,7 @@ pub mod tests {
 
         // Duplicate the table, check it has the same partitions
         let new_version_id = repository
-            .create_new_table_version(table_version_id)
+            .create_new_table_version(table_version_id, true)
             .await
             .unwrap();
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -1196,6 +1196,18 @@ async fn test_delete_statement() {
     assert_batches_eq!(expected, &results);
 
     //
+    // Execute a no-op DELETE, leaving the new table version the same as the prior one
+    //
+
+    let plan = context
+        .plan_query("DELETE FROM test_table WHERE some_value < 35")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    assert_partition_ids(&context, 7, vec![1, 4, 5]).await;
+
+    //
     // Execute DELETE with multiple conditions, removing entire partition 4, and trimming partitions 1 and 5
     //
     let plan = context
@@ -1204,7 +1216,7 @@ async fn test_delete_statement() {
         .unwrap();
     context.collect(plan).await.unwrap();
 
-    assert_partition_ids(&context, 7, vec![6]).await;
+    assert_partition_ids(&context, 8, vec![6]).await;
 
     // Verify results
     let plan = context
@@ -1230,7 +1242,7 @@ async fn test_delete_statement() {
     let plan = context.plan_query("DELETE FROM test_table").await.unwrap();
     context.collect(plan).await.unwrap();
 
-    assert_partition_ids(&context, 8, vec![]).await;
+    assert_partition_ids(&context, 9, vec![]).await;
 
     // Verify results
     let plan = context

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -12,6 +12,7 @@ use seafowl::config::schema::load_config_from_string;
 use seafowl::context::DefaultSeafowlContext;
 use seafowl::context::SeafowlContext;
 use seafowl::data_types::TableVersionId;
+use seafowl::provider::SeafowlPartition;
 use seafowl::repository::postgres::testutils::get_random_schema;
 
 // Hack because integration tests do not set cfg(test)
@@ -31,6 +32,7 @@ const FILENAME_RECHUNKED: &str =
 /// (but uses an in-memory object store)
 async fn make_context_with_pg() -> DefaultSeafowlContext {
     let dsn = env::var("DATABASE_URL").unwrap();
+    let schema = get_random_schema();
 
     let config_text = format!(
         r#"
@@ -41,8 +43,7 @@ type = "memory"
 type = "postgres"
 dsn = "{}"
 schema = "{}""#,
-        dsn,
-        get_random_schema()
+        dsn, schema
     );
 
     // Ignore the "in-memory object store / persistent catalog" error in e2e tests (we'll discard
@@ -1070,4 +1071,173 @@ async fn test_vacuum_command() {
     assert_orphan_partitions(context.clone(), vec![]).await;
     let object_metas = get_object_metas().await;
     assert_eq!(object_metas.len(), 0);
+}
+
+#[tokio::test]
+async fn test_delete_statement() {
+    async fn scan_partitions(
+        context: &DefaultSeafowlContext,
+        projection: Option<Vec<usize>>,
+        partitions: SeafowlPartition,
+    ) -> Vec<RecordBatch> {
+        let table = context.try_get_seafowl_table("test_table").unwrap();
+        let plan = table
+            .partition_scan_plan(
+                &projection,
+                vec![partitions],
+                &[],
+                None,
+                context.internal_object_store.inner.clone(),
+            )
+            .await
+            .unwrap();
+
+        context.collect(plan).await.unwrap()
+    }
+
+    async fn assert_partition_ids(
+        context: &DefaultSeafowlContext,
+        table_version: TableVersionId,
+        expected_partition_ids: Vec<i64>,
+    ) {
+        let partitions = context
+            .partition_catalog
+            .load_table_partitions(table_version)
+            .await
+            .unwrap();
+
+        let partition_ids: Vec<i64> =
+            partitions.iter().map(|p| p.partition_id.unwrap()).collect();
+        assert_eq!(partition_ids, expected_partition_ids);
+    }
+
+    let context = make_context_with_pg().await;
+
+    // Creates table with table_versions 1 (empty) and 2
+    create_table_and_insert(&context, "test_table").await;
+
+    // Add another partition for table_version 3
+    let plan = context
+        .plan_query("INSERT INTO test_table (some_value) VALUES (45), (46), (47)")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    // Add another partition for table_version 4
+    let plan = context
+        .plan_query("INSERT INTO test_table (some_value) VALUES (46), (47), (48)")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    // Add another partition for table_version 5
+    let plan = context
+        .plan_query("INSERT INTO test_table (some_value) VALUES (42), (41), (40)")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    // We have 4 partitions from 4 INSERTS
+    assert_partition_ids(&context, 5, vec![1, 2, 3, 4]).await;
+
+    //
+    // Execute DELETE affecting partitions 2, 3 and creating table_version 6
+    //
+    let plan = context
+        .plan_query("DELETE FROM test_table WHERE some_value > 46")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    assert_partition_ids(&context, 6, vec![1, 4, 5]).await;
+
+    let partitions = context
+        .partition_catalog
+        .load_table_partitions(6 as TableVersionId)
+        .await
+        .unwrap();
+
+    // Assert result of the new partition with id 5
+    let results = scan_partitions(&context, Some(vec![4]), partitions[2].clone()).await;
+    let expected = vec![
+        "+------------+",
+        "| some_value |",
+        "+------------+",
+        "| 45         |",
+        "| 46         |",
+        "| 46         |",
+        "+------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    // Verify results
+    let plan = context
+        .plan_query("SELECT some_value FROM test_table")
+        .await
+        .unwrap();
+    let results = context.collect(plan).await.unwrap();
+
+    // TODO: the partition order is swapped here
+    let expected = vec![
+        "+------------+",
+        "| some_value |",
+        "+------------+",
+        "| 42         |",
+        "| 43         |",
+        "| 44         |",
+        "| 42         |",
+        "| 41         |",
+        "| 40         |",
+        "| 45         |",
+        "| 46         |",
+        "| 46         |",
+        "+------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    //
+    // Execute DELETE with multiple conditions, removing entire partition 4, and trimming partitions 1 and 5
+    //
+    let plan = context
+        .plan_query("DELETE FROM test_table WHERE some_value < 43 OR some_value > 45")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    assert_partition_ids(&context, 7, vec![6]).await;
+
+    // Verify results
+    let plan = context
+        .plan_query("SELECT some_value FROM test_table")
+        .await
+        .unwrap();
+    let results = context.collect(plan).await.unwrap();
+
+    let expected = vec![
+        "+------------+",
+        "| some_value |",
+        "+------------+",
+        "| 43         |",
+        "| 44         |",
+        "| 45         |",
+        "+------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    //
+    // Execute blank DELETE, without qualifiers
+    //
+    let plan = context.plan_query("DELETE FROM test_table").await.unwrap();
+    context.collect(plan).await.unwrap();
+
+    assert_partition_ids(&context, 8, vec![]).await;
+
+    // Verify results
+    let plan = context
+        .plan_query("SELECT some_value FROM test_table")
+        .await
+        .unwrap();
+    let results = context.collect(plan).await.unwrap();
+
+    assert!(results.is_empty());
 }


### PR DESCRIPTION
The present `DELETE` implementation is based on the fine-grained approach, whereby we utilize pruning to pinpoint which partitions will need elements removed. We then scan + filter from these partitions only (batching adjacent ones together to minimize sparse partition number) creating new substitute partitions, while re-using the ones unaffected by the `WHERE` qualifier of the `DELETE` from the old table version as is.