### PR TITLE
Enable passing query as a path parameter in the GET endpoint

### DIFF
--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -265,7 +265,12 @@ pub fn cached_read_query_authz(
         .untuple_one()
 }
 
-/// GET /q/[query hash] or /[database_name]/q/[query hash]
+/// Supports either one of:
+/// 1. GET /q/[query]
+/// 2. GET /q/[query hash] {"query": "[query]"}
+/// 3. GET -H "X-Seafowl-Query: [query]" /q/[query hash]
+/// In all cases the path can have an optional prefix parameter in order do specify a non-default
+/// database as target, e.g. /[database_name]/q/[query]
 pub async fn cached_read_query(
     database_name: String,
     query_or_hash: String,


### PR DESCRIPTION
This is in addition to the previously supported options of using the request body or a special `X-Seafowl-Query` header as mediums to send the query, but this particular approach is a bit more user-friendly (no need to calculate/supply the query hash).

Closes #55.