### PR TITLE
Implement streaming of result rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,24 +1866,29 @@ checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
 
 [[package]]
 name = "deltalake"
-version = "0.11.0"
-source = "git+https://github.com/delta-io/delta-rs?rev=930d16e583fbd784f5f3d4bb8bcd753e2d6488a6#930d16e583fbd784f5f3d4bb8bcd753e2d6488a6"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51500e2a5f31c9d64435297f9f8a227dac90a04814596e8243a5f401bd8aee33"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-cast",
+ "arrow-ord",
+ "arrow-row",
  "arrow-schema",
+ "arrow-select",
  "async-trait",
  "bytes",
  "cfg-if",
  "chrono",
+ "dashmap",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
  "datafusion-proto",
  "datafusion-sql",
- "dynamodb_lock 0.4.3 (git+https://github.com/delta-io/delta-rs?rev=930d16e583fbd784f5f3d4bb8bcd753e2d6488a6)",
+ "dynamodb_lock",
  "errno",
  "futures",
  "glibc_version",
@@ -2029,21 +2034,6 @@ name = "dynamodb_lock"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff628406c318f098017c78e203b5b6466e0610fc48be865ebb9ae0eb229b4c8"
-dependencies = [
- "async-trait",
- "log",
- "maplit",
- "rusoto_core",
- "rusoto_dynamodb",
- "thiserror",
- "tokio",
- "uuid 1.3.3",
-]
-
-[[package]]
-name = "dynamodb_lock"
-version = "0.4.3"
-source = "git+https://github.com/delta-io/delta-rs?rev=930d16e583fbd784f5f3d4bb8bcd753e2d6488a6#930d16e583fbd784f5f3d4bb8bcd753e2d6488a6"
 dependencies = [
  "async-trait",
  "log",
@@ -2591,7 +2581,8 @@ dependencies = [
 [[package]]
 name = "glibc_version"
 version = "0.1.2"
-source = "git+https://github.com/delta-io/delta-rs?rev=930d16e583fbd784f5f3d4bb8bcd753e2d6488a6#930d16e583fbd784f5f3d4bb8bcd753e2d6488a6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803ff7635f1ab4e2c064b68a0c60da917d3d18dc8d086130f689d62ce4f1c33e"
 dependencies = [
  "regex",
 ]
@@ -5177,7 +5168,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-remote-tables",
  "deltalake",
- "dynamodb_lock 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dynamodb_lock",
  "futures",
  "hex",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ datafusion-expr = "25.0.0"
 
 datafusion-remote-tables = { path = "./datafusion_remote_tables", optional = true }
 
-deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "930d16e583fbd784f5f3d4bb8bcd753e2d6488a6", features = ["s3-native-tls", "datafusion-ext"] }
+deltalake = { version = "0.12.0", features = ["s3-native-tls", "datafusion-ext"] }
 dynamodb_lock = { version = "0.4.3", default_features = false, features = ["native-tls"] }
 
 futures = "0.3"

--- a/src/context.rs
+++ b/src/context.rs
@@ -463,7 +463,12 @@ pub fn is_read_only(plan: &LogicalPlan) -> bool {
 
 pub fn is_statement_read_only(statement: &DFStatement) -> bool {
     if let DFStatement::Statement(s) = statement {
-        matches!(**s, Statement::Query(_) | Statement::Explain { .. })
+        matches!(
+            **s,
+            Statement::Query(_)
+                | Statement::Explain { .. }
+                | Statement::ShowTables { .. }
+        )
     } else {
         false
     }
@@ -866,7 +871,7 @@ impl DefaultSeafowlContext {
         Ok(())
     }
 
-    async fn execute_stream(
+    pub(crate) async fn execute_stream(
         &self,
         physical_plan: Arc<dyn ExecutionPlan>,
     ) -> Result<SendableRecordBatchStream> {

--- a/src/frontend/http_utils.rs
+++ b/src/frontend/http_utils.rs
@@ -70,7 +70,6 @@ pub enum ApiError {
     UploadUnsupportedFileFormat(String),
     QueryDecodeError,
     QueryParsingError(Rejection),
-    JsonError(String),
 }
 
 // Wrap DataFusion errors so that we can automagically return an
@@ -117,7 +116,6 @@ impl ApiError {
             ApiError::UploadUnsupportedFileFormat(filename) => (StatusCode::BAD_REQUEST, format!("File {filename} not supported")),
             ApiError::QueryDecodeError => (StatusCode::BAD_REQUEST, "QUERY_DECODE_ERROR".to_string()),
             ApiError::QueryParsingError(r) => (StatusCode::BAD_REQUEST, format!("No query found in the request: {r:?}")),
-            ApiError::JsonError(message) => (StatusCode::INTERNAL_SERVER_ERROR, message.clone()),
         }
     }
 

--- a/src/frontend/http_utils.rs
+++ b/src/frontend/http_utils.rs
@@ -63,13 +63,14 @@ pub enum ApiError {
     UploadMissingFilename,
     UploadMissingFilenameExtension(String),
     UploadSchemaDeserializationError(serde_json::Error),
-    UploadSchemaParseError(datafusion::arrow::error::ArrowError),
+    UploadSchemaParseError(arrow::error::ArrowError),
     UploadFileLoadError(Box<dyn std::error::Error + Send + Sync>),
     UploadBodyLoadError(warp::Error),
     UploadHasHeaderParseError,
     UploadUnsupportedFileFormat(String),
     QueryDecodeError,
     QueryParsingError(Rejection),
+    JsonError(String),
 }
 
 // Wrap DataFusion errors so that we can automagically return an
@@ -116,6 +117,7 @@ impl ApiError {
             ApiError::UploadUnsupportedFileFormat(filename) => (StatusCode::BAD_REQUEST, format!("File {filename} not supported")),
             ApiError::QueryDecodeError => (StatusCode::BAD_REQUEST, "QUERY_DECODE_ERROR".to_string()),
             ApiError::QueryParsingError(r) => (StatusCode::BAD_REQUEST, format!("No query found in the request: {r:?}")),
+            ApiError::JsonError(message) => (StatusCode::INTERNAL_SERVER_ERROR, message.clone()),
         }
     }
 


### PR DESCRIPTION
This is so as to avoid accumulating the entire result in memory and potentially OOM-ing the process. Closes #258

Example, using a large table to perform `SELECT * ... LIMIT 100000`:
- W/O streaming memory peaks at 220MB (current main)
![slika](https://github.com/splitgraph/seafowl/assets/45558892/39c398b2-f582-49d7-a81d-1f090c727d38)

- W/ streaming memory peaks at 30MB (this PR)
![slika](https://github.com/splitgraph/seafowl/assets/45558892/804f8796-42a5-422c-8754-3d915e1fcfea)
