### PR TITLE
Minimal fix for unquote bug for DataFusion 15.0

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -35,7 +35,8 @@ use mockall::automock;
 use object_store::{path::Path, ObjectStore};
 
 use sqlparser::ast::{
-    AlterTableOperation, ObjectType, Statement, TableFactor, TableWithJoins,
+    AlterTableOperation, Ident, ObjectName, ObjectType, SchemaName, Statement,
+    TableFactor, TableWithJoins,
 };
 
 use arrow_integration_test::field_to_json;
@@ -125,6 +126,39 @@ pub fn internal_object_store_url() -> ObjectStoreUrl {
 
 fn quote_ident(val: &str) -> String {
     val.replace('"', "\"\"")
+}
+
+pub fn remove_quotes_from_string(possibly_quoted_name: &str) -> String {
+    possibly_quoted_name.trim_matches('"').to_string()
+}
+
+pub fn remove_quotes_from_ident(possibly_quoted_name: &Ident) -> Ident {
+    Ident::new(remove_quotes_from_string(&possibly_quoted_name.value))
+}
+
+pub fn remove_quotes_from_idents(column_names: &[Ident]) -> Vec<Ident> {
+    column_names.iter().map(remove_quotes_from_ident).collect()
+}
+
+pub fn remove_quotes_from_object_name(name: &ObjectName) -> ObjectName {
+    ObjectName(remove_quotes_from_idents(&name.0))
+}
+
+pub fn remove_quotes_from_schema_name(name: &SchemaName) -> SchemaName {
+    match name {
+        SchemaName::Simple(schema_name) => {
+            SchemaName::Simple(remove_quotes_from_object_name(schema_name))
+        }
+        SchemaName::UnnamedAuthorization(auth) => {
+            SchemaName::UnnamedAuthorization(remove_quotes_from_ident(auth))
+        }
+        SchemaName::NamedAuthorization(schema_name, auth) => {
+            SchemaName::NamedAuthorization(
+                remove_quotes_from_object_name(schema_name),
+                remove_quotes_from_ident(auth),
+            )
+        }
+    }
 }
 
 fn reference_to_name(reference: &ResolvedTableReference) -> String {
@@ -968,7 +1002,12 @@ impl SeafowlContext for DefaultSeafowlContext {
 
                     query_planner.sql_statement_to_plan(Statement::Query(q))
                 },
-
+                Statement::CreateSchema { schema_name, if_not_exists } => query_planner.sql_statement_to_plan(
+                    Statement::CreateSchema {
+                        schema_name: remove_quotes_from_schema_name(&schema_name),
+                        if_not_exists
+                    }
+                ),
                 // Delegate generic queries to the basic DataFusion logical planner
                 // (though note EXPLAIN [our custom query] will mean we have to implement EXPLAIN ourselves)
                 Statement::Explain { .. }
@@ -976,7 +1015,6 @@ impl SeafowlContext for DefaultSeafowlContext {
                 | Statement::ShowTables { .. }
                 | Statement::ShowColumns { .. }
                 | Statement::CreateView { .. }
-                | Statement::CreateSchema { .. }
                 | Statement::CreateDatabase { .. }
                 | Statement::Drop { object_type: ObjectType::Table, .. } => query_planner.sql_statement_to_plan(*s),
 
@@ -1012,7 +1050,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                     Ok(LogicalPlan::Extension(Extension {
                         node: Arc::new(SeafowlExtensionNode::CreateTable(CreateTable {
                             schema: cols.to_dfschema_ref()?,
-                            name: name.to_string(),
+                            name: remove_quotes_from_object_name(&name).to_string(),
                             if_not_exists,
                             output_schema: Arc::new(DFSchema::empty())
                         })),
@@ -1021,19 +1059,20 @@ impl SeafowlContext for DefaultSeafowlContext {
 
                 // ALTER TABLE ... RENAME TO
                 Statement::AlterTable { name, operation: AlterTableOperation::RenameTable {table_name: new_name }} => {
-                    let table_name = name.to_string();
-                    let table = self.try_get_seafowl_table(table_name)?;
+                    let old_table_name = remove_quotes_from_object_name(&name).to_string();
+                    let new_table_name = remove_quotes_from_object_name(&new_name).to_string();
+                    let table = self.try_get_seafowl_table(old_table_name)?;
 
-                    if self.get_table_provider(new_name.to_string()).is_ok() {
+                    if self.get_table_provider(new_table_name.to_owned()).is_ok() {
                         return Err(Error::Plan(
-                            format!("Target table {:?} already exists", new_name.to_string())
+                            format!("Target table {new_table_name:?} already exists")
                         ))
                     }
 
                     Ok(LogicalPlan::Extension(Extension {
                         node: Arc::new(SeafowlExtensionNode::RenameTable(RenameTable {
                             table: Arc::from(table),
-                            new_name: new_name.to_string(),
+                            new_name: new_table_name,
                             output_schema: Arc::new(DFSchema::empty())
                         })),
                     }))
@@ -2410,6 +2449,33 @@ mod tests {
         assert_batches_eq!(expected, &results);
 
         Ok(())
+    }
+
+    async fn get_logical_plan(query: &str) -> String {
+        let sf_context = mock_context().await;
+
+        let plan = sf_context.create_logical_plan(query).await.unwrap();
+        format!("{plan:?}")
+    }
+
+    #[tokio::test]
+    async fn test_plan_create_schema_name_in_quotes() {
+        assert_eq!(
+            get_logical_plan("CREATE SCHEMA schema_name;").await,
+            "CreateCatalogSchema: \"schema_name\""
+        );
+        assert_eq!(
+            get_logical_plan("CREATE SCHEMA \"schema_name\";").await,
+            "CreateCatalogSchema: \"schema_name\""
+        );
+    }
+
+    #[tokio::test]
+    async fn test_plan_rename_table_name_in_quotes() {
+        assert_eq!(
+            get_logical_plan("ALTER TABLE \"testcol\".\"some_table\" RENAME TO \"testcol\".\"some_table_2\"").await,
+            "RenameTable: some_table to testcol.some_table_2"
+        );
     }
 
     #[tokio::test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -128,12 +128,8 @@ fn quote_ident(val: &str) -> String {
     val.replace('"', "\"\"")
 }
 
-pub fn remove_quotes_from_string(possibly_quoted_name: &str) -> String {
-    possibly_quoted_name.trim_matches('"').to_string()
-}
-
 pub fn remove_quotes_from_ident(possibly_quoted_name: &Ident) -> Ident {
-    Ident::new(remove_quotes_from_string(&possibly_quoted_name.value))
+    Ident::new(&possibly_quoted_name.value)
 }
 
 pub fn remove_quotes_from_idents(column_names: &[Ident]) -> Vec<Ident> {
@@ -149,14 +145,8 @@ pub fn remove_quotes_from_schema_name(name: &SchemaName) -> SchemaName {
         SchemaName::Simple(schema_name) => {
             SchemaName::Simple(remove_quotes_from_object_name(schema_name))
         }
-        SchemaName::UnnamedAuthorization(auth) => {
-            SchemaName::UnnamedAuthorization(remove_quotes_from_ident(auth))
-        }
-        SchemaName::NamedAuthorization(schema_name, auth) => {
-            SchemaName::NamedAuthorization(
-                remove_quotes_from_object_name(schema_name),
-                remove_quotes_from_ident(auth),
-            )
+        SchemaName::UnnamedAuthorization(_) | SchemaName::NamedAuthorization(_, _) => {
+            name.to_owned()
         }
     }
 }

--- a/src/wasm_udf/data_types.rs
+++ b/src/wasm_udf/data_types.rs
@@ -62,27 +62,21 @@ pub enum CreateFunctionDataType {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, EnumString, Display, Clone)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum CreateFunctionVolatility {
     Immutable,
     Stable,
+    #[default]
     Volatile,
-}
-impl Default for CreateFunctionVolatility {
-    fn default() -> Self {
-        CreateFunctionVolatility::Volatile
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, EnumString, Display, Clone)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum CreateFunctionLanguage {
+    #[default]
     Wasm,
     WasmMessagePack,
-}
-impl Default for CreateFunctionLanguage {
-    fn default() -> Self {
-        CreateFunctionLanguage::Wasm
-    }
 }
 
 fn parse_create_function_data_type(


### PR DESCRIPTION
There's a [nasty bug](https://github.com/apache/arrow-datafusion/blob/3cc607de4ce6e9e1fd537091e471858c62f58653/datafusion/sql/src/statement.rs#L167) in `datafusion-sql` which results in quoted collection and column names being parsed incorrectly (with the `"` character being considered part of the name).

During Splitgraph to Seafowl sync, the following SQL statements are run:
```sql
CREATE EXTERNAL TABLE tmp_hvlfgdshkjhnkbhy STORED AS PARQUET LOCATION 'https://storage.googleapis.com/jruw973mdb/p.parquet';
CREATE TABLE tmp_hvlfgdshkjhnkbhy AS SELECT * FROM staging.tmp_hvlfgdshkjhnkbhy;
CREATE SCHEMA "neumarktest/seafowlsync";
ALTER TABLE tmp_hvlfgdshkjhnkbhy RENAME TO "neumarktest/seafowlsync"."table1";
```

This MR requires to absolute minimum required to enable the query above to run.
Independetly, I will submit a fix to the datafusion table, hopefully included in DF 16+, which will fix the quoting issues when we upgrade rendering this code obsolete.