### PR TITLE
Fix `VACUUM PARTITIONS` with multiple tables (same contents)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +195,15 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "assert_unordered"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74323b7881323eb351134e08ee5331594826789557afef8e309baf481b2264"
+dependencies = [
+ "ansi_term",
 ]
 
 [[package]]
@@ -3381,6 +3399,7 @@ dependencies = [
  "anyhow",
  "arrow",
  "arrow-integration-test",
+ "assert_unordered",
  "async-trait",
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "784f10
 
 
 [dev-dependencies]
+assert_unordered = "0.3"
 mockall = "0.11.1"
 test-case = "*"
 wiremock = "0.5"

--- a/ci/clippy.sh
+++ b/ci/clippy.sh
@@ -6,5 +6,5 @@
 #
 # https://users.rust-lang.org/t/pre-commit-clippy-fix/66584
 
-cargo clippy --all-targets --workspace --fix --allow-dirty --allow-staged
+cargo clippy --all-targets --workspace --fix --allow-dirty --allow-staged --allow-no-vcs
 cargo clippy --all-targets --workspace -- -D warnings

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -311,8 +311,7 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
             }) => {
                 // Defensive assertion to make sure that DataFusion gave us back the correct number
                 // of expressions.
-                let expected_len =
-                    assignments.len() + (if selection.is_some() { 1 } else { 0 });
+                let expected_len = assignments.len() + usize::from(selection.is_some());
                 if exprs.len() != expected_len {
                     // DataFusion doesn't let us give back an Error and this really shouldn't
                     // happen. Other alternatives (like partially initializing the node) might hide

--- a/src/repository/default.rs
+++ b/src/repository/default.rs
@@ -359,8 +359,10 @@ impl Repository for $repo {
         &self,
     ) -> Result<Vec<String>, Error> {
         let object_storage_ids = sqlx::query(
-            "SELECT object_storage_id FROM physical_partition \
-            WHERE id NOT IN (SELECT physical_partition_id FROM table_partition)"
+            "SELECT DISTINCT object_storage_id FROM physical_partition
+                WHERE object_storage_id NOT IN (SELECT object_storage_id FROM physical_partition
+                    WHERE id IN (SELECT physical_partition_id FROM table_partition)
+            )"
         )
             .fetch(&self.executor)
             .map_ok(|row| row.get("object_storage_id"))


### PR DESCRIPTION
Multiple partition IDs can have the same object storage IDs (which can happen if we produced two tables with contents that hash to the same ID). We want to select only those object storage IDs that are not used by any partition that's linked to any table.

For example:

```
physical_partition: (partition_1, object_1), (partition_2, object_1)
table_partition: (id_1, partition_1)
```

Currently, we just select object IDs where partition IDs are not in table_partition. This means we'll mistakenly delete object_1. We need to first build a set of all objects used by at least one partition, then subtract that from the set of all objects.