### PR TITLE
Enable caching of S3 objects in the local FS

### DIFF
--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -108,7 +108,7 @@ fn build_object_store(cfg: &schema::SeafowlConfig) -> Arc<dyn ObjectStore> {
             if let Some(ObjectCacheProperties {
                 capacity,
                 min_fetch_size,
-                ttl,
+                ttl_s,
             }) = cache_properties
             {
                 let tmp_dir = TempDir::new().unwrap();
@@ -119,7 +119,7 @@ fn build_object_store(cfg: &schema::SeafowlConfig) -> Arc<dyn ObjectStore> {
                     &path,
                     *capacity,
                     *min_fetch_size,
-                    Duration::from_secs(*ttl),
+                    Duration::from_secs(*ttl_s),
                 ));
             }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -128,7 +128,7 @@ pub struct S3 {
 pub struct ObjectCacheProperties {
     pub capacity: u64,
     pub min_fetch_size: u64,
-    pub ttl: u64, // We could use humantime_serde crate to parse directly into `std::time::Duration`
+    pub ttl_s: u64, // We could use humantime_serde crate to parse directly into `std::time::Duration`
 }
 
 impl Default for ObjectCacheProperties {
@@ -136,7 +136,7 @@ impl Default for ObjectCacheProperties {
         Self {
             capacity: DEFAULT_CACHE_CAPACITY,
             min_fetch_size: DEFAULT_MIN_FETCH_SIZE,
-            ttl: DEFAULT_CACHE_ENTRY_TTL.as_secs(),
+            ttl_s: DEFAULT_CACHE_ENTRY_TTL.as_secs(),
         }
     }
 }
@@ -412,7 +412,7 @@ bucket = "seafowl"
 
 [object_store.cache_properties]
 min_fetch_size = 4096
-ttl = 10
+ttl_s = 10
 
 [catalog]
 type = "postgres"
@@ -482,7 +482,7 @@ upload_data_max_length = 1
     #[case::basic_s3(TEST_CONFIG_S3, None)]
     #[case::basic_s3_with_cache(
         TEST_CONFIG_S3_WITH_CACHE,
-        Some(ObjectCacheProperties{ capacity: DEFAULT_CACHE_CAPACITY, min_fetch_size: 4096, ttl: 10 }))
+        Some(ObjectCacheProperties{ capacity: DEFAULT_CACHE_CAPACITY, min_fetch_size: 4096, ttl_s: 10 }))
     ]
     fn test_parse_config_with_s3(
         #[case] config_str: &str,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1771,7 +1771,7 @@ impl SeafowlContext for DefaultSeafowlContext {
                     )
                     .await?
                     .ok_or_else(|| {
-                        DataFusionError::Execution("Table {name} not found".to_string())
+                        DataFusionError::Execution(format!("Table {name} not found"))
                     })?;
 
                 self.table_catalog.drop_table(table_id).await?;

--- a/tests/statements/mod.rs
+++ b/tests/statements/mod.rs
@@ -73,8 +73,12 @@ data_dir = "{}""#,
 access_key_id = "minioadmin"
 secret_access_key = "minioadmin"
 endpoint = "http://127.0.0.1:9000"
-bucket = "seafowl-test-bucket""#
-                .to_string(),
+bucket = "seafowl-test-bucket"
+
+[object_store.cache_properties]
+ttl = 30
+"#
+            .to_string(),
             None,
         ),
     };


### PR DESCRIPTION
Also, enforce a TTL on the cache as a workaround for moka's eviction policy shortcomings for full caches:  https://github.com/moka-rs/moka/issues/147#issuecomment-1162899784

Closes #41.
