### PR TITLE
Use native DML planning nodes for processing write statements 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "16.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "16.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
 dependencies = [
  "arrow",
  "chrono",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "16.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "16.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "16.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "16.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
 dependencies = [
  "arrow",
  "chrono",
@@ -1827,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "16.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "16.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
 dependencies = [
  "arrow-schema",
  "datafusion-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix-df16#b51b9768e4a920d6b2609350a7feed4ee21520f9"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix-df16#b51b9768e4a920d6b2609350a7feed4ee21520f9"
 dependencies = [
  "arrow",
  "chrono",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix-df16#b51b9768e4a920d6b2609350a7feed4ee21520f9"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix-df16#b51b9768e4a920d6b2609350a7feed4ee21520f9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix-df16#b51b9768e4a920d6b2609350a7feed4ee21520f9"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix-df16#b51b9768e4a920d6b2609350a7feed4ee21520f9"
 dependencies = [
  "arrow",
  "chrono",
@@ -1827,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix-df16#b51b9768e4a920d6b2609350a7feed4ee21520f9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix#095e3f80ae80a6b1f5c00da6faf32398d1c3e6d3"
+source = "git+https://github.com/splitgraph/arrow-datafusion?branch=insert-target-columns-empty-fix-df16#b51b9768e4a920d6b2609350a7feed4ee21520f9"
 dependencies = [
  "arrow-schema",
  "datafusion-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=planner-from-session-state#0ffe4037ca7620bab98bb8bc8eb37df2f3c81cf1"
+source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=planner-from-session-state#0ffe4037ca7620bab98bb8bc8eb37df2f3c81cf1"
+source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
 dependencies = [
  "arrow",
  "chrono",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=planner-from-session-state#0ffe4037ca7620bab98bb8bc8eb37df2f3c81cf1"
+source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=planner-from-session-state#0ffe4037ca7620bab98bb8bc8eb37df2f3c81cf1"
+source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=planner-from-session-state#0ffe4037ca7620bab98bb8bc8eb37df2f3c81cf1"
+source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
 dependencies = [
  "ahash 0.8.1",
  "arrow",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=planner-from-session-state#0ffe4037ca7620bab98bb8bc8eb37df2f3c81cf1"
+source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
 dependencies = [
  "arrow",
  "chrono",
@@ -1827,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=planner-from-session-state#0ffe4037ca7620bab98bb8bc8eb37df2f3c81cf1"
+source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "16.0.0"
-source = "git+https://github.com/splitgraph/arrow-datafusion?branch=planner-from-session-state#0ffe4037ca7620bab98bb8bc8eb37df2f3c81cf1"
+source = "git+https://github.com/apache/arrow-datafusion?rev=e6a050058bd704f73b38106b7abf21dc4539eebc#e6a050058bd704f73b38106b7abf21dc4539eebc"
 dependencies = [
  "arrow-schema",
  "datafusion-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,10 +96,10 @@ wasmtime = "1.0.1"
 wasmtime-wasi = "1.0.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "planner-from-session-state" }
-datafusion-common = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "planner-from-session-state" }
-datafusion-expr = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "planner-from-session-state" }
-datafusion-proto = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "planner-from-session-state" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "e6a050058bd704f73b38106b7abf21dc4539eebc" }
+datafusion-common = { git = "https://github.com/apache/arrow-datafusion", rev = "e6a050058bd704f73b38106b7abf21dc4539eebc" }
+datafusion-expr = { git = "https://github.com/apache/arrow-datafusion", rev = "e6a050058bd704f73b38106b7abf21dc4539eebc" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "e6a050058bd704f73b38106b7abf21dc4539eebc" }
 
 [dev-dependencies]
 assert_unordered = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,10 +96,10 @@ wasmtime = "1.0.1"
 wasmtime-wasi = "1.0.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "e6a050058bd704f73b38106b7abf21dc4539eebc" }
-datafusion-common = { git = "https://github.com/apache/arrow-datafusion", rev = "e6a050058bd704f73b38106b7abf21dc4539eebc" }
-datafusion-expr = { git = "https://github.com/apache/arrow-datafusion", rev = "e6a050058bd704f73b38106b7abf21dc4539eebc" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "e6a050058bd704f73b38106b7abf21dc4539eebc" }
+datafusion = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix" }
+datafusion-common = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix" }
+datafusion-expr = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix" }
+datafusion-proto = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix" }
 
 [dev-dependencies]
 assert_unordered = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,10 +96,10 @@ wasmtime = "1.0.1"
 wasmtime-wasi = "1.0.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix" }
-datafusion-common = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix" }
-datafusion-expr = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix" }
-datafusion-proto = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix" }
+datafusion = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix-df16" }
+datafusion-common = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix-df16" }
+datafusion-expr = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix-df16" }
+datafusion-proto = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "insert-target-columns-empty-fix-df16" }
 
 [dev-dependencies]
 assert_unordered = "0.3"

--- a/src/context.rs
+++ b/src/context.rs
@@ -24,7 +24,7 @@ use datafusion::execution::DiskManager;
 use datafusion_proto::protobuf;
 
 use crate::datafusion::parser::{DFParser, Statement as DFStatement};
-use crate::datafusion::utils::{build_schema, normalize_ident};
+use crate::datafusion::utils::build_schema;
 use crate::object_store::http::try_prepare_http_url;
 use crate::object_store::wrapped::InternalObjectStore;
 use crate::utils::{gc_partitions, group_partitions, hash_file};
@@ -46,7 +46,7 @@ use std::iter::zip;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use datafusion::common::{DFField, DFSchema, ToDFSchema};
+use datafusion::common::{DFSchema, ToDFSchema};
 use datafusion::datasource::file_format::avro::AvroFormat;
 use datafusion::datasource::file_format::csv::CsvFormat;
 use datafusion::datasource::file_format::file_type::{FileCompressionType, FileType};
@@ -83,7 +83,7 @@ use datafusion_expr::logical_plan::{
     CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateMemoryTable,
     DropTable, Extension, LogicalPlan, Projection,
 };
-use datafusion_expr::{cast, DmlStatement, Expr, Filter, WriteOp};
+use datafusion_expr::{DmlStatement, Filter, WriteOp};
 use log::{debug, info, warn};
 use prost::Message;
 use tempfile::TempPath;
@@ -101,8 +101,8 @@ use crate::{
     catalog::{FunctionCatalog, TableCatalog},
     data_types::DatabaseId,
     nodes::{
-        CreateFunction, CreateTable, DropSchema, Insert, RenameTable,
-        SeafowlExtensionNode, Vacuum,
+        CreateFunction, CreateTable, DropSchema, RenameTable, SeafowlExtensionNode,
+        Vacuum,
     },
     schema::Schema as SeafowlSchema,
     version::TableVersionProcessor,
@@ -1050,7 +1050,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                 | Statement::ShowColumns { .. }
                 | Statement::CreateView { .. }
                 | Statement::CreateDatabase { .. } => state.statement_to_plan(statement).await,
-                Statement::Delete{ .. } => {
+                Statement::Insert{ .. } => {
                     let plan = state.statement_to_plan(statement).await?;
                     state.optimize(&plan)
                 }
@@ -1063,7 +1063,8 @@ impl SeafowlContext for DefaultSeafowlContext {
                     let plan = state.statement_to_plan(statement).await?;
 
                     // Create a custom optimizer to avoid mangling effects of some optimizers (like
-                    // `CommonSubexprEliminate`) which
+                    // `CommonSubexprEliminate`) which can add nested Projection plans and rewrite
+                    // expressions
                     let optimizer = Optimizer::with_rules(
                         vec![
                             Arc::new(TypeCoercion::new()),
@@ -1080,6 +1081,10 @@ impl SeafowlContext for DefaultSeafowlContext {
                     }
                     )
                 },
+                Statement::Delete{ .. } => {
+                    let plan = state.statement_to_plan(statement).await?;
+                    state.optimize(&plan)
+                }
                 Statement::Drop { object_type: ObjectType::Table,
                     if_exists,
                     names,
@@ -1158,71 +1163,6 @@ impl SeafowlContext for DefaultSeafowlContext {
                 // a CreateMemoryTable node. We're fine with that, but we'll execute it differently.
                 Statement::CreateTable { .. } => state.statement_to_plan(statement).await,
 
-                // This DML is defined by us
-                Statement::Insert {
-                    table_name,
-                    columns,
-                    source,
-                    ..
-                } => {
-                    let table_name = table_name.to_string();
-
-                    let seafowl_table = self.try_get_seafowl_table(table_name).await?;
-
-                    // Get a list of columns we're inserting into and schema we
-                    // have to cast `source` into
-                    // INSERT INTO table (col_3, col_4) VALUES (1, 2)
-                    let table_schema = seafowl_table.schema.arrow_schema.clone().to_dfschema()?;
-
-                    let target_schema = if columns.is_empty() {
-                        // Empty means we're inserting into all columns of the table
-                        seafowl_table.schema.arrow_schema.clone().to_dfschema()?
-                    } else {
-                        let fields = columns.iter().map(|c|
-                            Ok(table_schema.field_with_unqualified_name(&normalize_ident(c))?.clone())).collect::<Result<Vec<DFField>>>()?;
-                        DFSchema::new_with_metadata(fields, table_schema.metadata().clone())?
-                    };
-
-                    let plan = state.statement_to_plan(DFStatement::Statement(Box::from(Statement::Query(source)))).await?;
-
-                    // Check the length
-                    if plan.schema().fields().len() != target_schema.fields().len() {
-                        return Err(Error::Plan(
-                            format!("Unexpected number of columns in VALUES: expected {:?}, got {:?}", target_schema.fields().len(), plan.schema().fields().len())
-                        ))
-                    }
-
-                    // Check we can cast from the values in the INSERT to the actual table schema
-                    target_schema.check_arrow_schema_type_compatible(&((**plan.schema()).clone().into()))?;
-
-                    // Make a projection around the input plan to rename the columns / change the schema
-                    // (it doesn't seem to actually do casts at runtime, but ArrowWriter should forcefully
-                    // cast the columns when we're writing to Parquet)
-
-                    let expr = target_schema.fields().iter().zip(plan.schema().fields()).map(|(table_field, query_field)| {
-                        // Generate CAST (source_col AS table_col_type) AS table_col
-                        // If the type is the same, this will be optimized out.
-                        cast(
-                            Expr::Column(query_field.qualified_column()),
-                            table_field.data_type().clone()
-                        ).alias(table_field.name())
-                    }).collect();
-                    let plan = LogicalPlan::Projection(Projection::try_new_with_schema(
-                        expr,
-                        Arc::new(plan),
-                        Arc::new(target_schema),
-                    )?);
-
-                    Ok(LogicalPlan::Extension(Extension {
-                        node: Arc::new(SeafowlExtensionNode::Insert(Insert {
-                            // TODO we might not need the whole table (we're currently cloning it in
-                            // try_get_seafowl_table)
-                            table: Arc::new(seafowl_table),
-                            input: Arc::new(plan),
-                            output_schema: Arc::new(DFSchema::empty())
-                        })),
-                    }))
-                }
                 Statement::CreateFunction {
                     temporary: false,
                     name,
@@ -1269,7 +1209,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                     "Unsupported SQL statement: {s:?}"
                 ))),
             },
-            DFStatement::DescribeTable(_) | DFStatement::CreateExternalTable(_) => {
+            DFStatement::DescribeTableStmt(_) | DFStatement::CreateExternalTable(_) => {
                 state.statement_to_plan(statement).await
             }
         }
@@ -1370,6 +1310,142 @@ impl SeafowlContext for DefaultSeafowlContext {
                 let physical = self.create_physical_plan(input).await?;
 
                 self.execute_plan_to_table(&physical, None, Some(name.to_string()), None)
+                    .await?;
+
+                Ok(make_dummy_exec())
+            }
+            LogicalPlan::Dml(DmlStatement {
+                table_name,
+                op: WriteOp::Insert,
+                input,
+                ..
+            }) => {
+                let table = self.try_get_seafowl_table(table_name.to_string()).await?;
+
+                let physical = self.create_physical_plan(input).await?;
+
+                self.execute_plan_to_table(
+                    &physical,
+                    None,
+                    None,
+                    Some(table.table_version_id),
+                )
+                .await?;
+
+                Ok(make_dummy_exec())
+            }
+            LogicalPlan::Dml(DmlStatement {
+                table_name,
+                op: WriteOp::Update,
+                input,
+                ..
+            }) => {
+                let table = self.try_get_seafowl_table(table_name.to_string()).await?;
+
+                // Destructure input into projection expressions and the upstream scan/filter plan
+                let LogicalPlan::Projection(Projection { expr, input, .. }) = &**input
+                    else { return Err(DataFusionError::Plan("Update plan doesn't contain a Projection node".to_string())) };
+
+                // Load all pre-existing partitions
+                let partitions = self
+                    .partition_catalog
+                    .load_table_partitions(table.table_version_id)
+                    .await?;
+
+                // By default (e.g. when there is no qualifier/selection, or we somehow
+                // fail to prune partitions) update all partitions
+                let mut partitions_to_update = HashSet::<PhysicalPartitionId>::from_iter(
+                    partitions.iter().map(|p| p.partition_id.unwrap()),
+                );
+
+                let schema = table.schema().as_ref().clone();
+                let df_schema =
+                    DFSchema::try_from_qualified_schema(&table.name, &schema)?;
+                let mut selection_expr = None;
+
+                // Try to scope down partition ids which need to be updated with pruning
+                if let LogicalPlan::Filter(Filter { predicate, .. }) = &**input {
+                    selection_expr = Some(create_physical_expr(
+                        &predicate.clone(),
+                        &schema.clone().to_dfschema()?,
+                        &schema,
+                        &ExecutionProps::new(),
+                    )?);
+
+                    match SeafowlPruningStatistics::from_partitions(
+                        partitions.clone(),
+                        table.schema(),
+                    ) {
+                        Ok(pruning_stats) => {
+                            partitions_to_update = HashSet::from_iter(
+                                pruning_stats
+                                    .prune(& [predicate.clone()])
+                                    .await
+                                    .iter()
+                                    .map( | p| p.partition_id.unwrap()),
+                            );
+                        }
+                        Err(error) => warn ! (
+                            "Failed constructing pruning statistics for table {} (version: {}) during UPDATE execution: {}",
+                            table.name, table.table_version_id, error
+                            )
+                    }
+                }
+
+                let mut final_partition_ids = Vec::with_capacity(partitions.len());
+
+                let mut update_plan: Arc<dyn ExecutionPlan>;
+                let projections =
+                    project_expressions(expr, &df_schema, &schema, selection_expr)?;
+
+                // Iterate over partitions, updating the ones affected by the selection,
+                // while re-using the rest
+                for (keep, group) in
+                    group_partitions(partitions, |p: &SeafowlPartition| {
+                        !partitions_to_update.contains(&p.partition_id.unwrap())
+                    })
+                {
+                    if keep {
+                        // Inherit the partition(s) as is from the previous
+                        // table version
+                        final_partition_ids
+                            .extend(group.iter().map(|p| p.partition_id.unwrap()));
+                        continue;
+                    }
+
+                    let scan_plan = table
+                        .partition_scan_plan(
+                            None,
+                            group,
+                            &[],
+                            None,
+                            self.internal_object_store.inner.clone(),
+                        )
+                        .await?;
+
+                    update_plan = Arc::new(ProjectionExec::try_new(
+                        projections.clone(),
+                        scan_plan,
+                    )?);
+
+                    final_partition_ids.extend(
+                        self.execute_plan_to_partitions(
+                            &update_plan,
+                            Some(table.schema()),
+                        )
+                        .await?,
+                    );
+                }
+
+                // Create a new blank table version
+                let new_table_version_id = self
+                    .table_catalog
+                    .create_new_table_version(table.table_version_id, false)
+                    .await?;
+
+                // Link the new table version with the corresponding partitions
+                self.partition_catalog
+                    .append_partitions_to_table(final_partition_ids, new_table_version_id)
                     .await?;
 
                 Ok(make_dummy_exec())
@@ -1492,122 +1568,6 @@ impl SeafowlContext for DefaultSeafowlContext {
 
                 Ok(make_dummy_exec())
             }
-            LogicalPlan::Dml(DmlStatement {
-                table_name,
-                op: WriteOp::Update,
-                input,
-                ..
-            }) => {
-                let table = self.try_get_seafowl_table(table_name.to_string()).await?;
-
-                // Destructure input into projection expressions and the upstream scan/filter plan
-                let LogicalPlan::Projection(Projection { expr, input, .. }) = &**input
-                    else { return Err(DataFusionError::Plan("Update plan doesn't contain a Projection node".to_string())) };
-
-                // Load all pre-existing partitions
-                let partitions = self
-                    .partition_catalog
-                    .load_table_partitions(table.table_version_id)
-                    .await?;
-
-                // By default (e.g. when there is no qualifier/selection, or we somehow
-                // fail to prune partitions) update all partitions
-                let mut partitions_to_update = HashSet::<PhysicalPartitionId>::from_iter(
-                    partitions.iter().map(|p| p.partition_id.unwrap()),
-                );
-
-                let schema = table.schema().as_ref().clone();
-                let df_schema =
-                    DFSchema::try_from_qualified_schema(&table.name, &schema)?;
-                let mut selection_expr = None;
-
-                // Try to scope down partition ids which need to be updated with pruning
-                if let LogicalPlan::Filter(Filter { predicate, .. }) = &**input {
-                    selection_expr = Some(create_physical_expr(
-                        &predicate.clone(),
-                        &schema.clone().to_dfschema()?,
-                        &schema,
-                        &ExecutionProps::new(),
-                    )?);
-
-                    match SeafowlPruningStatistics::from_partitions(
-                        partitions.clone(),
-                        table.schema(),
-                    ) {
-                        Ok(pruning_stats) => {
-                            partitions_to_update = HashSet::from_iter(
-                                pruning_stats
-                                    .prune(& [predicate.clone()])
-                                    .await
-                                    .iter()
-                                    .map( | p| p.partition_id.unwrap()),
-                            );
-                        }
-                        Err(error) => warn ! (
-                            "Failed constructing pruning statistics for table {} (version: {}) during UPDATE execution: {}",
-                            table.name, table.table_version_id, error
-                            )
-                    }
-                }
-
-                let mut final_partition_ids = Vec::with_capacity(partitions.len());
-
-                let mut update_plan: Arc<dyn ExecutionPlan>;
-                let projections =
-                    project_expressions(expr, &df_schema, &schema, selection_expr)?;
-
-                // Iterate over partitions, updating the ones affected by the selection,
-                // while re-using the rest
-                for (keep, group) in
-                    group_partitions(partitions, |p: &SeafowlPartition| {
-                        !partitions_to_update.contains(&p.partition_id.unwrap())
-                    })
-                {
-                    if keep {
-                        // Inherit the partition(s) as is from the previous
-                        // table version
-                        final_partition_ids
-                            .extend(group.iter().map(|p| p.partition_id.unwrap()));
-                        continue;
-                    }
-
-                    let scan_plan = table
-                        .partition_scan_plan(
-                            None,
-                            group,
-                            &[],
-                            None,
-                            self.internal_object_store.inner.clone(),
-                        )
-                        .await?;
-
-                    update_plan = Arc::new(ProjectionExec::try_new(
-                        projections.clone(),
-                        scan_plan,
-                    )?);
-
-                    final_partition_ids.extend(
-                        self.execute_plan_to_partitions(
-                            &update_plan,
-                            Some(table.schema()),
-                        )
-                        .await?,
-                    );
-                }
-
-                // Create a new blank table version
-                let new_table_version_id = self
-                    .table_catalog
-                    .create_new_table_version(table.table_version_id, false)
-                    .await?;
-
-                // Link the new table version with the corresponding partitions
-                self.partition_catalog
-                    .append_partitions_to_table(final_partition_ids, new_table_version_id)
-                    .await?;
-
-                Ok(make_dummy_exec())
-            }
             LogicalPlan::DropTable(DropTable {
                 name,
                 if_exists: _,
@@ -1633,19 +1593,6 @@ impl SeafowlContext for DefaultSeafowlContext {
                             ..
                         }) => {
                             self.exec_create_table(name, schema).await?;
-
-                            Ok(make_dummy_exec())
-                        }
-                        SeafowlExtensionNode::Insert(Insert { table, input, .. }) => {
-                            let physical = self.create_physical_plan(input).await?;
-
-                            self.execute_plan_to_table(
-                                &physical,
-                                None,
-                                None,
-                                Some(table.table_version_id),
-                            )
-                            .await?;
 
                             Ok(make_dummy_exec())
                         }
@@ -1826,7 +1773,7 @@ pub mod test_utils {
     use crate::{
         catalog::{
             MockFunctionCatalog, MockPartitionCatalog, MockTableCatalog, TableCatalog,
-            DEFAULT_DB, DEFAULT_SCHEMA,
+            DEFAULT_SCHEMA,
         },
         object_store::http::add_http_object_store,
         provider::{SeafowlCollection, SeafowlDatabase},
@@ -1852,7 +1799,7 @@ pub mod test_utils {
     pub fn make_session() -> SessionContext {
         let session_config = SessionConfig::new()
             .with_information_schema(true)
-            .with_default_catalog_and_schema(DEFAULT_DB, DEFAULT_SCHEMA);
+            .with_default_catalog_and_schema("testdb", DEFAULT_SCHEMA);
 
         let context = SessionContext::with_config(session_config);
         let object_store = Arc::new(InMemory::new());
@@ -2297,7 +2244,7 @@ mod tests {
 
         assert_eq!(
             format!("{plan:?}"),
-            "Insert: some_table\
+            "Dml: op=[Insert] table=[testcol.some_table]\
             \n  Projection: CAST(column1 AS Date64) AS date, CAST(column2 AS Float64) AS value\
             \n    Values: (Utf8(\"2022-01-01T12:00:00\"), Int64(42))"
         );
@@ -2308,7 +2255,6 @@ mod tests {
         let sf_context = mock_context().await;
 
         let plan = sf_context
-            // TODO: we need to do FROM testdb since it's not set as a default?
             .create_logical_plan(
                 "INSERT INTO testcol.some_table (date, value)
                 SELECT \"date\" AS my_date, \"value\" AS my_value FROM testdb.testcol.some_table",
@@ -2316,10 +2262,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(format!("{plan:?}"), "Insert: some_table\
-        \n  Projection: CAST(my_date AS Date64) AS date, CAST(my_value AS Float64) AS value\
+        assert_eq!(format!("{plan:?}"), "Dml: op=[Insert] table=[testcol.some_table]\
+        \n  Projection: my_date AS date, my_value AS value\
         \n    Projection: testdb.testcol.some_table.date AS my_date, testdb.testcol.some_table.value AS my_value\
-        \n      TableScan: testdb.testcol.some_table");
+        \n      TableScan: testdb.testcol.some_table projection=[date, value]");
     }
 
     #[tokio::test]
@@ -2474,7 +2420,7 @@ mod tests {
 
         assert_eq!(
             format!("{plan:?}"),
-            "Insert: some_table\
+            "Dml: op=[Insert] table=[testcol.some_table]\
             \n  Projection: CAST(column1 AS Date64) AS date, CAST(column2 AS Float64) AS value\
             \n    Values: (Utf8(\"2022-01-01T12:00:00\"), Int64(42))"
         );
@@ -2490,7 +2436,7 @@ mod tests {
         let err = sf_context
             .create_logical_plan("INSERT INTO testcol.some_table SELECT '2022-01-01', to_timestamp('2022-01-01T12:00:00')")
             .await.unwrap_err();
-        assert_eq!(err.to_string(), "Error during planning: Column totimestamp(Utf8(\"2022-01-01T12:00:00\")) (type: Timestamp(Nanosecond, None)) is not compatible with column value (type: Float64)");
+        assert_eq!(err.to_string(), "Error during planning: Cannot automatically convert Timestamp(Nanosecond, None) to Float64");
     }
 
     #[tokio::test]
@@ -2505,7 +2451,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "Error during planning: Unexpected number of columns in VALUES: expected 2, got 1"
+            "Error during planning: Column count doesn't match insert query!"
         );
     }
 

--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -26,7 +26,7 @@
 //! Declares a SQL parser based on sqlparser that handles custom formats that we need.
 
 pub use datafusion::sql::parser::Statement;
-use datafusion::sql::parser::{CreateExternalTable, DescribeTable};
+use datafusion::sql::parser::{CreateExternalTable, DescribeTableStmt};
 use datafusion_common::parsers::CompressionTypeVariant;
 use sqlparser::ast::{CreateFunctionBody, ObjectName};
 use sqlparser::tokenizer::{TokenWithLocation, Word};
@@ -181,7 +181,9 @@ impl<'a> DFParser<'a> {
 
     pub fn parse_describe(&mut self) -> Result<Statement, ParserError> {
         let table_name = self.parser.parse_object_name()?;
-        Ok(Statement::DescribeTable(DescribeTable { table_name }))
+        Ok(Statement::DescribeTableStmt(DescribeTableStmt {
+            table_name,
+        }))
     }
 
     pub fn parse_vacuum(&mut self) -> Result<Statement, ParserError> {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,6 +1,4 @@
 use datafusion::common::DFSchemaRef;
-use datafusion::error::DataFusionError;
-use datafusion_expr::expr_rewriter::{ExprRewritable, ExprRewriter, RewriteRecursion};
 
 use std::{any::Any, fmt, sync::Arc, vec};
 
@@ -28,32 +26,6 @@ pub struct Insert {
     pub table: Arc<SeafowlTable>,
     /// Result of a query to insert (with a type-compatible schema that is a subset of the target table)
     pub input: Arc<LogicalPlan>,
-    /// Dummy result schema for the plan (empty)
-    pub output_schema: DFSchemaRef,
-}
-
-#[derive(Debug, Clone)]
-pub struct Update {
-    /// The table to update
-    pub table: Arc<SeafowlTable>,
-    /// WHERE clause
-    pub selection: Option<Expr>,
-    /// Subplan for a table scan without a WHERE clause (used by the query optimizer)
-    pub table_plan: Arc<LogicalPlan>,
-    /// Columns to update
-    pub assignments: Vec<(String, Expr)>,
-    /// Dummy result schema for the plan (empty)
-    pub output_schema: DFSchemaRef,
-}
-
-#[derive(Debug, Clone)]
-pub struct Delete {
-    /// The table to delete from
-    pub table: Arc<SeafowlTable>,
-    /// Subplan for a table scan without a WHERE clause (used by the query optimizer)
-    pub table_plan: Arc<LogicalPlan>,
-    /// WHERE clause
-    pub selection: Option<Expr>,
     /// Dummy result schema for the plan (empty)
     pub output_schema: DFSchemaRef,
 }
@@ -100,8 +72,6 @@ pub struct Vacuum {
 pub enum SeafowlExtensionNode {
     CreateTable(CreateTable),
     Insert(Insert),
-    Update(Update),
-    Delete(Delete),
     CreateFunction(CreateFunction),
     RenameTable(RenameTable),
     DropSchema(DropSchema),
@@ -114,40 +84,6 @@ impl SeafowlExtensionNode {
     }
 }
 
-// Code for removing aliases in DELETE/UPDATE predicates
-// Copied from `datafusion_expr::utils::from_plan` for Filter
-// The query optimizer adds aliases to rewritten expressions in order
-// to make them keep the same names. This is not needed in filters and, in our
-// case, breaks partition pruning, which makes updates/deletes less efficient.
-
-// To fix this, we remove all aliases in all expressions used by UPDATE/DELETE
-struct RemoveAliases {}
-
-impl ExprRewriter for RemoveAliases {
-    fn pre_visit(&mut self, expr: &Expr) -> Result<RewriteRecursion, DataFusionError> {
-        match expr {
-            Expr::Exists { .. } | Expr::ScalarSubquery(_) | Expr::InSubquery { .. } => {
-                // subqueries could contain aliases so we don't recurse into those
-                Ok(RewriteRecursion::Stop)
-            }
-            Expr::Alias(_, _) => Ok(RewriteRecursion::Mutate),
-            _ => Ok(RewriteRecursion::Continue),
-        }
-    }
-
-    fn mutate(&mut self, expr: Expr) -> Result<Expr, DataFusionError> {
-        Ok(expr.unalias())
-    }
-}
-
-fn remove_aliases(predicate: Expr) -> Expr {
-    let mut remove_aliases = RemoveAliases {};
-    // NB we can't propagate errors in our logical nodes' from_template
-    // (unlike vanilla DataFusion's from_plan), so we have to cross our fingers
-    // and panic if something went wrong during the rewrite.
-    predicate.rewrite(&mut remove_aliases).unwrap()
-}
-
 impl UserDefinedLogicalNode for SeafowlExtensionNode {
     fn as_any(&self) -> &dyn Any {
         self
@@ -156,16 +92,6 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
     fn inputs(&self) -> Vec<&LogicalPlan> {
         match self {
             SeafowlExtensionNode::Insert(Insert { input, .. }) => vec![input.as_ref()],
-
-            // For UPDATE/DELETE, the optimizer needs to know the schema of the "input" (in this
-            // case, our tables we're updating) in order to optimize this node's expressions (in our
-            // case, the WHERE ... and the SET col = expr clauses).
-            SeafowlExtensionNode::Update(Update { table_plan, .. }) => {
-                vec![table_plan.as_ref()]
-            }
-            SeafowlExtensionNode::Delete(Delete { table_plan, .. }) => {
-                vec![table_plan.as_ref()]
-            }
             _ => vec![],
         }
     }
@@ -180,8 +106,6 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
             SeafowlExtensionNode::CreateTable(CreateTable { output_schema, .. }) => {
                 output_schema
             }
-            SeafowlExtensionNode::Update(Update { output_schema, .. }) => output_schema,
-            SeafowlExtensionNode::Delete(Delete { output_schema, .. }) => output_schema,
             SeafowlExtensionNode::CreateFunction(CreateFunction {
                 output_schema,
                 ..
@@ -200,23 +124,7 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
         // NB: this is used by the plan optimizer (gets expressions(), optimizes them,
         // calls from_template(optimized_exprs) and we'll need to expose our expressions here
         // and support from_template for a given node if we want them to be optimized.
-        match self {
-            // For UPDATEs, we pack a list of all SET col = expr expressions and append
-            // the WHERE clause expression at the end, if it exists.
-            SeafowlExtensionNode::Update(Update {
-                assignments,
-                selection,
-                ..
-            }) => assignments
-                .iter()
-                .map(|(_, e)| e.clone())
-                .chain(selection.clone().into_iter())
-                .collect::<Vec<Expr>>(),
-            SeafowlExtensionNode::Delete(Delete {
-                selection: Some(e), ..
-            }) => vec![e.clone()],
-            _ => vec![],
-        }
+        vec![]
     }
 
     fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -226,41 +134,6 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
             }
             SeafowlExtensionNode::CreateTable(CreateTable { name, .. }) => {
                 write!(f, "Create: {name}")
-            }
-            SeafowlExtensionNode::Update(Update {
-                table,
-                assignments,
-                selection,
-                ..
-            }) => {
-                write!(
-                    f,
-                    "Update: {}, SET: {}",
-                    table.name,
-                    assignments
-                        .iter()
-                        .map(|(c, e)| format!("{c} = {e}"))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                )?;
-                if let Some(s) = selection {
-                    write!(f, " WHERE {s}")?;
-                }
-                Ok(())
-            }
-            SeafowlExtensionNode::Delete(Delete {
-                table,
-                selection: None,
-                ..
-            }) => {
-                write!(f, "Delete: {}", table.name)
-            }
-            SeafowlExtensionNode::Delete(Delete {
-                table,
-                selection: Some(e),
-                ..
-            }) => {
-                write!(f, "Delete: {} WHERE {}", table.name, e)
             }
             SeafowlExtensionNode::CreateFunction(CreateFunction { name, .. }) => {
                 write!(f, "CreateFunction: {name}")
@@ -285,7 +158,7 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
 
     fn from_template(
         &self,
-        exprs: &[Expr],
+        _exprs: &[Expr],
         inputs: &[LogicalPlan],
     ) -> Arc<dyn UserDefinedLogicalNode> {
         match self {
@@ -300,69 +173,6 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
                     None => input.clone(),
                 },
                 output_schema: output_schema.clone(),
-            })),
-
-            SeafowlExtensionNode::Update(Update {
-                table,
-                selection,
-                table_plan,
-                assignments,
-                output_schema,
-            }) => {
-                // Defensive assertion to make sure that DataFusion gave us back the correct number
-                // of expressions.
-                let expected_len = assignments.len() + usize::from(selection.is_some());
-                if exprs.len() != expected_len {
-                    // DataFusion doesn't let us give back an Error and this really shouldn't
-                    // happen. Other alternatives (like partially initializing the node) might hide
-                    // errors downstream, so panic here instead.
-                    panic!("DataFusion optimizer returned incorrect number of expressions. Expected {}, got {}", expected_len, exprs.len())
-                };
-
-                let exprs: Vec<Expr> =
-                    exprs.iter().map(|e| remove_aliases(e.clone())).collect();
-
-                Arc::new(SeafowlExtensionNode::Update(Update {
-                    // We ignore the optimized "inputs" in this case (it's just a TableScan without
-                    // filters) and keep our old one
-                    table: table.clone(),
-                    table_plan: table_plan.clone(),
-                    output_schema: output_schema.clone(),
-
-                    // Unpack the assignments and the selection expression
-                    assignments: assignments
-                        .iter()
-                        .zip(exprs.iter())
-                        .map(|((col, _), new_expr)| (col.clone(), new_expr.clone()))
-                        .collect(),
-                    // If we have a selection expression in this node, the last entry in the list is
-                    // the optimized expression
-                    selection: if selection.is_none() {
-                        None
-                    } else {
-                        exprs.get(assignments.len()).cloned()
-                    },
-                }))
-            }
-
-            SeafowlExtensionNode::Delete(Delete {
-                table,
-                table_plan,
-                selection,
-                output_schema,
-            }) => Arc::new(SeafowlExtensionNode::Delete(Delete {
-                table: table.clone(),
-                table_plan: table_plan.clone(),
-                output_schema: output_schema.clone(),
-                selection: if selection.is_none() {
-                    None
-                } else {
-                    let e = exprs.first();
-                    if e.is_none() {
-                        panic!("DataFusion optimizer returned incorrect number of expressions. Expected 1, got 0");
-                    }
-                    e.cloned().map(remove_aliases)
-                },
             })),
             _ => Arc::from(self.clone()),
         }

--- a/tests/statements/dml.rs
+++ b/tests/statements/dml.rs
@@ -223,8 +223,10 @@ async fn test_delete_statement() {
         .await
         .unwrap();
     assert_eq!(
-        format!("{}", plan.display()),
-        "Delete: test_table WHERE some_value > Float32(46)"
+        format!("{}", plan.display_indent()),
+        r#"Dml: op=[Delete] table=[test_table]
+  Filter: some_value > Float32(46)
+    TableScan: test_table projection=[some_bool_value, some_int_value, some_other_value, some_time, some_value], partial_filters=[some_value > Float32(46)]"#
     );
 
     //
@@ -530,8 +532,11 @@ async fn test_update_statement() {
 
     let plan = context.create_logical_plan(query).await.unwrap();
     assert_eq!(
-        format!("{}", plan.display()),
-        "Update: test_table, SET: some_time = Utf8(\"2022-01-01 21:21:21Z\"), some_int_value = Int64(5555), some_value = some_value - CAST(Int64(10) AS Float32) WHERE some_value IN ([CAST(Int64(41) AS Float32), CAST(Int64(42) AS Float32), CAST(Int64(43) AS Float32)])"
+        format!("{}", plan.display_indent()),
+        r#"Dml: op=[Update] table=[test_table]
+  Projection: test_table.some_bool_value AS some_bool_value, Int64(5555) AS some_int_value, test_table.some_other_value AS some_other_value, Utf8("2022-01-01 21:21:21Z") AS some_time, test_table.some_value - Float32(10) AS some_value
+    Filter: some_value = Float32(43) OR some_value = Float32(42) OR some_value = Float32(41)
+      TableScan: test_table"#
     );
 
     //
@@ -653,14 +658,15 @@ async fn test_update_statement_errors() {
     // Execute UPDATE that references a nonexistent column in the assignment or in the selection,
     // or results in a type mismatch
     //
-    let err = context
-        .plan_query("UPDATE test_table SET nonexistent = 42 WHERE some_value = 32")
-        .await
-        .unwrap_err();
-
-    assert!(err
-        .to_string()
-        .contains("Schema error: No field named 'nonexistent'"));
+    // TODO: This errors out with "Unsupported CAST from Decimal128(38, 10) to Timestamp(Nanosecond, None)"
+    // let err = context
+    //     .plan_query("UPDATE test_table SET nonexistent = 42 WHERE some_value = 32")
+    //     .await
+    //     .unwrap_err();
+    //
+    // assert!(err
+    //     .to_string()
+    //     .contains("Schema error: No field named 'nonexistent'"));
 
     let err = context
         .plan_query("UPDATE test_table SET some_value = 42 WHERE nonexistent = 32")

--- a/tests/statements/dml.rs
+++ b/tests/statements/dml.rs
@@ -658,15 +658,14 @@ async fn test_update_statement_errors() {
     // Execute UPDATE that references a nonexistent column in the assignment or in the selection,
     // or results in a type mismatch
     //
-    // TODO: This errors out with "Unsupported CAST from Decimal128(38, 10) to Timestamp(Nanosecond, None)"
-    // let err = context
-    //     .plan_query("UPDATE test_table SET nonexistent = 42 WHERE some_value = 32")
-    //     .await
-    //     .unwrap_err();
-    //
-    // assert!(err
-    //     .to_string()
-    //     .contains("Schema error: No field named 'nonexistent'"));
+    let err = context
+        .plan_query("UPDATE test_table SET nonexistent = 42 WHERE some_value = 32")
+        .await
+        .unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("Schema error: No field named 'nonexistent'"));
 
     let err = context
         .plan_query("UPDATE test_table SET some_value = 42 WHERE nonexistent = 32")


### PR DESCRIPTION
Instead of using our custom extension nodes. This has some potential upsides, mostly revolving around leveraging the community development and support around the new `LogicalPlan::Dml` variants.

However, I'm not convinced that this is a proper thing to do right now. For one thing, `LogicalPlan::Dml` makes a specific interpretation for the INSERT, UPDATE and DELETE plans, which is that it simply projects the changed rows (deleted, updated), instead of all the resulting rows which makes natural sense for other plans. Arguably, this is good since the changes to the tables can be arbitrarily small so it makes more sense to only output the changes. Consequently though, we have to extract the effective assignment and selection expressions for our purposes (keeping in mind table versioning and partition inheritance) from the provided logical plans, which is a bit hacky. We also must disable some of the optimizations that would complicate things a lot more (namely common expression elimination).

Alternatively, if we forego the custom partition re-use logic that we currently have (i.e. inheriting unchanged partitions based on partition pruning for the new table versions), we could also potentially simplify our planning logic. We could do this by simply evoking the DF `create_physical_plan` to turn the underlying projection/filter/scan logical plans that are the `input` to `LogicalPlan::Dml` into physical plans (which would end up scanning our table) and then execute those into our new partitions (adding or removing what's needed). In this case we'd minimize the chance of partition re-use, though each write would end up with more nicely balanced partitions (in terms of size).I;m also not sure how migrating our storage to delta-rs at some point fits in with these approaches.