### PR TITLE
Fix the silent panic in the cache eviction hook rendering it useless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,7 @@ dependencies = [
 [[package]]
 name = "connectorx"
 version = "0.3.2-alpha.2"
-source = "git+https://github.com/splitgraph/connector-x?rev=df8f50b3f53606717407c6677c7c0c2cbcc7f6ce#df8f50b3f53606717407c6677c7c0c2cbcc7f6ce"
+source = "git+https://github.com/splitgraph/connector-x?branch=datafusion-19-upgrade#72e1823bb86e751c8367029001d94faa71e8f702"
 dependencies = [
  "anyhow",
  "arrow",

--- a/datafusion_remote_tables/Cargo.toml
+++ b/datafusion_remote_tables/Cargo.toml
@@ -19,7 +19,7 @@ arrow-schema = "33.0.0"
 async-trait = "0.1.64"
 
 # Remote query execution for a variety of DBs
-connectorx = { git = "https://github.com/splitgraph/connector-x", rev = "df8f50b3f53606717407c6677c7c0c2cbcc7f6ce", features = [ "dst_arrow", "src_postgres", "src_mysql", "src_sqlite" ] }
+connectorx = { git = "https://github.com/splitgraph/connector-x", branch = "datafusion-19-upgrade", features = [ "dst_arrow", "src_postgres", "src_mysql", "src_sqlite" ] }
 
 datafusion = "19.0.0"
 datafusion-expr = "19.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ async fn main() {
         )
         .init();
 
-    info!("Starting Seafowl");
+    info!("Starting Seafowl {}", env!("VERGEN_GIT_SEMVER"));
 
     let config_path = &args.config_path;
 


### PR DESCRIPTION
The tokio runtime handle that is used to block on evicted value's corresponding file deletion needs to be created in a context of a Tokio runtime. 

If created in the eviction method itself it will silently panic with `there is no reactor running, must be called from the context of a Tokio 1.x runtime`, after which point no evictions will be attempted again (but everything will continue running). In turn this will eventually lead to `cached file path already exists` errors from #333, as the files are never cleaned up. 

Arguably, it may be preferable to either skip or overwrite an existing path instead of erroring out, but I've left it for now as it may help us flush out some other bugs.

Co-incidentally, this revealed a design problem with the cache, namely after we full up the cache entirely, no further entries will be accepted, see here for more details: https://github.com/moka-rs/moka/issues/147#issuecomment-1162899784

Closes #333.