### PR TITLE
Implement remote table factory

### DIFF
--- a/datafusion_remote_tables/src/factory.rs
+++ b/datafusion_remote_tables/src/factory.rs
@@ -1,0 +1,36 @@
+use crate::provider::RemoteTable;
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use datafusion::datasource::datasource::TableProviderFactory;
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::SessionState;
+use datafusion_expr::CreateExternalTable;
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// Factory for creating remote tables
+pub struct RemoteTableFactory {}
+
+#[async_trait]
+impl TableProviderFactory for RemoteTableFactory {
+    async fn create(
+        &self,
+        _ctx: &SessionState,
+        cmd: &CreateExternalTable,
+    ) -> Result<Arc<dyn TableProvider>> {
+        let table = RemoteTable::new(
+            cmd.options
+                .get("name")
+                .ok_or(DataFusionError::Execution(
+                    "Missing 'name' option".to_string(),
+                ))?
+                .clone(),
+            cmd.location.clone(),
+            SchemaRef::from(cmd.schema.deref().clone()),
+        )
+        .await?;
+
+        Ok(Arc::new(table))
+    }
+}

--- a/datafusion_remote_tables/src/lib.rs
+++ b/datafusion_remote_tables/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod factory;
 pub mod filter_pushdown;
 pub mod provider;

--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -347,11 +347,7 @@ impl<'a> DFParser<'a> {
             false => ',',
         };
 
-        let file_compression_type = if file_type == *"TABLE" {
-            // Parse the remote table name, and smuggle it through the compression field of the
-            // CreateExternalTable struct
-            self.parser.parse_literal_string()?
-        } else if self.parse_has_file_compression_type() {
+        let file_compression_type = if self.parse_has_file_compression_type() {
             self.parse_file_compression_type()?
         } else {
             "".to_string()

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -23,23 +23,6 @@ pub struct CreateTable {
 }
 
 #[derive(Debug, Clone)]
-pub struct CreateRemoteTable {
-    /// The table schema
-    pub schema: DFSchemaRef,
-    /// The table name
-    pub name: String,
-    /// Remote table name
-    pub remote_name: String,
-    /// Option to not error if table already exists
-    pub if_not_exists: bool,
-    /// Database connection string
-    pub conn: String,
-
-    /// Dummy result schema for the plan (empty)
-    pub output_schema: DFSchemaRef,
-}
-
-#[derive(Debug, Clone)]
 pub struct Insert {
     /// The table to insert into
     pub table: Arc<SeafowlTable>,
@@ -116,7 +99,6 @@ pub struct Vacuum {
 #[derive(Debug, Clone)]
 pub enum SeafowlExtensionNode {
     CreateTable(CreateTable),
-    CreateRemoteTable(CreateRemoteTable),
     Insert(Insert),
     Update(Update),
     Delete(Delete),
@@ -198,10 +180,6 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
             SeafowlExtensionNode::CreateTable(CreateTable { output_schema, .. }) => {
                 output_schema
             }
-            SeafowlExtensionNode::CreateRemoteTable(CreateRemoteTable {
-                output_schema,
-                ..
-            }) => output_schema,
             SeafowlExtensionNode::Update(Update { output_schema, .. }) => output_schema,
             SeafowlExtensionNode::Delete(Delete { output_schema, .. }) => output_schema,
             SeafowlExtensionNode::CreateFunction(CreateFunction {
@@ -248,11 +226,6 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
             }
             SeafowlExtensionNode::CreateTable(CreateTable { name, .. }) => {
                 write!(f, "Create: {name}")
-            }
-            SeafowlExtensionNode::CreateRemoteTable(CreateRemoteTable {
-                name, ..
-            }) => {
-                write!(f, "Create remote: {name}")
             }
             SeafowlExtensionNode::Update(Update {
                 table,

--- a/tests/statements/query.rs
+++ b/tests/statements/query.rs
@@ -445,7 +445,8 @@ async fn test_remote_table_querying(
         .plan_query(
             format!(
                 "CREATE EXTERNAL TABLE remote_table {table_column_schema}
-                STORED AS TABLE '{table_name}'
+                STORED AS TABLE
+                OPTIONS ('name' '{table_name}')
                 LOCATION '{dsn}'"
             )
             .as_str(),
@@ -580,7 +581,8 @@ async fn test_remote_table_querying(
             "|               |     TableScan: staging.remote_table projection=[c, date field], full_filters=[staging.remote_table.date field > Date32(\"19297\") OR staging.remote_table.c = Utf8(\"two\"), staging.remote_table.a > Int32(2) OR staging.remote_table.e < TimestampNanosecond(1667599865000000000, None)], fetch=2 |",
             "| physical_plan | ProjectionExec: expr=[date field@1 as date field, c@0 as c]                                                                                                                                                                                                                                     |",
             "|               |   GlobalLimitExec: skip=0, fetch=2                                                                                                                                                                                                                                                              |",
-            "|               |     MemoryExec: partitions=1, partition_sizes=[1]                                                                                                                                                                                                                                               |",
+            "|               |     ProjectionExec: expr=[c@0 as c, date field@1 as date field]                                                                                                                                                                                                                                 |",
+            "|               |       MemoryExec: partitions=1, partition_sizes=[1]                                                                                                                                                                                                                                             |",
             "|               |                                                                                                                                                                                                                                                                                                 |",
             "+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
         ]


### PR DESCRIPTION
This employs DataFusion's new external table creation logic, so that conditional on registering the remote table factory during runtime, anyone can use the plain `CREATE EXTERNAL TABLE` statement without having to rely on custom/parsing hacks (such as smuggling the table name via the `file_compression_type` field that we used to do).