### PR TITLE
Percent-decode incoming queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,6 +3278,7 @@ dependencies = [
  "mockall",
  "moka",
  "object_store",
+ "percent-encoding",
  "pretty_env_logger",
  "prost",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,13 @@ datafusion = "12"
 datafusion-expr = "12"
 datafusion-proto = "12"
 futures = "0.3"
-
-# passing to DF's query planner
 hashbrown = { version = "0.12", features = ["raw"] }
 hex = ">=0.4.0"
 itertools = ">=0.10.0"
 log = "0.4"
 moka = { version = "0.9.3", default_features = false, features = ["future", "atomic64", "quanta"] }
 object_store = "0.5.0"
+percent-encoding = "2.2.0"
 pretty_env_logger = "0.4"
 prost = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ include = [
     "Cargo.toml",
     "build.rs",
     "migrations",
+
 ]
 
 [features]

--- a/src/frontend/http_utils.rs
+++ b/src/frontend/http_utils.rs
@@ -67,6 +67,7 @@ pub enum ApiError {
     UploadBodyLoadError(warp::Error),
     UploadHasHeaderParseError,
     UploadUnsupportedFileFormat(String),
+    QueryDecodeError,
 }
 
 // Wrap DataFusion errors so that we can automagically return an
@@ -74,6 +75,13 @@ pub enum ApiError {
 impl From<DataFusionError> for ApiError {
     fn from(err: DataFusionError) -> Self {
         ApiError::DataFusionError(err)
+    }
+}
+
+// Similarly, wrap Utf8 string decode errors.
+impl From<std::str::Utf8Error> for ApiError {
+    fn from(_e: std::str::Utf8Error) -> ApiError {
+        ApiError::QueryDecodeError
     }
 }
 
@@ -103,6 +111,7 @@ impl ApiError {
             ApiError::UploadFileLoadError(e) => (StatusCode::BAD_REQUEST, format!("Error loading the upload file: {:}", e)),
             ApiError::UploadHasHeaderParseError => (StatusCode::BAD_REQUEST, "Invalid has_header".to_string()),
             ApiError::UploadUnsupportedFileFormat(filename) => (StatusCode::BAD_REQUEST, format!("File {} not supported", filename)),
+            ApiError::QueryDecodeError => (StatusCode::BAD_REQUEST, "QUERY_DECODE_ERROR".to_string()),
         }
     }
 


### PR DESCRIPTION
headers cannot contain special characters such as newlines (as is described in GH issue #104). The solution is to percent-encode (aka: encodeURIComponent()) the query string. Encoding is not mandatory, some characters like the space are HTTP header-safe, these characters can be sent both as they are or percent encoded (e.g. %20 for space).