### PR TITLE
Add update statement support

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1279,12 +1279,6 @@ impl SeafowlContext for DefaultSeafowlContext {
                             assignments,
                             ..
                         }) => {
-                            // Create a new blank table version
-                            let new_table_version_id = self
-                                .table_catalog
-                                .create_new_table_version(table.table_version_id, false)
-                                .await?;
-
                             // Load all pre-existing partitions
                             let partitions = self
                                 .partition_catalog
@@ -1466,6 +1460,12 @@ impl SeafowlContext for DefaultSeafowlContext {
                                     .await?,
                                 );
                             }
+
+                            // Create a new blank table version
+                            let new_table_version_id = self
+                                .table_catalog
+                                .create_new_table_version(table.table_version_id, false)
+                                .await?;
 
                             // Link the new table version with the corresponding partitions
                             self.partition_catalog

--- a/src/context.rs
+++ b/src/context.rs
@@ -79,7 +79,7 @@ use tokio::sync::Semaphore;
 use crate::catalog::{PartitionCatalog, DEFAULT_SCHEMA, STAGING_SCHEMA};
 use crate::data_types::{PhysicalPartitionId, TableId, TableVersionId};
 use crate::provider::{
-    projection_expressions, PartitionColumn, SeafowlPartition, SeafowlPruningStatistics,
+    project_expressions, PartitionColumn, SeafowlPartition, SeafowlPruningStatistics,
     SeafowlTable,
 };
 use crate::wasm_udf::data_types::{get_volatility, get_wasm_type, CreateFunctionDetails};
@@ -1325,7 +1325,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                             let mut final_partition_ids =
                                 Vec::with_capacity(partitions.len());
                             let mut update_plan: Arc<dyn ExecutionPlan>;
