### PR TITLE
Move ssl_cert_file option into seafowl config

### DIFF
--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -152,7 +152,7 @@ pub async fn build_context(
     );
 
     // Register the HTTP object store for external tables
-    add_http_object_store(&context);
+    add_http_object_store(&context, &cfg.misc.ssl_cert_file);
 
     let (tables, partitions, functions) = build_catalog(cfg).await;
 
@@ -228,6 +228,7 @@ mod tests {
             misc: schema::Misc {
                 max_partition_size: 1024 * 1024,
                 gc_interval: 0,
+                ssl_cert_file: None,
             },
         };
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -268,6 +268,7 @@ pub struct Misc {
     pub max_partition_size: u32,
     // Perhaps make this accept a cron job format and use tokio-cron-scheduler?
     pub gc_interval: u16,
+    pub ssl_cert_file: Option<String>,
 }
 
 impl Default for Misc {
@@ -275,6 +276,7 @@ impl Default for Misc {
         Self {
             max_partition_size: 1024 * 1024,
             gc_interval: 0,
+            ssl_cert_file: None,
         }
     }
 }
@@ -486,6 +488,7 @@ upload_data_max_length = 1
                 misc: Misc {
                     max_partition_size: 1024 * 1024,
                     gc_interval: 0,
+                    ssl_cert_file: None
                 },
             }
         )
@@ -578,6 +581,7 @@ upload_data_max_length = 1
                 misc: Misc {
                     max_partition_size: 1024 * 1024,
                     gc_interval: 0,
+                    ssl_cert_file: None
                 },
             }
         )

--- a/src/context.rs
+++ b/src/context.rs
@@ -1933,7 +1933,7 @@ pub mod test_utils {
         );
 
         // Register the HTTP object store for external tables
-        add_http_object_store(&context);
+        add_http_object_store(&context, &None);
 
         context
     }

--- a/src/object_store/cache.rs
+++ b/src/object_store/cache.rs
@@ -394,7 +394,7 @@ mod tests {
         let path = tmp_dir.into_path();
 
         CachingObjectStore::new(
-            Arc::new(HttpObjectStore::new("http".to_string())),
+            Arc::new(HttpObjectStore::new("http".to_string(), &None)),
             &path,
             16,
             512,
@@ -406,7 +406,7 @@ mod tests {
         let path = tmp_dir.into_path();
 
         CachingObjectStore::new(
-            Arc::new(HttpObjectStore::new("http".to_string())),
+            Arc::new(HttpObjectStore::new("http".to_string(), &None)),
             &path,
             16,
             4 * 16, // Max capacity 4 chunks


### PR DESCRIPTION
To set a custom root CA for TLS, use eg:
```bash
SEAFOWL__MISC__SSL_CERT_FILE=rootCA.pem ./target/debug/seafowl -c seafowl.toml
```

or in `seafowl.toml` add:
```toml
[misc]
ssl_cert_file="rootCA.pem"
```