### PR TITLE
Fix remote table projection bug

### DIFF
--- a/src/remote_tables.rs
+++ b/src/remote_tables.rs
@@ -137,7 +137,7 @@ impl TableProvider for RemoteTable {
         let mut plan: Arc<dyn ExecutionPlan> = Arc::new(MemoryExec::try_new(
             &[data],
             Arc::new(src_schema.clone()),
-            projection.clone(),
+            None,
         )?);
 
         if src_schema != schema {

--- a/tests/statements/query.rs
+++ b/tests/statements/query.rs
@@ -464,18 +464,20 @@ async fn test_remote_table_querying(db_type: &str, introspect_schema: bool) {
 
     // Test that projection and filtering work
     let plan = context
-        .plan_query("SELECT \"date field\", b, c FROM staging.remote_table WHERE a > 3 OR c = 'two'")
+        .plan_query(
+            "SELECT \"date field\", c FROM staging.remote_table WHERE a > 3 OR c = 'two'",
+        )
         .await
         .unwrap();
     let results = context.collect(plan).await.unwrap();
 
     let expected = vec![
-        "+------------+--------+------+",
-        "| date field | b      | c    |",
-        "+------------+--------+------+",
-        "| 2022-11-02 | 2.22   | two  |",
-        "| 2022-11-04 | 4.4444 | four |",
-        "+------------+--------+------+",
+        "+------------+------+",
+        "| date field | c    |",
+        "+------------+------+",
+        "| 2022-11-02 | two  |",
+        "| 2022-11-04 | four |",
+        "+------------+------+",
     ];
     assert_batches_eq!(expected, &results);
 


### PR DESCRIPTION
Given that we already apply to supplied projection when fetching remote table data there's no need to set it in the MemoryExec plan as well, otherwise we try to project from the projected schema, which usually end with out of bounds indices

```bash
$ curl -H "Content-Type: application/json" localhost:8080/q -d'{"query": "SELECT * FROM staging.table_1"}'
{"a":1,"b":1.1,"c":"one","date field":"2022-11-01","e":"2022-11-01"}
{"a":2,"b":2.22,"c":"two","date field":"2022-11-02","e":"2022-11-02"}
$ curl -H "Content-Type: application/json" localhost:8080/q -d'{"query": "SELECT \"date field\", b FROM staging.table_1 WHERE a > 1"}'
Arrow error: Schema error: project index 3 out of bounds, max field 3
```