### PR TITLE
Enable `VACUUM` for Delta tables

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -193,10 +193,7 @@ pub trait TableCatalog: Sync + Send {
         uuid: Uuid,
     ) -> Result<(TableId, TableVersionId)>;
 
-    async fn delete_old_table_versions(
-        &self,
-        table_id: Option<TableId>,
-    ) -> Result<u64, Error>;
+    async fn delete_old_table_versions(&self, table_id: TableId) -> Result<u64, Error>;
 
     async fn create_new_table_version(
         &self,
@@ -511,10 +508,7 @@ impl TableCatalog for DefaultCatalog {
             })
     }
 
-    async fn delete_old_table_versions(
-        &self,
-        table_id: Option<TableId>,
-    ) -> Result<u64, Error> {
+    async fn delete_old_table_versions(&self, table_id: TableId) -> Result<u64, Error> {
         self.repository
             .delete_old_table_versions(table_id)
             .await

--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -194,8 +194,6 @@ impl<'a> DFParser<'a> {
 
         if self.parser.parse_keyword(Keyword::PARTITIONS) {
             partitions = Some(vec![]);
-        } else if self.parser.parse_keyword(Keyword::TABLES) {
-            // The default case is fine here
         } else if self.parser.parse_keyword(Keyword::TABLE) {
             table_name = self.parser.parse_object_name()?;
         } else if self.parser.parse_keyword(Keyword::DATABASE) {
@@ -203,7 +201,7 @@ impl<'a> DFParser<'a> {
             partitions = Some(vec![Expr::Identifier(database_name)]);
         } else {
             return self.expected(
-                "PARTITIONS, TABLES, TABLE or DATABASE are supported VACUUM targets",
+                "PARTITIONS, TABLE or DATABASE are supported VACUUM targets",
                 self.parser.peek_token(),
             );
         }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -3,10 +3,8 @@ use datafusion::common::DFSchemaRef;
 use arrow_schema::Schema;
 use std::{any::Any, fmt, sync::Arc, vec};
 
-use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNode};
-
-use crate::data_types::TableId;
 use crate::wasm_udf::data_types::CreateFunctionDetails;
+use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNode};
 
 #[derive(Debug, Clone)]
 pub struct CreateTable {
@@ -54,9 +52,8 @@ pub struct Vacuum {
     pub database: Option<String>,
     /// Denotes whether to vacuum the partitions
     pub partitions: bool,
-    /// If the vacuum target are not the partitions, denotes whether it applies to all tables, or a
-    /// specific one
-    pub table_id: Option<TableId>,
+    /// If the vacuum target are not the partitions or the db, denotes which table it applies to
+    pub table_name: Option<String>,
     /// Dummy result schema for the plan (empty)
     pub output_schema: DFSchemaRef,
 }

--- a/src/repository/interface.rs
+++ b/src/repository/interface.rs
@@ -170,10 +170,7 @@ pub trait Repository: Send + Sync + Debug {
         uuid: Uuid,
     ) -> Result<(TableId, TableVersionId), Error>;
 
-    async fn delete_old_table_versions(
-        &self,
-        table_id: Option<TableId>,
-    ) -> Result<u64, Error>;
+    async fn delete_old_table_versions(&self, table_id: TableId) -> Result<u64, Error>;
 
     async fn get_orphan_partition_store_ids(&self) -> Result<Vec<String>, Error>;
 

--- a/tests/statements/mod.rs
+++ b/tests/statements/mod.rs
@@ -7,10 +7,11 @@ use arrow::record_batch::RecordBatch;
 use assert_unordered::assert_eq_unordered_sort;
 use chrono::{TimeZone, Utc};
 use datafusion::assert_batches_eq;
+use datafusion::datasource::TableProvider;
 use datafusion_common::{assert_contains, DataFusionError};
 use deltalake::DeltaDataTypeVersion;
 use futures::TryStreamExt;
-use itertools::{sorted, Itertools};
+use itertools::sorted;
 use object_store::path::Path;
 use seafowl::catalog::{DEFAULT_DB, DEFAULT_SCHEMA};
 #[cfg(feature = "remote-tables")]
@@ -39,10 +40,6 @@ mod query_legacy;
 #[path = "../../src/object_store/testutils.rs"]
 mod testutils;
 mod vacuum;
-
-// Object store IDs for frequently-used test data
-const FILENAME_1: &str =
-    "7fbfeeeade71978b4ae82cd3d97b8c1bd9ae7ab9a7a78ee541b66209cfd7722d.parquet";
 
 enum ObjectStoreType {
     Local,
@@ -285,16 +282,4 @@ async fn assert_orphan_partitions(context: Arc<DefaultSeafowlContext>, parts: Ve
             .collect(),
         parts
     );
-}
-
-async fn get_partition_count(
-    context: Arc<DefaultSeafowlContext>,
-    table_version_id: i32,
-) -> usize {
-    context
-        .partition_catalog
-        .load_table_partitions(table_version_id as TableVersionId)
-        .await
-        .unwrap()
-        .len()
 }

--- a/tests/statements/query_legacy.rs
+++ b/tests/statements/query_legacy.rs
@@ -442,7 +442,7 @@ async fn test_vacuum_legacy_tables() {
     assert_batches_eq!(expected, &results);
 
     context
-        .collect(context.plan_query("VACUUM TABLES").await.unwrap())
+        .collect(context.plan_query("VACUUM TABLE test_table").await.unwrap())
         .await
         .unwrap();
 
@@ -468,7 +468,7 @@ async fn test_vacuum_legacy_tables() {
         .await
         .unwrap();
     context
-        .collect(context.plan_query("VACUUM TABLES").await.unwrap())
+        .collect(context.plan_query("VACUUM TABLE test_table").await.unwrap())
         .await
         .unwrap();
 

--- a/tests/statements/vacuum.rs
+++ b/tests/statements/vacuum.rs
@@ -1,125 +1,178 @@
 use crate::statements::*;
 
-#[ignore = "not yet implemented"]
 #[tokio::test]
-async fn test_vacuum_command() {
+async fn test_vacuum_table() -> Result<(), DataFusionError> {
     let (context, _) = make_context_with_pg(ObjectStoreType::InMemory).await;
-    let context = Arc::new(context);
 
-    let get_object_metas = || async {
-        context
-            .internal_object_store
-            .inner
-            .list(None)
-            .await
-            .unwrap()
-            .try_collect::<Vec<_>>()
-            .await
-            .unwrap()
-    };
-
-    //
-    // Create two tables with multiple versions
-    //
-
-    // Creates table_1 with table_versions 1 (empty) and 2
+    // Create table_1 and make tombstone by replacing the first file
     create_table_and_insert(&context, "table_1").await;
-
-    // Make table_1 with table_version 3
     let plan = context
-        .plan_query("INSERT INTO table_1 (some_value) VALUES (42)")
+        .plan_query("DELETE FROM table_1 WHERE some_value = 42")
         .await
         .unwrap();
     context.collect(plan).await.unwrap();
 
-    // Creates table_2 with table_versions 4 (empty) and 5
+    // Creates table_2 but append a new file instead of replacing the first one
     create_table_and_insert(&context, "table_2").await;
-
-    // Make table_2 with table_version 6
     let plan = context
-        .plan_query("INSERT INTO table_2 (some_value) VALUES (42), (43), (44)")
+        .plan_query("INSERT INTO table_2 (some_int_value) VALUES (4444), (5555), (6666)")
         .await
         .unwrap();
     context.collect(plan).await.unwrap();
 
-    // Run vacuum on table_1 to remove previous versions
+    // Check current table versions
+    let plan = context
+        .plan_query("SELECT table_name, version FROM system.table_versions")
+        .await
+        .unwrap();
+    let results = context.collect(plan).await.unwrap();
+
+    let expected = vec![
+        "+------------+---------+",
+        "| table_name | version |",
+        "+------------+---------+",
+        "| table_1    | 0       |",
+        "| table_1    | 1       |",
+        "| table_1    | 2       |",
+        "| table_2    | 0       |",
+        "| table_2    | 1       |",
+        "| table_2    | 2       |",
+        "+------------+---------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    // Fetch data relevant for the test
+    let table_1_uuid = context.get_table_uuid("table_1").await?;
+    let table_2_uuid = context.get_table_uuid("table_2").await?;
+    let mut table_1 = context.try_get_delta_table("table_1").await?;
+    let mut table_2 = context.try_get_delta_table("table_2").await?;
+
+    table_1.load_version(1).await?;
+    let table_1_v1_file = table_1.get_files()[0].clone();
+    table_1.load_version(2).await?;
+    let table_1_v2_file = table_1.get_files()[0].clone();
+
+    table_2.load().await?;
+    let table_2_v1_file = table_2.get_files()[0].clone();
+    table_2.load_version(2).await?;
+    let table_2_v2_file = table_2.get_files()[1].clone();
+
+    // Check initial directory state
+    testutils::assert_uploaded_objects(
+        context.internal_object_store.for_delta_table(table_1_uuid),
+        vec![
+            Path::from("_delta_log/00000000000000000000.json"),
+            Path::from("_delta_log/00000000000000000001.json"),
+            Path::from("_delta_log/00000000000000000002.json"),
+            table_1_v1_file,
+            table_1_v2_file.clone(),
+        ],
+    )
+    .await;
+
+    // Run vacuum on table_1 to remove tombstoned file
     context
         .collect(context.plan_query("VACUUM TABLE table_1").await.unwrap())
         .await
         .unwrap();
 
-    // TODO: make more explicit the check for deleted table versions
-    for &table_version_id in &[1, 2, 4] {
-        assert_eq!(
-            get_partition_count(context.clone(), table_version_id).await,
-            0
-        );
-    }
-    for &table_version_id in &[3, 5, 6] {
-        assert!(get_partition_count(context.clone(), table_version_id).await > 0);
-    }
-
-    // Run vacuum on all tables; table_2 will now also lose all but the latest version
-    context
-        .collect(context.plan_query("VACUUM TABLES").await.unwrap())
+    // Check table versions again; table_1 now only has latest version
+    let plan = context
+        .plan_query("SELECT table_name, version FROM system.table_versions")
         .await
         .unwrap();
+    let results = context.collect(plan).await.unwrap();
 
-    // Check table versions cleared up from partition counts
-    for &table_version_id in &[1, 2, 4, 5] {
-        assert_eq!(
-            get_partition_count(context.clone(), table_version_id).await,
-            0
-        );
-    }
-    for &table_version_id in &[3, 6] {
-        assert!(get_partition_count(context.clone(), table_version_id).await > 0);
-    }
-
-    // Drop tables to leave orphan partitions around
-    context
-        .collect(context.plan_query("DROP TABLE table_1").await.unwrap())
-        .await
-        .unwrap();
-    context
-        .collect(context.plan_query("DROP TABLE table_2").await.unwrap())
-        .await
-        .unwrap();
-
-    // Check we have orphan partitions
-    // NB: we deduplicate object storage IDs here to avoid running the DELETE call
-    // twice, but we can have two different partition IDs with same object storage ID
-    // See https://github.com/splitgraph/seafowl/issues/5
-    let orphans = vec![
-        FILENAME_1,
-        "d7eaa930f0eba532970d950b74e6c4ff192a30c1d5eb24dcd82e27399ff439ac.parquet",
-        "eab1c5d838c2e025ec9048faf15c1585f6c794a3928b1cc8690eeb3a118980b7.parquet",
+    let expected = vec![
+        "+------------+---------+",
+        "| table_name | version |",
+        "+------------+---------+",
+        "| table_1    | 2       |",
+        "| table_2    | 0       |",
+        "| table_2    | 1       |",
+        "| table_2    | 2       |",
+        "+------------+---------+",
     ];
+    assert_batches_eq!(expected, &results);
 
-    assert_orphan_partitions(context.clone(), orphans.clone()).await;
-    let object_metas = get_object_metas().await;
-    assert_eq!(object_metas.len(), 3);
-    for (ind, &orphan) in orphans
-        .into_iter()
-        .unique()
-        .sorted()
-        .collect::<Vec<&str>>()
-        .iter()
-        .enumerate()
-    {
-        assert_eq!(object_metas[ind].location, Path::from(orphan));
-    }
+    // Check table_1_v1_file is gone as it's been tombstoned's by the `DELETE` command. Note that
+    // no changes have been made to the _delta_log folder
+    testutils::assert_uploaded_objects(
+        context.internal_object_store.for_delta_table(table_1_uuid),
+        vec![
+            Path::from("_delta_log/00000000000000000000.json"),
+            Path::from("_delta_log/00000000000000000001.json"),
+            Path::from("_delta_log/00000000000000000002.json"),
+            table_1_v2_file,
+        ],
+    )
+    .await;
 
-    // Run vacuum on partitions
+    // Likewise, trying to time-travel to table_1 v1 will fail
+    table_1.load_version(1).await?;
+    let plan = table_1
+        .scan(&context.inner.state(), Some(&vec![4_usize]), &[], None)
+        .await?;
+    let err = context.collect(plan).await.unwrap_err();
+    assert!(err.to_string().contains(".parquet not found"));
+
+    // Run vacuum on table_2 as well
     context
-        .collect(context.plan_query("VACUUM PARTITIONS").await.unwrap())
+        .collect(context.plan_query("VACUUM TABLE table_2").await.unwrap())
         .await
         .unwrap();
 
-    // Ensure no orphan partitions are left
-    assert_orphan_partitions(context.clone(), vec![]).await;
-    let object_metas = get_object_metas().await;
-    assert_eq!(object_metas.len(), 0);
+    // Check both table now have only the latest version
+    let plan = context
+        .plan_query("SELECT table_name, version FROM system.table_versions")
+        .await
+        .unwrap();
+    let results = context.collect(plan).await.unwrap();
+
+    let expected = vec![
+        "+------------+---------+",
+        "| table_name | version |",
+        "+------------+---------+",
+        "| table_1    | 2       |",
+        "| table_2    | 2       |",
+        "+------------+---------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    // However, no changes have been made to the actual table_2 storage since `table_2_v1_file` is
+    // referenced by the latest table version.
+    testutils::assert_uploaded_objects(
+        context.internal_object_store.for_delta_table(table_2_uuid),
+        vec![
+            Path::from("_delta_log/00000000000000000000.json"),
+            Path::from("_delta_log/00000000000000000001.json"),
+            Path::from("_delta_log/00000000000000000002.json"),
+            table_2_v1_file,
+            table_2_v2_file,
+        ],
+    )
+    .await;
+
+    // This does mean that the output of `system.table_versions` above is misleading since we can
+    // still retrieve data from v1 of table_2 via time-travel.
+    table_2.load_version(1).await?;
+    let plan = table_2
+        .scan(&context.inner.state(), Some(&vec![4_usize]), &[], None)
+        .await?;
+    let results = context.collect(plan).await.unwrap();
+
+    let expected = vec![
+        "+----------------+",
+        "| some_int_value |",
+        "+----------------+",
+        "| 1111           |",
+        "| 2222           |",
+        "| 3333           |",
+        "+----------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
 }
 
 #[rstest]


### PR DESCRIPTION
There's one caveat with the current implementation, though it's not a deal breaker IMO—when Delta files are deleted there's no API to determine which table versions are valid, so we delete all but the latest one in our catalog. This means there could be versions which are still working and can be queries via time-travel but are not listed in `system.table_versions`.