### PR TITLE
Enable SQLite remote tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 dependencies = [
  "jobserver",
 ]
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "connectorx"
 version = "0.3.1"
-source = "git+https://github.com/splitgraph/connector-x?branch=datafusion-14-arrow-26-upgrade#dc47e1f7682bf41ab24afd88232e5fe8a5cd877c"
+source = "git+https://github.com/sfu-db/connector-x?rev=1c4e578f9d4cf6e963be67f96828b8709bd67022#1c4e578f9d4cf6e963be67f96828b8709bd67022"
 dependencies = [
  "anyhow",
  "arrow",
@@ -766,6 +766,7 @@ dependencies = [
  "native-tls",
  "num-traits",
  "openssl",
+ "owning_ref",
  "postgres",
  "postgres-native-tls",
  "postgres-openssl",
@@ -2470,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3113,6 +3114,15 @@ name = "os_str_bytes"
 version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+
+[[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "parking"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,12 +753,13 @@ dependencies = [
 [[package]]
 name = "connectorx"
 version = "0.3.1"
-source = "git+https://github.com/sfu-db/connector-x?rev=1c4e578f9d4cf6e963be67f96828b8709bd67022#1c4e578f9d4cf6e963be67f96828b8709bd67022"
+source = "git+https://github.com/splitgraph/connector-x?rev=ee8d459e8a7e5f524ce4f3059459a71e2def3a27#ee8d459e8a7e5f524ce4f3059459a71e2def3a27"
 dependencies = [
  "anyhow",
  "arrow",
  "chrono",
  "csv",
+ "fallible-streaming-iterator",
  "fehler",
  "hex",
  "itertools",
@@ -773,12 +774,15 @@ dependencies = [
  "r2d2",
  "r2d2_mysql",
  "r2d2_postgres",
+ "r2d2_sqlite",
  "rayon",
+ "rusqlite",
  "rust_decimal",
  "serde_json",
  "sqlparser 0.11.0",
  "thiserror",
  "url",
+ "urlencoding",
  "uuid 0.8.2",
 ]
 
@@ -1535,6 +1539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +1988,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -3678,6 +3697,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2_sqlite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fdc8e4da70586127893be32b7adf21326a4c6b1aba907611edf467d13ffe895"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+]
+
+[[package]]
 name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3924,6 +3953,22 @@ dependencies = [
  "base64",
  "bitflags",
  "serde",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.7.0",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]
@@ -4500,7 +4545,7 @@ dependencies = [
  "futures-executor",
  "futures-intrusive",
  "futures-util",
- "hashlink",
+ "hashlink 0.8.1",
  "hex",
  "hkdf",
  "hmac",
@@ -5229,6 +5274,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ clap = { version = "3.2.19", features = [ "derive" ] }
 config = "0.13.1"
 
 # Remote query execution for a variety of DBs
-connectorx = { git = "https://github.com/splitgraph/connector-x", branch = "datafusion-14-arrow-26-upgrade", features = [ "dst_arrow", "src_postgres", "src_mysql" ] }
+connectorx = { git = "https://github.com/sfu-db/connector-x", rev = "1c4e578f9d4cf6e963be67f96828b8709bd67022", features = [ "dst_arrow", "src_postgres", "src_mysql" ] }
 
 # PG wire protocol support
 convergence = { git = "https://github.com/splitgraph/convergence", branch = "datafusion-14-upgrade", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ clap = { version = "3.2.19", features = [ "derive" ] }
 config = "0.13.1"
 
 # Remote query execution for a variety of DBs
-connectorx = { git = "https://github.com/sfu-db/connector-x", rev = "1c4e578f9d4cf6e963be67f96828b8709bd67022", features = [ "dst_arrow", "src_postgres", "src_mysql" ] }
+connectorx = { git = "https://github.com/splitgraph/connector-x", rev = "ee8d459e8a7e5f524ce4f3059459a71e2def3a27", features = [ "dst_arrow", "src_postgres", "src_mysql", "src_sqlite" ] }
 
 # PG wire protocol support
 convergence = { git = "https://github.com/splitgraph/convergence", branch = "datafusion-14-upgrade", optional = true }
@@ -72,7 +72,7 @@ serde = "1.0.138"
 serde_json = "1.0.81"
 sha2 = ">=0.10.1"
 sqlparser = "0.26.0"
-sqlx = { version = "0.6.2", features = [ "runtime-tokio-rustls", "sqlite" ] }
+sqlx = { version = "0.6.2", features = [ "runtime-tokio-rustls", "sqlite", "any" ] }
 strum = ">=0.24"
 strum_macros = ">=0.24"
 tempfile = "3"

--- a/tests/statements/ddl.rs
+++ b/tests/statements/ddl.rs
@@ -2,7 +2,7 @@ use crate::statements::*;
 
 #[tokio::test]
 async fn test_create_table() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     let plan = context
         .plan_query(
@@ -37,7 +37,7 @@ async fn test_create_table() {
 
 #[tokio::test]
 async fn test_create_table_as() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
     create_table_and_insert(&context, "test_table").await;
 
     let plan = context
@@ -78,7 +78,7 @@ async fn test_create_table_as() {
 async fn test_create_table_move_and_drop() {
     // Create two tables, insert some data into them
 
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     for table_name in ["test_table_1", "test_table_2"] {
         create_table_and_insert(&context, table_name).await;
@@ -219,7 +219,7 @@ async fn test_create_table_move_and_drop() {
 
 #[tokio::test]
 async fn test_create_table_drop_schema() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     for table_name in ["test_table_1", "test_table_2"] {
         create_table_and_insert(&context, table_name).await;
@@ -337,7 +337,7 @@ async fn test_create_table_drop_schema() {
 
 #[tokio::test]
 async fn test_create_table_schema_already_exists() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     context
         .collect(
@@ -369,7 +369,7 @@ async fn test_create_table_schema_already_exists() {
 
 #[tokio::test]
 async fn test_create_table_in_staging_schema() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
     context
         .collect(
             context
@@ -420,7 +420,7 @@ async fn test_create_external_table_http() {
         &mock_server.uri()
     );
 
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     // Try creating a table in a non-staging schema
     let err = context

--- a/tests/statements/dml.rs
+++ b/tests/statements/dml.rs
@@ -2,7 +2,7 @@ use crate::statements::*;
 
 #[tokio::test]
 async fn test_insert_two_different_schemas() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
     create_table_and_insert(&context, "test_table").await;
 
     let plan = context
@@ -39,7 +39,7 @@ async fn test_insert_two_different_schemas() {
 
 #[tokio::test]
 async fn test_table_partitioning_and_rechunking() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     // Make table versions 1 and 2
     create_table_and_insert(&context, "test_table").await;
@@ -164,7 +164,7 @@ async fn test_table_partitioning_and_rechunking() {
 
 #[tokio::test]
 async fn test_delete_statement() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     create_table_and_some_partitions(&context, "test_table", None).await;
 
@@ -369,7 +369,7 @@ async fn test_delete_statement() {
 
 #[tokio::test]
 async fn test_delete_with_string_filter_exact_match() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     context
         .collect(
@@ -452,7 +452,7 @@ async fn test_delete_with_string_filter_exact_match() {
 
 #[tokio::test]
 async fn test_update_statement() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     create_table_and_some_partitions(&context, "test_table", None).await;
 
@@ -577,7 +577,7 @@ async fn test_update_statement() {
 
 #[tokio::test]
 async fn test_update_statement_errors() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     // Creates table with table_versions 1 (empty) and 2
     create_table_and_insert(&context, "test_table").await;

--- a/tests/statements/function.rs
+++ b/tests/statements/function.rs
@@ -2,7 +2,7 @@ use crate::statements::*;
 
 #[tokio::test]
 async fn test_create_and_run_function() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     let function_query = r#"CREATE FUNCTION sintau AS '
     {
@@ -55,7 +55,7 @@ async fn test_create_and_run_function() {
 
 #[tokio::test]
 async fn test_create_and_run_function_legacy_type_names() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     let function_query = r#"CREATE FUNCTION sintau AS '
     {
@@ -108,7 +108,7 @@ async fn test_create_and_run_function_legacy_type_names() {
 
 #[tokio::test]
 async fn test_create_and_run_function_uppercase_type_names() {
-    let (context, _) = make_context_with_pg().await;
+    let context = make_context_with_pg().await;
 
     let function_query = r#"CREATE FUNCTION sintau AS '
     {

--- a/tests/statements/vacuum.rs
+++ b/tests/statements/vacuum.rs
@@ -2,7 +2,7 @@ use crate::statements::*;
 
 #[tokio::test]
 async fn test_vacuum_command() {
-    let context = Arc::new(make_context_with_pg().await.0);
+    let context = Arc::new(make_context_with_pg().await);
 
     let get_object_metas = || async {
         context
@@ -122,7 +122,7 @@ async fn test_vacuum_command() {
 
 #[tokio::test]
 async fn test_vacuum_with_reused_file() {
-    let context = Arc::new(make_context_with_pg().await.0);
+    let context = Arc::new(make_context_with_pg().await);
 
     // Creates table_1 (empty v1, v2) and table_2 (empty v3, v4)
     // V2 and V4 point to a single identical partition


### PR DESCRIPTION
Use custom connector-x version with bumped rusqlite that allows for using the sqlite source aligned with our sqlx crate version.

Use the [AnyPool](https://github.com/launchbadge/sqlx/blob/054f61980a13716844bc9f90bf135b887a5a0fdb/src/lib.rs#L47) abstraction for seeding the remote DB in the tests.