-                            let projection_expressions = projection_expressions(
+                            let project_expressions = project_expressions(
                                 &schema,
                                 assignments,
                                 selection_expr,
@@ -1359,7 +1359,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                                     .await?;
 
                                 update_plan = Arc::new(ProjectionExec::try_new(
-                                    projection_expressions.clone(),
+                                    project_expressions.clone(),
                                     scan_plan,
                                 )?);
 

--- a/src/datafusion/utils.rs
+++ b/src/datafusion/utils.rs
@@ -2,12 +2,8 @@ use datafusion::sql::planner::convert_simple_data_type;
 
 use sqlparser::ast::{ColumnDef as SQLColumnDef, ColumnOption, Ident};
 
+use datafusion::arrow::datatypes::{Field, Schema};
 pub use datafusion::error::{DataFusionError as Error, Result};
-use datafusion::{
-    arrow::datatypes::{Field, Schema},
-    error::DataFusionError,
-    logical_plan::Column,
-};
 
 // Normalize an identifier to a lowercase string unless the identifier is quoted.
 pub(crate) fn normalize_ident(id: &Ident) -> String {
@@ -37,19 +33,4 @@ pub(crate) fn build_schema(columns: Vec<SQLColumnDef>) -> Result<Schema> {
     }
 
     Ok(Schema::new(fields))
-}
-
-// This one is partially taken from the planner for SQLExpr::CompoundIdentifier
-pub(crate) fn compound_identifier_to_column(ids: &[Ident]) -> Result<Column> {
-    let mut var_names: Vec<_> = ids.iter().map(normalize_ident).collect();
-    match (var_names.pop(), var_names.pop()) {
-        (Some(name), Some(relation)) if var_names.is_empty() => Ok(Column {
-            relation: Some(relation),
-            name,
-        }),
-        _ => Err(DataFusionError::NotImplemented(format!(
-            "Unsupported compound identifier '{:?}'",
-            var_names,
-        ))),
-    }
 }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,8 +1,7 @@
 use std::{any::Any, fmt, sync::Arc, vec};
 
-use datafusion::logical_plan::{
-    Column, DFSchemaRef, Expr, LogicalPlan, UserDefinedLogicalNode,
-};
+use datafusion::logical_plan::{DFSchemaRef, Expr, LogicalPlan, UserDefinedLogicalNode};
+use hashbrown::HashMap;
 
 use crate::data_types::TableId;
 use crate::{provider::SeafowlTable, wasm_udf::data_types::CreateFunctionDetails};
@@ -31,19 +30,13 @@ pub struct Insert {
 }
 
 #[derive(Debug, Clone)]
-pub struct Assignment {
-    pub column: Column,
-    pub expr: Expr,
-}
-
-#[derive(Debug, Clone)]
 pub struct Update {
-    /// The table name (TODO: should this be a table ref?)
-    pub name: String,
+    /// The table to update
+    pub table: Arc<SeafowlTable>,
     /// WHERE clause
     pub selection: Option<Expr>,
     /// Columns to update
-    pub assignments: Vec<Assignment>,
+    pub assignments: HashMap<String, Expr>,
     /// Dummy result schema for the plan (empty)
     pub output_schema: DFSchemaRef,
 }
@@ -168,8 +161,8 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
             SeafowlExtensionNode::CreateTable(CreateTable { name, .. }) => {
                 write!(f, "Create: {}", name)
             }
-            SeafowlExtensionNode::Update(Update { name, .. }) => {
-                write!(f, "Update: {}", name)
+            SeafowlExtensionNode::Update(Update { table, .. }) => {
+                write!(f, "Update: {}", table.name)
             }
             SeafowlExtensionNode::Delete(Delete { table, .. }) => {
                 write!(f, "Delete: {}", table.name)

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -465,7 +465,7 @@ impl PruningStatistics for SeafowlPruningStatistics {
 // Create a complete projection expression for all columns, simply replicating the columns omitted
 // in the provided assignments, and enveloping CAST (for fixing mistypes) with a CASE expression to
 // scope down the rows to which the assignment is applied
-pub fn projection_expressions(
+pub fn project_expressions(
     schema: &ArrowSchema,
     assignments: &HashBrownMap<String, Expr>,
     selection_expr: Option<Arc<dyn PhysicalExpr>>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -98,7 +98,7 @@ pub fn group_partitions<F>(
     f: F,
 ) -> Vec<(bool, Vec<SeafowlPartition>)>
 where
-    F: FnMut(&SeafowlPartition) -> bool,
+    F: Fn(&SeafowlPartition) -> bool,
 {
     partitions
         .into_iter()

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -1438,26 +1438,24 @@ async fn test_update_statement() {
         .to_string()
         .contains("Schema error: No field named 'nonexistent'"));
 
-    // let err = context
-    //     .plan_query("UPDATE test_table SET some_int_value = 'nope'")
-    //     .await
-    //     .unwrap_err();
-    //
-    // assert!(err
-    //     .to_string()
-    //     .contains("Cannot cast string 'nope' to value of Int64 type")
-    // );
+    let err = context
+        .plan_query("UPDATE test_table SET some_int_value = 'nope'")
+        .await
+        .unwrap_err();
 
-    // // This one's a bit different
-    // let err = context
-    //     .plan_query("UPDATE test_table SET some_other_value = 'nope'")
-    //     .await
-    //     .unwrap_err();
-    //
-    // assert!(err
-    //     .to_string()
-    //     .contains("Unsupported CAST from Utf8 to Decimal128(38, 10)")
-    // );
+    assert!(err
+        .to_string()
+        .contains("Cannot cast string 'nope' to value of Int64 type"));
+
+    // This one's a bit different
+    let err = context
+        .plan_query("UPDATE test_table SET some_other_value = 'nope'")
+        .await
+        .unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("Unsupported CAST from Utf8 to Decimal128(38, 10)"));
 
     //
     // Execute complex UPDATE (redundant assignment and a case assignment) without a selection,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -124,6 +124,45 @@ async fn create_table_and_insert(context: &DefaultSeafowlContext, table_name: &s
     context.collect(plan).await.unwrap();
 }
 
+// A helper function for asserting contents of a given partition
+async fn scan_partition(
+    context: &DefaultSeafowlContext,
+    projection: Option<Vec<usize>>,
+    partition: SeafowlPartition,
+    table_name: &str,
+) -> Vec<RecordBatch> {
+    let table = context.try_get_seafowl_table(table_name).unwrap();
+    let plan = table
+        .partition_scan_plan(
+            &projection,
+            vec![partition],
+            &[],
+            None,
+            context.internal_object_store.inner.clone(),
+        )
+        .await
+        .unwrap();
+
+    context.collect(plan).await.unwrap()
+}
+
+// Used for checking partition ids making up a given table version
+async fn assert_partition_ids(
+    context: &DefaultSeafowlContext,
+    table_version: TableVersionId,
+    expected_partition_ids: Vec<i64>,
+) {
+    let partitions = context
+        .partition_catalog
+        .load_table_partitions(table_version)
+        .await
+        .unwrap();
+
+    let partition_ids: Vec<i64> =
+        partitions.iter().map(|p| p.partition_id.unwrap()).collect();
+    assert_eq!(partition_ids, expected_partition_ids);
+}
+
 #[tokio::test]
 async fn test_information_schema() {
     let context = make_context_with_pg().await;
@@ -1075,42 +1114,6 @@ async fn test_vacuum_command() {
 
 #[tokio::test]
 async fn test_delete_statement() {
-    async fn scan_partition(
-        context: &DefaultSeafowlContext,
-        projection: Option<Vec<usize>>,
-        partition: SeafowlPartition,
-    ) -> Vec<RecordBatch> {
-        let table = context.try_get_seafowl_table("test_table").unwrap();
-        let plan = table
-            .partition_scan_plan(
-                &projection,
-                vec![partition],
-                &[],
-                None,
-                context.internal_object_store.inner.clone(),
-            )
-            .await
-            .unwrap();
-
-        context.collect(plan).await.unwrap()
-    }
-
-    async fn assert_partition_ids(
-        context: &DefaultSeafowlContext,
-        table_version: TableVersionId,
-        expected_partition_ids: Vec<i64>,
-    ) {
-        let partitions = context
-            .partition_catalog
-            .load_table_partitions(table_version)
-            .await
-            .unwrap();
-
-        let partition_ids: Vec<i64> =
-            partitions.iter().map(|p| p.partition_id.unwrap()).collect();
-        assert_eq!(partition_ids, expected_partition_ids);
-    }
-
     let context = make_context_with_pg().await;
 
     // Creates table with table_versions 1 (empty) and 2
@@ -1158,7 +1161,9 @@ async fn test_delete_statement() {
         .unwrap();
 
     // Assert result of the new partition with id 5
-    let results = scan_partition(&context, Some(vec![4]), partitions[2].clone()).await;
+    let results =
+        scan_partition(&context, Some(vec![4]), partitions[2].clone(), "test_table")
+            .await;
     let expected = vec![
         "+------------+",
         "| some_value |",
@@ -1235,7 +1240,9 @@ async fn test_delete_statement() {
         .await
         .unwrap();
 
-    let results = scan_partition(&context, Some(vec![4]), partitions[1].clone()).await;
+    let results =
+        scan_partition(&context, Some(vec![4]), partitions[1].clone(), "test_table")
+            .await;
     let expected = vec![
         "+------------+",
         "| some_value |",
@@ -1246,7 +1253,9 @@ async fn test_delete_statement() {
     ];
     assert_batches_eq!(expected, &results);
 
-    let results = scan_partition(&context, Some(vec![4]), partitions[2].clone()).await;
+    let results =
+        scan_partition(&context, Some(vec![4]), partitions[2].clone(), "test_table")
+            .await;
     let expected = vec![
         "+------------+",
         "| some_value |",
@@ -1277,7 +1286,9 @@ async fn test_delete_statement() {
         .await
         .unwrap();
 
-    let results = scan_partition(&context, Some(vec![4]), partitions[1].clone()).await;
+    let results =
+        scan_partition(&context, Some(vec![4]), partitions[1].clone(), "test_table")
+            .await;
     let expected = vec![
         "+------------+",
         "| some_value |",
@@ -1288,7 +1299,9 @@ async fn test_delete_statement() {
     ];
     assert_batches_eq!(expected, &results);
 
-    let results = scan_partition(&context, Some(vec![4]), partitions[2].clone()).await;
+    let results =
+        scan_partition(&context, Some(vec![4]), partitions[2].clone(), "test_table")
+            .await;
     let expected = vec![
         "+------------+",
         "| some_value |",
@@ -1315,4 +1328,118 @@ async fn test_delete_statement() {
     let results = context.collect(plan).await.unwrap();
 
     assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn test_update_statement() {
+    let context = make_context_with_pg().await;
+
+    // Creates table with table_versions 1 (empty) and 2
+    create_table_and_insert(&context, "test_table").await;
+
+    // Add another partition for table_version 3
+    let plan = context
+        .plan_query("INSERT INTO test_table (some_value) VALUES (45), (46), (47)")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    // Add another partition for table_version 4
+    let plan = context
+        .plan_query("INSERT INTO test_table (some_value) VALUES (46), (47), (48)")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    // Add another partition for table_version 5
+    let plan = context
+        .plan_query("INSERT INTO test_table (some_value) VALUES (42), (41), (40)")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    // We have 4 partitions from 4 INSERTS
+    assert_partition_ids(&context, 5, vec![1, 2, 3, 4]).await;
+
+    //
+    // Execute UPDATE with a selection, affecting partitions 1 and 4, and creating table_version 6
+    //
+    let plan = context
+        .plan_query("UPDATE test_table SET some_int_value = 5555, some_value = some_value - 10 WHERE some_value IN (41, 42, 43)")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    assert_partition_ids(&context, 6, vec![2, 3, 5, 6]).await;
+
+    // Verify new partition contents
+    let partitions = context
+        .partition_catalog
+        .load_table_partitions(6 as TableVersionId)
+        .await
+        .unwrap();
+
+    let results =
+        scan_partition(&context, None, partitions[2].clone(), "test_table").await;
+    let expected = vec![
+        "+-----------------+----------------+------------------+---------------------+------------+",
+        "| some_bool_value | some_int_value | some_other_value | some_time           | some_value |",
+        "+-----------------+----------------+------------------+---------------------+------------+",
+        "|                 | 5555           |                  | 2022-01-01 20:01:01 | 32         |",
+        "|                 | 5555           |                  | 2022-01-01 20:02:02 | 33         |",
+        "|                 | 3333           |                  | 2022-01-01 20:03:03 | 44         |",
+        "+-----------------+----------------+------------------+---------------------+------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    let results =
+        scan_partition(&context, None, partitions[3].clone(), "test_table").await;
+    let expected = vec![
+        "+-----------------+----------------+------------------+-----------+------------+",
+        "| some_bool_value | some_int_value | some_other_value | some_time | some_value |",
+        "+-----------------+----------------+------------------+-----------+------------+",
+        "|                 | 5555           |                  |           | 32         |",
+        "|                 | 5555           |                  |           | 31         |",
+        "|                 |                |                  |           | 40         |",
+        "+-----------------+----------------+------------------+-----------+------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    //
+    // Execute UPDATE without a selection, creating table_version 7 with all new partitions
+    //
+    let plan = context
+        .plan_query("UPDATE test_table SET some_value = 42")
+        .await
+        .unwrap();
+    context.collect(plan).await.unwrap();
+
+    assert_partition_ids(&context, 7, vec![7]).await;
+
+    // Verify results
+    let plan = context
+        .plan_query("SELECT * FROM test_table")
+        .await
+        .unwrap();
+    let results = context.collect(plan).await.unwrap();
+
+    let expected = vec![
+        "+-----------------+----------------+------------------+---------------------+------------+",
+        "| some_bool_value | some_int_value | some_other_value | some_time           | some_value |",
+        "+-----------------+----------------+------------------+---------------------+------------+",
+        "|                 |                |                  |                     | 42         |",
+        "|                 |                |                  |                     | 42         |",
+        "|                 |                |                  |                     | 42         |",
+        "|                 |                |                  |                     | 42         |",
+        "|                 |                |                  |                     | 42         |",
+        "|                 |                |                  |                     | 42         |",
+        "|                 | 5555           |                  | 2022-01-01 20:01:01 | 42         |",
+        "|                 | 5555           |                  | 2022-01-01 20:02:02 | 42         |",
+        "|                 | 3333           |                  | 2022-01-01 20:03:03 | 42         |",
+        "|                 | 5555           |                  |                     | 42         |",
+        "|                 | 5555           |                  |                     | 42         |",
+        "|                 |                |                  |                     | 42         |",
+        "+-----------------+----------------+------------------+---------------------+------------+",
+    ];
+    assert_batches_eq!(expected, &results);
 }


### PR DESCRIPTION
Implementation of `UPDATE` statement in Seafowl, along similar lines as `DELETE`.

Basically, we pinpoint the exact partitions that need to be updated, and then for the new table version we do a projection of all columns that were changed using the provided assignment expressions. If a WHERE qualifier has been used, we further wrap up the assignment expressions using a CASE expression, to scope down the changes only to affected rows. The columns which were not changed are just projected as is.