### PR TITLE
Use Debian Bookworm as Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # cargo build --release
 # DOCKER_BUILDKIT=1 docker build . -t splitgraph/seafowl:nightly
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY target/release/seafowl /usr/local/bin/seafowl
 


### PR DESCRIPTION
The CI builds now link to libssl 3 (bullseye ships with an older libssl). To fix this, use a newer Debian version as the base image.