### PR TITLE
System schema and table version table

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -862,7 +862,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                         // the map and having the versioned query fail during execution.
                         let session_ctx = SessionContext::with_state(state.clone());
 
-                        version_processor.triage_version_ids(self.table_catalog.clone()).await?;
+                        version_processor.triage_version_ids(self.database.clone(), self.table_catalog.clone()).await?;
                         // We now have table_version_ids for each table with version specified; do another
                         // run over the query AST to rewrite the table.
                         version_processor.visit_query(&mut q);
@@ -1759,6 +1759,7 @@ pub mod test_utils {
     use crate::config::context::build_context;
     use crate::config::schema;
     use crate::config::schema::{Catalog, SeafowlConfig, Sqlite};
+    use crate::system_tables::SystemSchemaProvider;
     use sqlx::sqlite::SqliteJournalMode;
     use std::collections::HashMap as StdHashMap;
 
@@ -1862,6 +1863,10 @@ pub mod test_utils {
                     name: Arc::from("testdb"),
                     collections: collections.clone(),
                     staging_schema: Arc::new(MemorySchemaProvider::new()),
+                    system_schema: Arc::new(SystemSchemaProvider::new(
+                        Arc::from("testdb"),
+                        Arc::new(MockTableCatalog::new()),
+                    )),
                 })
             });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod object_store;
 pub mod provider;
 pub mod repository;
 pub mod schema;
+pub mod system_tables;
 pub mod utils;
 pub mod version;
 pub mod wasm_udf;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -48,6 +48,7 @@ use prost::Message;
 use object_store::path::Path;
 
 use crate::data_types::PhysicalPartitionId;
+use crate::system_tables::{SystemSchemaProvider, SYSTEM_SCHEMA};
 use crate::{
     catalog::PartitionCatalog,
     data_types::{TableId, TableVersionId},
@@ -60,6 +61,7 @@ pub struct SeafowlDatabase {
     pub name: Arc<str>,
     pub collections: HashMap<Arc<str>, Arc<SeafowlCollection>>,
     pub staging_schema: Arc<MemorySchemaProvider>,
+    pub system_schema: Arc<SystemSchemaProvider>,
 }
 
 impl CatalogProvider for SeafowlDatabase {
@@ -71,13 +73,15 @@ impl CatalogProvider for SeafowlDatabase {
         self.collections
             .keys()
             .map(|s| s.to_string())
-            .chain([STAGING_SCHEMA.to_string()])
+            .chain([STAGING_SCHEMA.to_string(), SYSTEM_SCHEMA.to_string()])
             .collect()
     }
 
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
         if name == STAGING_SCHEMA {
             Some(self.staging_schema.clone())
+        } else if name == SYSTEM_SCHEMA {
+            Some(self.system_schema.clone())
         } else {
             self.collections.get(name).map(|c| Arc::clone(c) as _)
         }

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -144,7 +144,8 @@ pub trait Repository: Send + Sync + Debug {
 
     async fn get_all_table_versions(
         &self,
-        table_names: Vec<String>,
+        database_name: &str,
+        table_names: Option<Vec<String>>,
     ) -> Result<Vec<TableVersionsResult>>;
 
     async fn move_table(
@@ -353,7 +354,7 @@ pub mod tests {
 
         // Check the existing table versions
         let all_table_versions: Vec<TableVersionId> = repository
-            .get_all_table_versions(vec!["testtable".to_string()])
+            .get_all_table_versions("testdb", Some(vec!["testtable".to_string()]))
             .await
             .expect("Error getting all columns")
             .iter()

--- a/src/system_tables.rs
+++ b/src/system_tables.rs
@@ -1,0 +1,172 @@
+//! Implementation for creating virtual Seafowl system tables, inspired by influxdb_iox system tables
+//! and datafusion's information_schema.
+
+use crate::catalog::TableCatalog;
+use arrow::array::{Int64Builder, StringBuilder, StructBuilder, TimestampSecondBuilder};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::catalog::schema::SchemaProvider;
+use datafusion::common::DataFusionError;
+use datafusion::datasource::TableProvider;
+use datafusion::error::Result;
+use datafusion::execution::context::SessionState;
+use datafusion::physical_plan::memory::MemoryExec;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_expr::{Expr, TableType};
+use std::any::Any;
+use std::sync::Arc;
+
+const _SYSTEM_SCHEMA: &str = "system";
+const TABLE_VERSIONS: &str = "table_versions";
+
+pub struct SystemSchemaProvider {
+    database: String,
+    table_catalog: Arc<dyn TableCatalog>,
+}
+
+impl SchemaProvider for SystemSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        vec![TABLE_VERSIONS.to_string()]
+    }
+
+    fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        match name {
+            TABLE_VERSIONS => {
+                // Lazy instantiate the table, but defer loading the rows until the scan is called.
+                let table = TableVersionsTable::new(
+                    self.database.clone(),
+                    self.table_catalog.clone(),
+                );
+                Some(Arc::new(SystemTableProvider {
+                    table: Arc::new(table),
+                }))
+            }
+            _ => None,
+        }
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        return matches!(name.to_ascii_lowercase().as_str(), TABLE_VERSIONS);
+    }
+}
+
+// Base trait for Seafowl system tables, as a way to imitate OOP
+#[async_trait]
+trait SeafowlSystemTable: Send + Sync {
+    /// The schema for this system table
+    fn schema(&self) -> SchemaRef;
+
+    /// Get the rows of the system table
+    async fn load_record_batch(&self) -> Result<RecordBatch>;
+}
+
+/// Adapter that makes any `SeafowlSystemTable` a DataFusion `TableProvider`
+struct SystemTableProvider<T: SeafowlSystemTable> {
+    table: Arc<T>,
+}
+
+#[async_trait]
+impl<T> TableProvider for SystemTableProvider<T>
+where
+    T: SeafowlSystemTable + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.table.schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    // TODO: Investigate streaming from sqlx instead of loading all the results in memory
+    async fn scan(
+        &self,
+        _ctx: &SessionState,
+        projection: &Option<Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(MemoryExec::try_new(
+            &[vec![self.table.load_record_batch().await?]],
+            self.table.schema(),
+            projection.clone(),
+        )?))
+    }
+}
+
+struct TableVersionsTable {
+    _database: String,
+    schema: SchemaRef,
+    table_catalog: Arc<dyn TableCatalog>,
+}
+
+impl TableVersionsTable {
+    fn new(database: String, table_catalog: Arc<dyn TableCatalog>) -> Self {
+        Self {
+            // This is dictated by the output of `get_all_table_versions`, except that we omit the
+            // database_name field, since we scope down to the database at hand.
+            _database: database,
+            schema: Arc::new(Schema::new(vec![
+                Field::new("table_schema", DataType::Utf8, false),
+                Field::new("table_name", DataType::Utf8, false),
+                Field::new("table_version_id", DataType::Int64, false),
+                Field::new(
+                    "creation_time",
+                    DataType::Timestamp(TimeUnit::Second, Some("UTC".to_string())),
+                    false,
+                ),
+            ])),
+            table_catalog,
+        }
+    }
+}
+
+#[async_trait]
+impl SeafowlSystemTable for TableVersionsTable {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    async fn load_record_batch(&self) -> Result<RecordBatch> {
+        let table_versions = self.table_catalog.get_all_table_versions(vec![]).await?;
+
+        let mut builder = StructBuilder::from_fields(
+            self.schema.fields().clone(),
+            table_versions.len(),
+        );
+
+        // Construct the table columns from the returned rows
+        for table_version in &table_versions {
+            builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_value(table_version.collection_name.clone());
+            builder
+                .field_builder::<StringBuilder>(1)
+                .unwrap()
+                .append_value(&table_version.database_name.clone());
+            builder
+                .field_builder::<Int64Builder>(2)
+                .unwrap()
+                .append_value(table_version.table_version_id);
+            builder
+                .field_builder::<TimestampSecondBuilder>(3)
+                .unwrap()
+                .append_value(table_version.creation_time);
+        }
+
+        let struct_array = builder.finish();
+
+        RecordBatch::try_new(self.schema.clone(), struct_array.columns_ref())
+            .map_err(DataFusionError::from)
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -103,6 +103,7 @@ impl TableVersionProcessor {
 
     pub async fn triage_version_ids(
         &mut self,
+        database: String,
         table_catalog: Arc<dyn TableCatalog>,
     ) -> Result<()> {
         // Fetch all available versions for the versioned tables from the metadata store, and
@@ -110,7 +111,10 @@ impl TableVersionProcessor {
         // and ti the Unix epoch when that version was created for the i-th version).
         let all_table_versions: HashMap<ObjectName, Vec<(TableVersionId, Timestamp)>> =
             table_catalog
-                .get_all_table_versions(self.get_versioned_tables())
+                .get_all_table_versions(
+                    database.as_str(),
+                    Some(self.get_versioned_tables()),
+                )
                 .await?
                 .into_iter()
                 .group_by(|tv| {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -181,13 +181,14 @@ async fn test_information_schema() {
     let results = context.collect(plan).await.unwrap();
 
     let expected = vec![
-        "+---------------+--------------------+------------+------------+",
-        "| table_catalog | table_schema       | table_name | table_type |",
-        "+---------------+--------------------+------------+------------+",
-        "| default       | information_schema | columns    | VIEW       |",
-        "| default       | information_schema | tables     | VIEW       |",
-        "| default       | information_schema | views      | VIEW       |",
-        "+---------------+--------------------+------------+------------+",
+        "+---------------+--------------------+----------------+------------+",
+        "| table_catalog | table_schema       | table_name     | table_type |",
+        "+---------------+--------------------+----------------+------------+",
+        "| default       | information_schema | columns        | VIEW       |",
+        "| default       | system             | table_versions | VIEW       |",
+        "| default       | information_schema | tables         | VIEW       |",
+        "| default       | information_schema | views          | VIEW       |",
+        "+---------------+--------------------+----------------+------------+",
     ];
 
     assert_batches_eq!(expected, &results);
@@ -214,15 +215,19 @@ async fn test_create_table() {
     let results = list_columns_query(&context).await;
 
     let expected = vec![
-        "+--------------+------------+------------------+-----------------------------+",
-        "| table_schema | table_name | column_name      | data_type                   |",
-        "+--------------+------------+------------------+-----------------------------+",
-        "| public       | test_table | some_bool_value  | Boolean                     |",
-        "| public       | test_table | some_int_value   | Int64                       |",
-        "| public       | test_table | some_other_value | Decimal128(38, 10)          |",
-        "| public       | test_table | some_time        | Timestamp(Nanosecond, None) |",
-        "| public       | test_table | some_value       | Float32                     |",
-        "+--------------+------------+------------------+-----------------------------+",
+        "+--------------+----------------+------------------+-----------------------------+",
+        "| table_schema | table_name     | column_name      | data_type                   |",
+        "+--------------+----------------+------------------+-----------------------------+",
+        "| system       | table_versions | table_schema     | Utf8                        |",
+        "| system       | table_versions | table_name       | Utf8                        |",
+        "| system       | table_versions | table_version_id | Int64                       |",
+        "| system       | table_versions | creation_time    | Timestamp(Second, None)     |",
+        "| public       | test_table     | some_bool_value  | Boolean                     |",
+        "| public       | test_table     | some_int_value   | Int64                       |",
+        "| public       | test_table     | some_other_value | Decimal128(38, 10)          |",
+        "| public       | test_table     | some_time        | Timestamp(Nanosecond, None) |",
+        "| public       | test_table     | some_value       | Float32                     |",
+        "+--------------+----------------+------------------+-----------------------------+",
     ];
 
     assert_batches_eq!(expected, &results);
@@ -502,20 +507,24 @@ async fn test_create_table_move_and_drop() {
     let results = list_columns_query(&context).await;
 
     let expected = vec![
-        "+--------------+--------------+------------------+-----------------------------+",
-        "| table_schema | table_name   | column_name      | data_type                   |",
-        "+--------------+--------------+------------------+-----------------------------+",
-        "| public       | test_table_1 | some_bool_value  | Boolean                     |",
-        "| public       | test_table_1 | some_int_value   | Int64                       |",
-        "| public       | test_table_1 | some_other_value | Decimal128(38, 10)          |",
-        "| public       | test_table_1 | some_time        | Timestamp(Nanosecond, None) |",
-        "| public       | test_table_1 | some_value       | Float32                     |",
-        "| public       | test_table_2 | some_bool_value  | Boolean                     |",
-        "| public       | test_table_2 | some_int_value   | Int64                       |",
-        "| public       | test_table_2 | some_other_value | Decimal128(38, 10)          |",
-        "| public       | test_table_2 | some_time        | Timestamp(Nanosecond, None) |",
-        "| public       | test_table_2 | some_value       | Float32                     |",
-        "+--------------+--------------+------------------+-----------------------------+",
+        "+--------------+----------------+------------------+-----------------------------+",
+        "| table_schema | table_name     | column_name      | data_type                   |",
+        "+--------------+----------------+------------------+-----------------------------+",
+        "| system       | table_versions | table_schema     | Utf8                        |",
+        "| system       | table_versions | table_name       | Utf8                        |",
+        "| system       | table_versions | table_version_id | Int64                       |",
+        "| system       | table_versions | creation_time    | Timestamp(Second, None)     |",
+        "| public       | test_table_1   | some_bool_value  | Boolean                     |",
+        "| public       | test_table_1   | some_int_value   | Int64                       |",
+        "| public       | test_table_1   | some_other_value | Decimal128(38, 10)          |",
+        "| public       | test_table_1   | some_time        | Timestamp(Nanosecond, None) |",
+        "| public       | test_table_1   | some_value       | Float32                     |",
+        "| public       | test_table_2   | some_bool_value  | Boolean                     |",
+        "| public       | test_table_2   | some_int_value   | Int64                       |",
+        "| public       | test_table_2   | some_other_value | Decimal128(38, 10)          |",
+        "| public       | test_table_2   | some_time        | Timestamp(Nanosecond, None) |",
+        "| public       | test_table_2   | some_value       | Float32                     |",
+        "+--------------+----------------+------------------+-----------------------------+",
     ];
 
     assert_batches_eq!(expected, &results);
@@ -542,15 +551,16 @@ async fn test_create_table_move_and_drop() {
     let results = list_tables_query(&context).await;
 
     let expected = vec![
-        "+--------------------+--------------+",
-        "| table_schema       | table_name   |",
-        "+--------------------+--------------+",
-        "| information_schema | columns      |",
-        "| information_schema | tables       |",
-        "| information_schema | views        |",
-        "| public             | test_table_2 |",
-        "| public             | test_table_3 |",
-        "+--------------------+--------------+",
+        "+--------------------+----------------+",
+        "| table_schema       | table_name     |",
+        "+--------------------+----------------+",
+        "| information_schema | columns        |",
+        "| information_schema | tables         |",
+        "| information_schema | views          |",
+        "| public             | test_table_2   |",
+        "| public             | test_table_3   |",
+        "| system             | table_versions |",
+        "+--------------------+----------------+",
     ];
     assert_batches_eq!(expected, &results);
 
@@ -586,15 +596,16 @@ async fn test_create_table_move_and_drop() {
     let results = list_tables_query(&context).await;
 
     let expected = vec![
-        "+--------------------+--------------+",
-        "| table_schema       | table_name   |",
-        "+--------------------+--------------+",
-        "| information_schema | columns      |",
-        "| information_schema | tables       |",
-        "| information_schema | views        |",
-        "| new_schema         | test_table_3 |",
-        "| public             | test_table_2 |",
-        "+--------------------+--------------+",
+        "+--------------------+----------------+",
+        "| table_schema       | table_name     |",
+        "+--------------------+----------------+",
+        "| information_schema | columns        |",
+        "| information_schema | tables         |",
+        "| information_schema | views          |",
+        "| new_schema         | test_table_3   |",
+        "| public             | test_table_2   |",
+        "| system             | table_versions |",
+        "+--------------------+----------------+",
     ];
     assert_batches_eq!(expected, &results);
 
@@ -608,15 +619,19 @@ async fn test_create_table_move_and_drop() {
     let results = list_columns_query(&context).await;
 
     let expected = vec![
-        "+--------------+--------------+------------------+-----------------------------+",
-        "| table_schema | table_name   | column_name      | data_type                   |",
-        "+--------------+--------------+------------------+-----------------------------+",
-        "| public       | test_table_2 | some_bool_value  | Boolean                     |",
-        "| public       | test_table_2 | some_int_value   | Int64                       |",
-        "| public       | test_table_2 | some_other_value | Decimal128(38, 10)          |",
-        "| public       | test_table_2 | some_time        | Timestamp(Nanosecond, None) |",
-        "| public       | test_table_2 | some_value       | Float32                     |",
-        "+--------------+--------------+------------------+-----------------------------+",
+        "+--------------+----------------+------------------+-----------------------------+",
+        "| table_schema | table_name     | column_name      | data_type                   |",
+        "+--------------+----------------+------------------+-----------------------------+",
+        "| system       | table_versions | table_schema     | Utf8                        |",
+        "| system       | table_versions | table_name       | Utf8                        |",
+        "| system       | table_versions | table_version_id | Int64                       |",
+        "| system       | table_versions | creation_time    | Timestamp(Second, None)     |",
+        "| public       | test_table_2   | some_bool_value  | Boolean                     |",
+        "| public       | test_table_2   | some_int_value   | Int64                       |",
+        "| public       | test_table_2   | some_other_value | Decimal128(38, 10)          |",
+        "| public       | test_table_2   | some_time        | Timestamp(Nanosecond, None) |",
+        "| public       | test_table_2   | some_value       | Float32                     |",
+        "+--------------+----------------+------------------+-----------------------------+",
     ];
 
     assert_batches_eq!(expected, &results);
@@ -628,7 +643,16 @@ async fn test_create_table_move_and_drop() {
 
     let results = list_columns_query(&context).await;
 
-    let expected = vec!["++", "++"];
+    let expected = vec![
+        "+--------------+----------------+------------------+-------------------------+",
+        "| table_schema | table_name     | column_name      | data_type               |",
+        "+--------------+----------------+------------------+-------------------------+",
+        "| system       | table_versions | table_schema     | Utf8                    |",
+        "| system       | table_versions | table_name       | Utf8                    |",
+        "| system       | table_versions | table_version_id | Int64                   |",
+        "| system       | table_versions | creation_time    | Timestamp(Second, None) |",
+        "+--------------+----------------+------------------+-------------------------+",
+    ];
 
     assert_batches_eq!(expected, &results);
 }
@@ -665,15 +689,16 @@ async fn test_create_table_drop_schema() {
     let results = list_tables_query(&context).await;
 
     let expected = vec![
-        "+--------------------+--------------+",
-        "| table_schema       | table_name   |",
-        "+--------------------+--------------+",
-        "| information_schema | columns      |",
-        "| information_schema | tables       |",
-        "| information_schema | views        |",
-        "| new_schema         | test_table_2 |",
-        "| public             | test_table_1 |",
-        "+--------------------+--------------+",
+        "+--------------------+----------------+",
+        "| table_schema       | table_name     |",
+        "+--------------------+----------------+",
+        "| information_schema | columns        |",
+        "| information_schema | tables         |",
+        "| information_schema | views          |",
+        "| new_schema         | test_table_2   |",
+        "| public             | test_table_1   |",
+        "| system             | table_versions |",
+        "+--------------------+----------------+",
     ];
     assert_batches_eq!(expected, &results);
 
@@ -686,14 +711,15 @@ async fn test_create_table_drop_schema() {
     let results = list_tables_query(&context).await;
 
     let expected = vec![
-        "+--------------------+--------------+",
-        "| table_schema       | table_name   |",
-        "+--------------------+--------------+",
-        "| information_schema | columns      |",
-        "| information_schema | tables       |",
-        "| information_schema | views        |",
-        "| new_schema         | test_table_2 |",
-        "+--------------------+--------------+",
+        "+--------------------+----------------+",
+        "| table_schema       | table_name     |",
+        "+--------------------+----------------+",
+        "| information_schema | columns        |",
+        "| information_schema | tables         |",
+        "| information_schema | views          |",
+        "| new_schema         | test_table_2   |",
+        "| system             | table_versions |",
+        "+--------------------+----------------+",
     ];
     assert_batches_eq!(expected, &results);
 
@@ -706,13 +732,14 @@ async fn test_create_table_drop_schema() {
     let results = list_tables_query(&context).await;
 
     let expected = vec![
-        "+--------------------+------------+",
-        "| table_schema       | table_name |",
-        "+--------------------+------------+",
-        "| information_schema | columns    |",
-        "| information_schema | tables     |",
-        "| information_schema | views      |",
-        "+--------------------+------------+",
+        "+--------------------+----------------+",
+        "| table_schema       | table_name     |",
+        "+--------------------+----------------+",
+        "| information_schema | columns        |",
+        "| information_schema | tables         |",
+        "| information_schema | views          |",
+        "| system             | table_versions |",
+        "+--------------------+----------------+",
     ];
     assert_batches_eq!(expected, &results);
 
@@ -735,14 +762,15 @@ async fn test_create_table_drop_schema() {
     let results = list_tables_query(&context).await;
 
     let expected = vec![
-        "+--------------------+--------------+",
-        "| table_schema       | table_name   |",
-        "+--------------------+--------------+",
-        "| information_schema | columns      |",
-        "| information_schema | tables       |",
-        "| information_schema | views        |",
-        "| public             | test_table_1 |",
-        "+--------------------+--------------+",
+        "+--------------------+----------------+",
+        "| table_schema       | table_name     |",
+        "+--------------------+----------------+",
+        "| information_schema | columns        |",
+        "| information_schema | tables         |",
+        "| information_schema | views          |",
+        "| public             | test_table_1   |",
+        "| system             | table_versions |",
+        "+--------------------+----------------+",
     ];
     assert_batches_eq!(expected, &results);
 }
@@ -1025,14 +1053,15 @@ async fn test_create_external_table_http() {
     let results = list_tables_query(&context).await;
 
     let expected = vec![
-        "+--------------------+------------+",
-        "| table_schema       | table_name |",
-        "+--------------------+------------+",
-        "| information_schema | columns    |",
-        "| information_schema | tables     |",
-        "| information_schema | views      |",
-        "| staging            | file       |",
-        "+--------------------+------------+",
+        "+--------------------+----------------+",
+        "| table_schema       | table_name     |",
+        "+--------------------+----------------+",
+        "| information_schema | columns        |",
+        "| information_schema | tables         |",
+        "| information_schema | views          |",
+        "| staging            | file           |",
+        "| system             | table_versions |",
+        "+--------------------+----------------+",
     ];
     assert_batches_eq!(expected, &results);
 
@@ -1832,29 +1861,56 @@ async fn test_table_time_travel() {
     let results = list_tables_query(&context).await;
 
     let expected = vec![
-        "+--------------------+------------+",
-        "| table_schema       | table_name |",
-        "+--------------------+------------+",
-        "| information_schema | columns    |",
-        "| information_schema | tables     |",
-        "| information_schema | views      |",
-        "| public             | test_table |",
-        "+--------------------+------------+",
+        "+--------------------+----------------+",
+        "| table_schema       | table_name     |",
+        "+--------------------+----------------+",
+        "| information_schema | columns        |",
+        "| information_schema | tables         |",
+        "| information_schema | views          |",
+        "| public             | test_table     |",
+        "| system             | table_versions |",
+        "+--------------------+----------------+",
     ];
     assert_batches_eq!(expected, &results);
 
     let results = list_columns_query(&context).await;
 
     let expected = vec![
-        "+--------------+------------+------------------+-----------------------------+",
-        "| table_schema | table_name | column_name      | data_type                   |",
-        "+--------------+------------+------------------+-----------------------------+",
-        "| public       | test_table | some_bool_value  | Boolean                     |",
-        "| public       | test_table | some_int_value   | Int64                       |",
-        "| public       | test_table | some_other_value | Decimal128(38, 10)          |",
-        "| public       | test_table | some_time        | Timestamp(Nanosecond, None) |",
-        "| public       | test_table | some_value       | Float32                     |",
-        "+--------------+------------+------------------+-----------------------------+",
+        "+--------------+----------------+------------------+-----------------------------+",
+        "| table_schema | table_name     | column_name      | data_type                   |",
+        "+--------------+----------------+------------------+-----------------------------+",
+        "| system       | table_versions | table_schema     | Utf8                        |",
+        "| system       | table_versions | table_name       | Utf8                        |",
+        "| system       | table_versions | table_version_id | Int64                       |",
+        "| system       | table_versions | creation_time    | Timestamp(Second, None)     |",
+        "| public       | test_table     | some_bool_value  | Boolean                     |",
+        "| public       | test_table     | some_int_value   | Int64                       |",
+        "| public       | test_table     | some_other_value | Decimal128(38, 10)          |",
+        "| public       | test_table     | some_time        | Timestamp(Nanosecond, None) |",
+        "| public       | test_table     | some_value       | Float32                     |",
+        "+--------------+----------------+------------------+-----------------------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    //
+    // Verify that the new table versions are shown in the corresponding system table
+    //
+    let plan = context
+        .plan_query("SELECT table_schema, table_name, table_version_id FROM system.table_versions")
+        .await
+        .unwrap();
+    let results = context.collect(plan).await.unwrap();
+
+    let expected = vec![
+        "+--------------+------------+------------------+",
+        "| table_schema | table_name | table_version_id |",
+        "+--------------+------------+------------------+",
+        "| public       | test_table | 1                |",
+        "| public       | test_table | 2                |",
+        "| public       | test_table | 3                |",
+        "| public       | test_table | 4                |",
+        "| public       | test_table | 5                |",
+        "+--------------+------------+------------------+",
     ];
     assert_batches_eq!(expected, &results);
 }


### PR DESCRIPTION
Implement a new systems schema, allowing for adding custom view-like tables that will query our metadata store and provide relevant insight to the users. The first example introduced here is `table_versions` table, which can be used to browse the available table versions and their creation timestamps.