### PR TITLE
Enable specifying the GET endpoint cache-control header via config

### DIFF
--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -279,7 +279,7 @@ mod tests {
                     read_access: schema::AccessSettings::Any,
                     write_access: schema::AccessSettings::Any,
                     upload_data_max_length: 256 * 1024 * 1024,
-                    cache_control: None,
+                    cache_control: "max-age=43200, public".to_string(),
                 }),
             },
             runtime: schema::Runtime {

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -183,10 +183,6 @@ pub async fn build_context(
         .with_information_schema(true)
         .with_default_catalog_and_schema(DEFAULT_DB, DEFAULT_SCHEMA);
 
-    // Make sure we have at least 2 target partitions even on single-core environments
-    // (issues with PartitionMode::CollectLeft hash joins if a single target partition)
-    let target_partitions = session_config.target_partitions().max(2);
-    let session_config = session_config.with_target_partitions(target_partitions);
     let runtime_env = RuntimeEnv::new(runtime_config)?;
     let state = build_state_with_table_factories(session_config, Arc::new(runtime_env));
     let context = SessionContext::with_state(state);
@@ -283,6 +279,7 @@ mod tests {
                     read_access: schema::AccessSettings::Any,
                     write_access: schema::AccessSettings::Any,
                     upload_data_max_length: 256 * 1024 * 1024,
+                    cache_control: None,
                 }),
             },
             runtime: schema::Runtime {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -279,7 +279,7 @@ pub struct HttpFrontend {
     pub read_access: AccessSettings,
     pub write_access: AccessSettings,
     pub upload_data_max_length: u64,
-    pub cache_control: Option<String>,
+    pub cache_control: String,
 }
 
 impl Default for HttpFrontend {
@@ -290,7 +290,7 @@ impl Default for HttpFrontend {
             read_access: AccessSettings::Any,
             write_access: AccessSettings::Off,
             upload_data_max_length: 256,
-            cache_control: None,
+            cache_control: "max-age=43200, public".to_string(), // defaults to 12 hours
         }
     }
 }
@@ -473,7 +473,7 @@ bind_port = 80
 read_access = "any"
 write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c"
 upload_data_max_length = 1
-cache_control = "max-age=3600, public"
+cache_control = "private, max-age=86400"
 "#;
 
     const TEST_CONFIG_ERROR: &str = r#"
@@ -549,7 +549,7 @@ cache_control = "max-age=3600, public"
                         read_access: AccessSettings::Any,
                         write_access: AccessSettings::Off,
                         upload_data_max_length: 256,
-                        cache_control: None,
+                        cache_control: "max-age=43200, public".to_string(),
                     })
                 },
                 runtime: Runtime {
@@ -581,7 +581,7 @@ cache_control = "max-age=3600, public"
                             .to_string()
                 },
                 upload_data_max_length: 1,
-                cache_control: Some("max-age=3600, public".to_string()),
+                cache_control: "private, max-age=86400".to_string(),
             }
         );
     }
@@ -644,7 +644,7 @@ cache_control = "max-age=3600, public"
                                 .to_string()
                         },
                         upload_data_max_length: 256,
-                        cache_control: None,
+                        cache_control: "max-age=43200, public".to_string(),
                     })
                 },
                                  runtime: Runtime {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -279,6 +279,7 @@ pub struct HttpFrontend {
     pub read_access: AccessSettings,
     pub write_access: AccessSettings,
     pub upload_data_max_length: u64,
+    pub cache_control: Option<String>,
 }
 
 impl Default for HttpFrontend {
@@ -289,6 +290,7 @@ impl Default for HttpFrontend {
             read_access: AccessSettings::Any,
             write_access: AccessSettings::Off,
             upload_data_max_length: 256,
+            cache_control: None,
         }
     }
 }
@@ -471,6 +473,7 @@ bind_port = 80
 read_access = "any"
 write_access = "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c"
 upload_data_max_length = 1
+cache_control = "max-age=3600, public"
 "#;
 
     const TEST_CONFIG_ERROR: &str = r#"
@@ -545,7 +548,8 @@ upload_data_max_length = 1
                         bind_port: 80,
                         read_access: AccessSettings::Any,
                         write_access: AccessSettings::Off,
-                        upload_data_max_length: 256
+                        upload_data_max_length: 256,
+                        cache_control: None,
                     })
                 },
                 runtime: Runtime {
@@ -576,7 +580,8 @@ upload_data_max_length = 1
                         "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c"
                             .to_string()
                 },
-                upload_data_max_length: 1
+                upload_data_max_length: 1,
+                cache_control: Some("max-age=3600, public".to_string()),
             }
         );
     }
@@ -638,7 +643,8 @@ upload_data_max_length = 1
                             "4364aacb2f4609e22d758981474dd82622ad53fc14716f190a5a8a557082612c"
                                 .to_string()
                         },
-                        upload_data_max_length: 256
+                        upload_data_max_length: 256,
+                        cache_control: None,
                     })
                 },
                                  runtime: Runtime {


### PR DESCRIPTION
Closes #56 