### PR TITLE
Implement multi-DB support in Seafowl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   CI:
     name: Lint, build, test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: amd64/rust
       env:
@@ -69,7 +69,7 @@ jobs:
       - name: Check pre-commit hooks (formatting and Clippy)
         # First command is temp fix for FatalError: git failed. Is it installed, and are you in a Git repository directory?
         run: |
-          git config --system --add safe.directory *
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pre-commit run --all
 
       # NB this one doesn't run as a pre-commit hook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
           rustup component add rustfmt clippy
 
       - name: Check pre-commit hooks (formatting and Clippy)
+        # First command is temp fix for FatalError: git failed. Is it installed, and are you in a Git repository directory?
         run: |
+          git config --system --add safe.directory *
           pre-commit run --all
 
       # NB this one doesn't run as a pre-commit hook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Check pre-commit hooks (formatting and Clippy)
         run: |
+          ls -l
+          which git
           pre-commit run --all
 
       # NB this one doesn't run as a pre-commit hook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   CI:
     name: Lint, build, test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: amd64/rust
       env:
@@ -68,8 +68,6 @@ jobs:
 
       - name: Check pre-commit hooks (formatting and Clippy)
         run: |
-          ls -l
-          which git
           pre-commit run --all
 
       # NB this one doesn't run as a pre-commit hook

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
             os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
           - build: macos
-            os: macos-latest
+            os: macos-11
             target: x86_64-apple-darwin
           - build: win-msvc
             os: windows-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,10 +85,6 @@ jobs:
           export PATH=$PATH:$HOME/d/protoc/bin
           cargo build --release
 
-      - name: Strip release binary (linux and macos)
-        if: matrix.build == 'linux' || matrix.build == 'macos'
-        run: strip "target/release/seafowl"
-
       - name: Test invoking the binaries
         shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,4 @@ vergen = "7"
 [profile.release]
 codegen-units = 1
 lto = true
+strip = true

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -158,6 +158,7 @@ impl From<Error> for DataFusionError {
 #[async_trait]
 pub trait TableCatalog: Sync + Send {
     async fn load_database(&self, id: DatabaseId) -> Result<SeafowlDatabase>;
+    async fn load_database_ids(&self) -> Result<HashMap<String, DatabaseId>>;
     async fn load_tables_by_version(
         &self,
         database_id: DatabaseId,
@@ -414,6 +415,16 @@ impl TableCatalog for DefaultCatalog {
                 Arc::new(self.clone()),
             )),
         })
