### PR TITLE
Pushdown LIMIT when querying remote tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       # selecting a toolchain either by action or manual `rustup` calls should happen
       # before the plugin, as the cache uses the current rustc version as its cache key
-      - run: rustup toolchain install nightly --profile minimal
+      - run: rustup toolchain install nightly-2022-11-15 --profile minimal
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -65,8 +65,8 @@ jobs:
       # Setup the rest of the toolchain
       - name: Setup toolchain
         run: |
-          rustup toolchain install nightly
-          rustup default nightly
+          rustup toolchain install nightly-2022-11-15
+          rustup default nightly-2022-11-15
           rustup component add rustfmt clippy
 
       - name: Check pre-commit hooks (formatting and Clippy)

--- a/tests/statements/query.rs
+++ b/tests/statements/query.rs
@@ -502,19 +502,19 @@ async fn test_remote_table_querying(db_type: &str, introspect_schema: bool) {
     // Test that projection and filtering work
     let plan = context
         .plan_query(
-            "SELECT \"date field\", c FROM staging.remote_table WHERE a > 3 OR c = 'two'",
+            "SELECT \"date field\", c FROM staging.remote_table WHERE a > 2 OR c = 'two' LIMIT 2",
         )
         .await
         .unwrap();
     let results = context.collect(plan).await.unwrap();
 
     let expected = vec![
-        "+------------+------+",
-        "| date field | c    |",
-        "+------------+------+",
-        "| 2022-11-02 | two  |",
-        "| 2022-11-04 | four |",
-        "+------------+------+",
+        "+------------+-------+",
+        "| date field | c     |",
+        "+------------+-------+",
+        "| 2022-11-02 | two   |",
+        "| 2022-11-03 | three |",
+        "+------------+-------+",
     ];
     assert_batches_eq!(expected, &results);
 


### PR DESCRIPTION
Siply add the LIMIT clause to the remote query if present