### PR TITLE
Experimental: introduce a basic "did it run" test to the GHA

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,6 +89,17 @@ jobs:
         if: matrix.build == 'linux' || matrix.build == 'macos'
         run: strip "target/release/seafowl"
 
+      - name: Test invoking the binaries
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            ./target/release/seafowl.exe --version
+            test $0 -eq 0 || exit $0
+          else
+            ./target/release/seafowl --version
+            test $0 -eq 0 || exit $0
+          fi
+
       - name: Prepare artifact name
         shell: bash
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,10 +94,10 @@ jobs:
         run: |
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             ./target/release/seafowl.exe --version
-            test $0 -eq 0 || exit $0
+            test $? -eq 0 || exit $?
           else
             ./target/release/seafowl --version
-            test $0 -eq 0 || exit $0
+            test $? -eq 0 || exit $?
           fi
 
       - name: Prepare artifact name

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,11 +93,9 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            ./target/release/seafowl.exe --version
-            test $? -eq 0 || exit $?
+            ./target/release/seafowl.exe --version || exit 1
           else
-            ./target/release/seafowl --version
-            test $? -eq 0 || exit $?
+            ./target/release/seafowl --version || exit 1
           fi
 
       - name: Prepare artifact name


### PR DESCRIPTION
### Goal
Help reduce the risk of building a bad binary

### Method
1. After building the binary we perform a minimally viable invocation (e.g. `seafowl --version`) using each OS in the [matrix](https://github.com/splitgraph/seafowl/commit/fd6ebfdf3d835e1360a9dba770a26ab6acde689a). Serves as a basic smoke test to answer the Q "did it run?"
2. In case of non-zero exit code, pass it into the `exit` call. I've only observed macOS so far, which today returned `134` for the binary with the SSL issue.

### How do we know it works?
Because I don't have a Windows machine immediately available to test on, I can't say for 100% sure. 😓 
My understanding is that because [bash](https://github.com/splitgraph/seafowl/commit/97a0a83e24f8eebf13073c347ac51f384ac351e0) is running across all three OSes, we can at least say the bash script ran because `act -n` on my dev server returned
```
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ☁  git clone 'https://github.com/docker/build-push-action' # ref=v3
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ☁  git clone 'https://github.com/actions/upload-artifact' # ref=v3
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] 🧪  Matrix: map[build:linux os:ubuntu-18.04 target:x86_64-unknown-linux-gnu]
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Install prerequisites
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Install prerequisites
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Checkout the repository
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Checkout the repository
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main rustup toolchain install stable --profile minimal
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main rustup toolchain install stable --profile minimal
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Swatinem/rust-cache@v2
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Swatinem/rust-cache@v2
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Build the release binary
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Build the release binary
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Strip release binary (linux and macos)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Strip release binary (linux and macos)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Test invoking the binaries
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Test invoking the binaries
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Prepare artifact name
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Prepare artifact name
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Login to DockerHub (Linux only)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Login to DockerHub (Linux only)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Determine Docker tags
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Determine Docker tags
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Build and push Docker image (Linux only)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Build and push Docker image (Linux only)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Main Upload binaries as artifacts
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Main Upload binaries as artifacts
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Post Build and push Docker image (Linux only)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Post Build and push Docker image (Linux only)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Post Login to DockerHub (Linux only)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Post Login to DockerHub (Linux only)
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] ⭐ Run Post Swatinem/rust-cache@v2
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1]   ✅  Success - Post Swatinem/rust-cache@v2
*DRYRUN* [Build nightly binaries and perform releases/Build the binaries-1] 🏁  Job succeeded

```
And we see success for the new step, "Test invoking the binaries."

Feedback welcome.