### PR TITLE
Replace unmaintained actions-rs/toolchain action in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,9 @@ jobs:
       # selecting a toolchain either by action or manual `rustup` calls should happen
       # before the plugin, as the cache uses the current rustc version as its cache key
       - name: Install minimal nightly with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
           components: rustfmt, clippy
 
       - name: Install tool for formatting Cargo.toml files


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/splitgraph/seafowl/actions/runs/4579083471:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain).