### PR TITLE
Fix renaming table to schemas/tables with special characters

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2680,23 +2680,20 @@ mod tests {
         context.collect(plan).await.unwrap();
 
         let plan = context
-            .plan_query(format!(r#"CREATE SCHEMA "schema/slash-dash:colon""#).as_str())
+            .plan_query(r#"CREATE SCHEMA "schema/slash-dash:colon""#)
             .await
             .unwrap();
         context.collect(plan).await.unwrap();
 
         let plan = context
-            .plan_query(format!(r#"ALTER TABLE test_table RENAME TO "schema/slash-dash:colon"."table/slash-dash:colon""#).as_str())
+            .plan_query(r#"ALTER TABLE test_table RENAME TO "schema/slash-dash:colon"."table/slash-dash:colon""#)
             .await
             .unwrap();
         context.collect(plan).await.unwrap();
 
         let plan = context
             .plan_query(
-                format!(
-                    r#"SELECT * FROM "schema/slash-dash:colon"."table/slash-dash:colon""#
-                )
-                .as_str(),
+                r#"SELECT * FROM "schema/slash-dash:colon"."table/slash-dash:colon""#,
             )
             .await
             .unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -2670,46 +2670,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rename_table_special_characters() {
-        let context = in_memory_context().await;
-
-        let plan = context
-            .plan_query("CREATE TABLE test_table AS VALUES (1, 'one')")
-            .await
-            .unwrap();
-        context.collect(plan).await.unwrap();
-
-        let plan = context
-            .plan_query(r#"CREATE SCHEMA "schema/slash-dash:colon""#)
-            .await
-            .unwrap();
-        context.collect(plan).await.unwrap();
-
-        let plan = context
-            .plan_query(r#"ALTER TABLE test_table RENAME TO "schema/slash-dash:colon"."table/slash-dash:colon""#)
-            .await
-            .unwrap();
-        context.collect(plan).await.unwrap();
-
-        let plan = context
-            .plan_query(
-                r#"SELECT * FROM "schema/slash-dash:colon"."table/slash-dash:colon""#,
-            )
-            .await
-            .unwrap();
-        let results = context.collect(plan).await.unwrap();
-
-        let expected = vec![
-            "+---------+---------+",
-            "| column1 | column2 |",
-            "+---------+---------+",
-            "| 1       | one     |",
-            "+---------+---------+",
-        ];
-        assert_batches_eq!(expected, &results);
-    }
-
-    #[tokio::test]
     async fn test_register_udf() -> Result<()> {
         let sf_context = in_memory_context().await;
 


### PR DESCRIPTION
In particular, ensure these can include slash, dash and colon at least.

Closes #361.