### PR TITLE
Add region config option for Amazon S3 store

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -112,9 +112,10 @@ pub struct InMemory {}
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct S3 {
+    pub region: Option<String>,
     pub access_key_id: String,
     pub secret_access_key: String,
-    pub endpoint: String,
+    pub endpoint: Option<String>,
     pub bucket: String,
 }
 
@@ -421,9 +422,10 @@ upload_data_max_length = 1
         assert_eq!(
             config.object_store,
             ObjectStore::S3(S3 {
+                region: None,
                 access_key_id: "AKI...".to_string(),
                 secret_access_key: "ABC...".to_string(),
-                endpoint: "https://s3.amazonaws.com:9000".to_string(),
+                endpoint: Some("https://s3.amazonaws.com:9000".to_string()),
                 bucket: "seafowl".to_string()
             })
         );

--- a/src/object_store/cache.rs
+++ b/src/object_store/cache.rs
@@ -448,7 +448,6 @@ mod tests {
 
         let paths = fs::read_dir(basedir)
             .unwrap()
-            .into_iter()
             .map(|e| e.unwrap().file_name().into_string().unwrap())
             .sorted()
             .collect_vec();


### PR DESCRIPTION
`AmazonS3Builder` does not infer region properly from the endpoint URL, so we need to add a specific `region` field to the config. Both `region` and `endpoint` are now optional parameters (but at least one needs to be supplied).

The previous functionality is obtained by omitting the `region` param (usefull for targeting e.g. minio). Otherwise, if pointing directly to AWS S3, only `region` is sufficient since the endpoint is inferred automatically.

Closes #253 