+    }
+
+    async fn load_database_ids(&self) -> Result<HashMap<String, DatabaseId>> {
+        let all_db_ids = self
+            .repository
+            .get_all_database_ids()
+            .await
+            .map_err(Self::to_sqlx_error)?;
+
+        Ok(HashMap::from_iter(all_db_ids))
     }
 
     async fn load_tables_by_version(

--- a/src/context.rs
+++ b/src/context.rs
@@ -568,6 +568,7 @@ pub trait SeafowlContext: Send + Sync {
 }
 
 impl DefaultSeafowlContext {
+    // Create a new `DefaultSeafowlContext` with a new inner context scoped to a different default DB
     pub fn scope_to_database(&self, name: String) -> Result<Arc<DefaultSeafowlContext>> {
         let database_id =
             self.all_database_ids
@@ -575,7 +576,6 @@ impl DefaultSeafowlContext {
                 .get(name.as_str())
                 .map(|db_id| *db_id as DatabaseId)
                 .ok_or_else(|| {
-                    // TODO: reload DBs from catalog to double-check
                     DataFusionError::Plan(format!(
                         "Unknown database {name}; try creating one with CREATE DATABASE first"
                     ))
@@ -1359,11 +1359,11 @@ impl SeafowlContext for DefaultSeafowlContext {
                     }
                 }
 
-                // Persist DB into catalog
+                // Persist DB into metadata catalog
                 let database_id =
                     self.table_catalog.create_database(catalog_name).await?;
 
-                // Create the corresponding default schema
+                // Create the corresponding default schema as well
                 self.table_catalog
                     .create_collection(database_id, DEFAULT_SCHEMA)
                     .await?;

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -1010,6 +1010,21 @@ mod tests {
         _query_uncached_endpoint(handler, query, path_prefix, Some(token)).await
     }
 
+    #[tokio::test]
+    async fn test_get_uncached_read_nonexistent_db() {
+        let context = in_memory_context_with_single_table(None).await;
+        let handler = filters(context, http_config_from_access_policy(free_for_all()));
+
+        let resp =
+            query_uncached_endpoint(&handler, SELECT_QUERY, Some("missing_db")).await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            resp.body(),
+            "Error during planning: Unknown database missing_db; try creating one with CREATE DATABASE first"
+        );
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_get_uncached_read_query(

--- a/src/frontend/postgres.rs
+++ b/src/frontend/postgres.rs
@@ -11,12 +11,15 @@ use convergence::{
 use convergence_arrow::table::{record_batch_to_rows, schema_to_field_desc};
 use datafusion::{error::DataFusionError, physical_plan::ExecutionPlan};
 
-use crate::{config::schema::PostgresFrontend, context::SeafowlContext};
+use crate::{
+    config::schema::PostgresFrontend,
+    context::{DefaultSeafowlContext, SeafowlContext},
+};
 use sqlparser::ast::Statement;
 
 pub struct SeafowlPortal {
     plan: Arc<dyn ExecutionPlan>,
-    context: Arc<dyn SeafowlContext>,
+    context: Arc<DefaultSeafowlContext>,
 }
 
 fn df_err_to_sql(err: DataFusionError) -> ErrorResponse {
@@ -39,7 +42,7 @@ impl Portal for SeafowlPortal {
 }
 
 struct SeafowlConvergenceEngine {
-    context: Arc<dyn SeafowlContext>,
+    context: Arc<DefaultSeafowlContext>,
 }
 
 #[async_trait]
@@ -75,7 +78,10 @@ impl Engine for SeafowlConvergenceEngine {
     }
 }
 
-pub async fn run_pg_server(context: Arc<dyn SeafowlContext>, config: PostgresFrontend) {
+pub async fn run_pg_server(
+    context: Arc<DefaultSeafowlContext>,
+    config: PostgresFrontend,
+) {
     server::run(
         BindOptions::new()
             .with_addr(&config.bind_host)

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use seafowl::{
         context::build_context,
         schema::{build_default_config, load_config, SeafowlConfig, DEFAULT_DATA_DIR},
     },
-    context::SeafowlContext,
+    context::DefaultSeafowlContext,
     frontend::http::run_server,
     utils::{gc_partitions, run_one_off_command},
 };
@@ -55,7 +55,7 @@ struct Args {
 }
 
 fn prepare_frontends(
-    context: Arc<dyn SeafowlContext>,
+    context: Arc<DefaultSeafowlContext>,
     config: &SeafowlConfig,
     shutdown: &Sender<()>,
 ) -> Vec<Pin<Box<dyn Future<Output = ()> + Send>>> {

--- a/src/repository/default.rs
+++ b/src/repository/default.rs
@@ -207,6 +207,17 @@ impl Repository for $repo {
         Ok(id)
     }
 
+    async fn get_all_database_ids(&self) -> Result<Vec<(String, DatabaseId)>> {
+        let all_db_ids = sqlx::query(r#"SELECT name, id FROM database"#)
+            .fetch_all(&self.executor)
+            .await.map_err($repo::interpret_error)?
+            .iter()
+            .map(|row| (row.get("name"), row.get("id")))
+            .collect();
+
+        Ok(all_db_ids)
+    }
+
     async fn create_collection(
         &self,
         database_id: DatabaseId,

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -109,6 +109,8 @@ pub trait Repository: Send + Sync + Debug {
         database_name: &str,
     ) -> Result<DatabaseId, Error>;
 
+    async fn get_all_database_ids(&self) -> Result<Vec<(String, DatabaseId)>, Error>;
+
     async fn create_database(&self, database_name: &str) -> Result<DatabaseId, Error>;
 
     async fn create_collection(

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -326,6 +326,13 @@ pub mod tests {
         let (database_id, _, table_id, table_version_id) =
             make_database_with_single_table(repository.clone()).await;
 
+        let all_database_ids = repository
+            .get_all_database_ids()
+            .await
+            .expect("Error getting all database ids");
+
+        assert_eq!(all_database_ids, vec![("testdb".to_string(), database_id)]);
+
         // Test loading all columns
 
         let all_columns = repository

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use crate::provider::SeafowlPartition;
 
 // Run a one-off command and output its results to a writer
 pub async fn run_one_off_command<W>(
-    context: Arc<dyn SeafowlContext>,
+    context: Arc<DefaultSeafowlContext>,
     command: &str,
     mut output: W,
 ) where

--- a/tests/http/mod.rs
+++ b/tests/http/mod.rs
@@ -29,7 +29,7 @@ use datafusion::assert_batches_eq;
 use datafusion::from_slice::FromSlice;
 use datafusion::parquet::arrow::ArrowWriter;
 use itertools::Itertools;
-use seafowl::context::SeafowlContext;
+use seafowl::context::{DefaultSeafowlContext, SeafowlContext};
 use std::net::SocketAddr;
 use tempfile::Builder;
 use tokio::sync::oneshot;
@@ -42,7 +42,7 @@ async fn make_read_only_http_server() -> (
     SocketAddr,
     Pin<Box<dyn Future<Output = ()> + Send>>,
     Sender<()>,
-    Arc<dyn SeafowlContext>,
+    Arc<DefaultSeafowlContext>,
 ) {
     let config_text = r#"
 [object_store]


### PR DESCRIPTION
Specifically, add support to scope down the session context to a particular database for a given statement/batch of statements. In other words cross-DB queries are not supported atm.  This is done by extending the existing GET & POST routes to also support the prefixed `/db-name/q[/query-hash]` form, and then effectively switch the default database to the one provided.

Also contains the implementation of `CREATE DATABASE` statement.

The upload endpoint needs to be altered as well, but I plan on doing it in a separate PR.

Closes #288.