### PR TITLE
Fix `DELETE` filter plan logic with string filters

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -756,6 +756,11 @@ impl DefaultSeafowlContext {
         )
         .await?;
 
+        debug!(
+            "execute_plan_to_partition completed, metrics: {:?}",
+            physical_plan.metrics()
+        );
+
         // Record partition metadata to the catalog
         self.partition_catalog
             .create_partitions(partitions)
@@ -1555,12 +1560,17 @@ impl SeafowlContext for DefaultSeafowlContext {
                                                 .partition_filter_plan(
                                                     group,
                                                     filter.clone(),
-                                                    &[expr.clone()],
+                                                    &[expr.clone().not()],
                                                     self.internal_object_store
                                                         .inner
                                                         .clone(),
                                                 )
                                                 .await?;
+
+                                            debug!(
+                                                "Prepared delete filter plan: {:?}",
+                                                &filter_plan
+                                            );
 
                                             final_partition_ids.extend(
                                                 self.execute_plan_to_partitions(
@@ -1582,7 +1592,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                                             .partition_filter_plan(
                                                 partitions,
                                                 filter.clone(),
-                                                &[expr.clone()],
+                                                &[expr.clone().not()],
                                                 self.internal_object_store.inner.clone(),
                                             )
                                             .await?;


### PR DESCRIPTION
When processing a `DELETE` statement, we use `WHERE` clause to see which partitions to scan through (vs copy directly to the new table version, since they're definitely unaffected by the `DELETE`). Then, we construct a scan through the remaining partitions that only keeps the rows that would remain after the `DELETE`.

However, we invert the `WHERE` clause only in the filter expression, not the `scan_filters` that go into the Parquet file reader. This means that the Parquet file reader will discard partitions that definitely don't need to be deleted (as opposed to discarding partitions that definitely don't need to be kept).