### PR TITLE
Simplify the external table creation logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,17 +4,23 @@ services:
     image: minio/minio:latest
     ports:
       - 9000:9000
+      - 9001:9001
+    environment:
+      MINIO_CONSOLE_ADDRESS: ":9001"
     command: minio server /data
 
   createbuckets:
     image: minio/mc:latest
     depends_on:
       - minio
+    volumes:
+      - ./tests/data:/test-data
     entrypoint: >
       /bin/sh -c " /usr/bin/mc config host add test-minio http://minio:9000 minioadmin minioadmin;
-      /usr/bin/mc rm -r --force test-minio/seafowl-test-bucket; /usr/bin/mc mb
-      test-minio/seafowl-test-bucket; /usr/bin/mc policy download test-minio/seafowl-test-bucket;
-      exit 0; "
+      /usr/bin/mc rm -r --force test-minio/seafowl-test-bucket;  /usr/bin/mc mb
+      test-minio/seafowl-test-bucket; /usr/bin/mc cp test-data/table_with_ns_column.parquet
+      test-minio/seafowl-test-bucket/table_with_ns_column.parquet; /usr/bin/mc anonymous set public
+      test-minio/seafowl-test-bucket/table_with_ns_column.parquet; exit 0; "
 
   fake-gcs:
     image: fsouza/fake-gcs-server

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -5,7 +5,7 @@ use crate::{
     catalog::{
         DefaultCatalog, FunctionCatalog, TableCatalog, DEFAULT_DB, DEFAULT_SCHEMA,
     },
-    context::{DefaultSeafowlContext, INTERNAL_OBJECT_STORE_SCHEME},
+    context::DefaultSeafowlContext,
     repository::{interface::Repository, sqlite::SqliteRepository},
 };
 use datafusion::execution::context::SessionState;
@@ -33,7 +33,6 @@ use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::path::Path;
 use parking_lot::lock_api::RwLock;
 use tempfile::TempDir;
-use url::Url;
 
 use super::schema::{self, GCS, MEBIBYTES, MEMORY_FRACTION, S3};
 
@@ -188,11 +187,6 @@ pub async fn build_context(
     let context = SessionContext::with_state(state);
 
     let object_store = build_object_store(cfg);
-    context.runtime_env().register_object_store(
-        &Url::parse(INTERNAL_OBJECT_STORE_SCHEME).unwrap(),
-        object_store.clone(),
-    );
-
     let internal_object_store = Arc::new(InternalObjectStore::new(
         object_store.clone(),
         cfg.object_store.clone(),

--- a/tests/statements/ddl.rs
+++ b/tests/statements/ddl.rs
@@ -484,10 +484,15 @@ async fn test_create_table_in_staging_schema() {
     assert_eq!(err.to_string(), expected_err,);
 }
 
+#[rstest]
+#[case::minio(Some(
+    "http://localhost:9000/seafowl-test-bucket/table_with_ns_column.parquet"
+))]
+#[case::mock(None)]
 #[tokio::test]
-async fn test_create_external_table_http() {
+async fn test_create_external_table_http(#[case] minio_url: Option<&str>) {
     /*
-    Test CREATE EXTERNAL TABLE works with an HTTP mock server.
+    Test CREATE EXTERNAL TABLE works with an HTTP mock server and MinIO.
 
     This also works with https + actual S3 (tested manually)
 
@@ -496,12 +501,17 @@ async fn test_create_external_table_http() {
     bytes_scanned{filename=seafowl-public.s3.eu-west-1.amazonaws.com/tutorial/trase-supply-chains.parquet}=232699
     */
 
-    let (mock_server, _) = testutils::make_mock_parquet_server(true, true).await;
-    // Add a query string that's ignored by the mock (make sure DataFusion doesn't eat the whole URL)
-    let url = format!(
-        "{}/some/file.parquet?query_string=ignore",
-        &mock_server.uri()
-    );
+    let url = match minio_url {
+        None => {
+            let (mock_server, _) = testutils::make_mock_parquet_server(true, true).await;
+            // Add a query string that's ignored by the mock (make sure DataFusion doesn't eat the whole URL)
+            format!(
+                "{}/some/file.parquet?query_string=ignore",
+                &mock_server.uri()
+            )
+        }
+        Some(url) => url.to_string(),
+    };
 
     let (context, _) = make_context_with_pg(ObjectStoreType::InMemory).await;
 
@@ -556,15 +566,27 @@ async fn test_create_external_table_http() {
         .await
         .unwrap();
     let results = context.collect(plan).await.unwrap();
-    let expected = vec![
-        "+-------+",
-        "| col_1 |",
-        "+-------+",
-        "| 1     |",
-        "| 2     |",
-        "| 3     |",
-        "+-------+",
-    ];
+    let expected = if minio_url.is_none() {
+        vec![
+            "+-------+",
+            "| col_1 |",
+            "+-------+",
+            "| 1     |",
+            "| 2     |",
+            "| 3     |",
+            "+-------+",
+        ]
+    } else {
+        vec![
+            "+----------------+---------------------+------------+",
+            "| some_int_value | some_time           | some_value |",
+            "+----------------+---------------------+------------+",
+            "| 1111           | 2022-01-01T20:01:01 | 42.0       |",
+            "| 2222           | 2022-01-01T20:02:02 | 43.0       |",
+            "| 3333           | 2022-01-01T20:03:03 | 44.0       |",
+            "+----------------+---------------------+------------+",
+        ]
+    };
 
     assert_batches_eq!(expected, &results);
 

--- a/tests/statements/ddl.rs
+++ b/tests/statements/ddl.rs
@@ -488,7 +488,7 @@ async fn test_create_table_in_staging_schema() {
 #[case::minio(Some(
     "http://localhost:9000/seafowl-test-bucket/table_with_ns_column.parquet"
 ))]
-#[case::mock(None)]
+#[case::mock_http_server(None)]
 #[tokio::test]
 async fn test_create_external_table_http(#[case] minio_url: Option<&str>) {
     /*
@@ -609,27 +609,4 @@ async fn test_create_external_table_http(#[case] minio_url: Option<&str>) {
         "+--------------------+-------------+",
     ];
     assert_batches_eq!(expected, &results);
-
-    // Test we can't hit the Seafowl object store directly via CREATE EXTERNAL TABLE
-    let err = context
-        .plan_query(
-            "CREATE EXTERNAL TABLE internal STORED AS PARQUET LOCATION 'seafowl://file'",
-        )
-        .await
-        .unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("Invalid URL scheme for location \"seafowl://file\""));
-
-    // (also test that the DF object store registry doesn't normalize the case so that people can't
-    // bypass this)
-    let err = context
-        .plan_query(
-            "CREATE EXTERNAL TABLE internal STORED AS PARQUET LOCATION 'SeAfOwL://file'",
-        )
-        .await
-        .unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("No suitable object store found for seafowl://file"));
 }


### PR DESCRIPTION
The only thing that prevented us from employing the relevant DataFusion functions entirely was our custom `file_extension` setting for HTTP files/tables (to allow disabling filtering by an extension). Previously we copied a lot of code just to make that small change, but now it works as desired in DF, thanks to https://github.com/apache/arrow-datafusion/pull/6274.

Also add a test targeting minio as the host of the HTTP file.