### PR TITLE
Upload endpoint refinements

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,11 +87,7 @@ jobs:
         # consumption by limiting the number of parallel jobs during build.
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            cargo build -j 1 --release
-          else
-            cargo build --release
-          fi
+          cargo build -j 1 --release
 
       - name: Test invoking the binaries
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,8 +1649,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9992c267436551d40b52d65289b144712e7b0ebdc62c8c859fd1574e5f73efbb"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "ahash 0.8.3",
  "arrow",
@@ -1699,8 +1698,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3be97f7a7c720cdbb71e9eeabf814fa6ad8102b9022390f6cac74d3b4af6392"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1714,8 +1712,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77c4b14b809b0e4c5bb101b6834504f06cdbb0d3c643400c61d0d844b33264e"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "dashmap",
  "datafusion-common",
@@ -1732,8 +1729,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ec7409bd45cf4fae6395d7d1024c8a97e543cadc88363e405d2aad5330e5e7"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "ahash 0.8.3",
  "arrow",
@@ -1747,8 +1743,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b537c93f87989c212db92a448a0f5eb4f0995e27199bb7687ae94f8b64a7a8"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1765,8 +1760,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60ee3f53340fdef36ee54d9e12d446ae2718b1d0196ac581f791d34808ec876"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "ahash 0.8.3",
  "arrow",
@@ -1798,8 +1792,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700dbf61d471cedb18574eebf5ddc253a64dff406244bbb34ed5402ebaeb197"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "arrow",
  "chrono",
@@ -1831,8 +1824,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58fc64058aa3bcb00077a0d19474a0d584d31dec8c7ac3406868f485f659af9"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1843,8 +1835,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1531f0314151a34bf6c0a83c7261525688b7c729876f53e7896b8f4ca8f57d07"
+source = "git+https://github.com/apache/arrow-datafusion?rev=70d633a71d0096b03bd8f173b000fdca82671d3f#70d633a71d0096b03bd8f173b000fdca82671d3f"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1876,7 +1867,7 @@ checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
 [[package]]
 name = "deltalake"
 version = "0.13.0"
-source = "git+https://github.com/delta-io/delta-rs?rev=8294c5f0e6fe441fa735a10726a81fc74e506c97#8294c5f0e6fe441fa735a10726a81fc74e506c97"
+source = "git+https://github.com/splitgraph/delta-rs?branch=df-post-26-parquet-schema-coercion#2ff9600b535ce790812d981ca9054e210001fcaa"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ datafusion-expr = "26.0.0"
 
 datafusion-remote-tables = { path = "./datafusion_remote_tables", optional = true }
 
-deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "8294c5f0e6fe441fa735a10726a81fc74e506c97", features = ["s3-native-tls", "datafusion-ext"] }
+deltalake = { git = "https://github.com/splitgraph/delta-rs", branch = "df-post-26-parquet-schema-coercion", features = ["s3-native-tls", "datafusion-ext"] }
 dynamodb_lock = { version = "0.4.3", default_features = false, features = ["native-tls"] }
 
 futures = "0.3"
@@ -96,13 +96,16 @@ wasi-common = "8.0.1"
 wasmtime = "8.0.1"
 wasmtime-wasi = "8.0.1"
 
+# Pick up post-26 DF that has Parquet schema type adapter/coercion
 [patch.crates-io]
 convergence = { git = "https://github.com/splitgraph/convergence", branch = "datafusion-26-upgrade", optional = true }
 convergence-arrow = { git = "https://github.com/splitgraph/convergence", branch = "datafusion-26-upgrade", optional = true }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "70d633a71d0096b03bd8f173b000fdca82671d3f", optional = true }
+datafusion-common = { git = "https://github.com/apache/arrow-datafusion", rev = "70d633a71d0096b03bd8f173b000fdca82671d3f", optional = true }
+datafusion-expr = { git = "https://github.com/apache/arrow-datafusion", rev = "70d633a71d0096b03bd8f173b000fdca82671d3f", optional = true }
 
 [dev-dependencies]
 assert_unordered = "0.3"
-datafusion-common = "26.0.0"
 mockall = "0.11.1"
 rstest = "*"
 serial_test = "2"

--- a/src/context.rs
+++ b/src/context.rs
@@ -955,7 +955,6 @@ impl DefaultSeafowlContext {
 
         // Make a scan plan for the listing table, which will be the input for the target table
         let plan = source.scan(&self.inner.state(), None, &[], None).await?;
-        //let plan = self.coerce_plan(scan).await?;
 
         let table_ref = TableReference::Full {
             catalog: Cow::from(self.database.clone()),

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -369,14 +369,14 @@ pub async fn upload(
     };
 
     if database_name != context.database {
-        context = context.scope_to_database(database_name)?;
+        context = context.scope_to_database(database_name.clone())?;
     }
 
     let mut has_header = true;
     let mut schema: Option<SchemaRef> = None;
     let mut filename = String::new();
     let mut temp_file = context.inner.runtime_env().disk_manager.create_tmp_file(
-        format!("Creating a target file to persist the uploaded {filename}").as_str(),
+        format!("Creating a target file to append to {database_name}.{schema_name}.{table_name}").as_str(),
     )?;
     while let Some(maybe_part) = form.next().await {
         let mut part = maybe_part.map_err(ApiError::UploadBodyLoadError)?;

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -1,23 +1,21 @@
-use arrow::csv::ReaderBuilder;
-use arrow::datatypes::Schema;
 use arrow::error::ArrowError;
 use datafusion::error::DataFusionError;
-use std::error::Error;
+
 use std::fmt::Debug;
-use std::io::{Cursor, Seek};
+use std::io::Write;
 use std::{net::SocketAddr, sync::Arc};
 use warp::{hyper, Rejection};
 
 use arrow::json::writer::record_batches_to_json_rows;
-use arrow::record_batch::{RecordBatch, RecordBatchReader};
-use arrow_csv::reader::Format;
+use arrow::record_batch::RecordBatch;
+
 use arrow_integration_test::{schema_from_json, schema_to_json};
 use arrow_schema::SchemaRef;
-use bytes::{Buf, Bytes};
+use bytes::Buf;
 
+use datafusion::datasource::file_format::file_type::FileType;
 use datafusion::datasource::DefaultTableSource;
-use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReader;
-use datafusion::physical_plan::memory::MemoryExec;
+
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_common::tree_node::{TreeNode, TreeNodeVisitor, VisitRecursion};
 use datafusion_expr::logical_plan::{LogicalPlan, TableScan};
@@ -375,11 +373,13 @@ pub async fn upload(
     }
 
     let mut has_header = true;
-    let mut csv_schema: Option<Schema> = None;
+    let mut schema: Option<SchemaRef> = None;
     let mut filename = String::new();
-    let mut part_data: Vec<u8> = vec![];
+    let mut temp_file = context.inner.runtime_env().disk_manager.create_tmp_file(
+        format!("Creating a target file to persist the uploaded {filename}").as_str(),
+    )?;
     while let Some(maybe_part) = form.next().await {
-        let part = maybe_part.map_err(ApiError::UploadBodyLoadError)?;
+        let mut part = maybe_part.map_err(ApiError::UploadBodyLoadError)?;
 
         if part.name() == "has_header" {
             let value_bytes = load_part(part).await?;
@@ -391,24 +391,25 @@ pub async fn upload(
         } else if part.name() == "schema" {
             let value_bytes = load_part(part).await?;
 
-            csv_schema = Some(
+            schema = Some(Arc::new(
                 schema_from_json(
                     &serde_json::from_slice::<serde_json::Value>(value_bytes.as_slice())
                         .map_err(ApiError::UploadSchemaDeserializationError)?,
                 )
                 .map_err(ApiError::UploadSchemaParseError)?,
-            );
+            ));
         } else if part.name() == "data" || part.name() == "file" {
             filename = part
                 .filename()
                 .ok_or(ApiError::UploadMissingFile)?
                 .to_string();
 
-            // Load the file content from the request
-            // TODO: we're actually buffering the entire file into memory here which is sub-optimal.
-            // Instead we should be writing the contents of the stream out into a temp file on the
-            // disk to have a smaller memory footprint.
-            part_data = load_part(part).await?;
+            // Write out the incoming bytes into the temporary file
+            while let Some(maybe_bytes) = part.data().await {
+                temp_file.write_all(
+                    maybe_bytes.map_err(ApiError::UploadBodyLoadError)?.chunk(),
+                )?;
+            }
         }
     }
 
@@ -416,33 +417,37 @@ pub async fn upload(
         return Err(ApiError::UploadMissingFile);
     }
 
-    // Parse the schema and load the file contents into a vector of record batches
-    let (schema, partition) = match filename
+    let file_type = match filename
         .split('.')
         .last()
         .ok_or_else(|| ApiError::UploadMissingFilenameExtension(filename.clone()))?
     {
-        "csv" => load_csv_bytes(part_data, csv_schema.clone(), has_header)
-            .map_err(|e| ApiError::UploadFileLoadError(e.into()))?,
-        "parquet" => {
-            load_parquet_bytes(part_data).map_err(ApiError::UploadFileLoadError)?
-        }
+        "csv" => FileType::CSV,
+        "parquet" => FileType::PARQUET,
         _ => return Err(ApiError::UploadUnsupportedFileFormat(filename)),
     };
 
-    // Create an execution plan for yielding the record batches we just generated
-    let execution_plan = Arc::new(MemoryExec::try_new(
-        &[partition],
-        Arc::new(schema.clone()),
-        None,
-    )?);
-
     // Execute the plan and persist objects as well as table/partition metadata
-    context
-        .plan_to_table(execution_plan, schema_name.clone(), table_name.clone())
+    let temp_path = temp_file.into_temp_path();
+    let table = context
+        .file_to_table(
+            temp_path.display().to_string(),
+            file_type,
+            schema,
+            has_header,
+            schema_name.clone(),
+            table_name.clone(),
+        )
         .await?;
 
-    Ok(warp::reply::with_status(Ok("done"), StatusCode::OK).into_response())
+    Ok(warp::reply::with_status(
+        Ok(format!(
+            "{filename} appended to table {table_name} version {}\n",
+            table.version()
+        )),
+        StatusCode::OK,
+    )
+    .into_response())
 }
 
 async fn load_part(mut part: Part) -> Result<Vec<u8>, ApiError> {
@@ -451,52 +456,6 @@ async fn load_part(mut part: Part) -> Result<Vec<u8>, ApiError> {
         bytes.extend(maybe_bytes.map_err(ApiError::UploadBodyLoadError)?.chunk())
     }
     Ok(bytes)
-}
-
-fn load_csv_bytes(
-    source: Vec<u8>,
-    schema: Option<Schema>,
-    has_header: bool,
-) -> Result<(Schema, Vec<RecordBatch>), ArrowError> {
-    let mut cursor = Cursor::new(source);
-
-    // If the schema part wasn't specified we'll need to infer it
-    let builder = match schema {
-        Some(schema) => ReaderBuilder::new(Arc::new(schema)).has_header(has_header),
-        None => {
-            let (schema, _) = Format::default()
-                .with_header(has_header)
-                .infer_schema(&mut cursor, None)
-                .unwrap();
-            cursor.rewind()?;
-            ReaderBuilder::new(Arc::new(schema)).has_header(has_header)
-        }
-    };
-
-    let csv_reader = builder.build(&mut cursor)?;
-    let schema = csv_reader.schema().as_ref().clone();
-    let partition: Vec<RecordBatch> = csv_reader
-        .into_iter()
-        .collect::<Result<Vec<RecordBatch>, ArrowError>>()?;
-
-    Ok((schema, partition))
-}
-
-/// Load a Parquet file from a byte vector and returns its schema/batches
-fn load_parquet_bytes(
-    source: Vec<u8>,
-) -> Result<(Schema, Vec<RecordBatch>), Box<dyn Error + Send + Sync>> {
-    // We have to return a boxed error here, since this could return either a
-    // ParquetError or an ArrowError
-    // (could also return an ApiError::UploadFileLoadError with a string?)
-    let parquet_reader = ParquetRecordBatchReader::try_new(Bytes::from(source), 1024)?;
-
-    let schema = parquet_reader.schema();
-
-    let partition: Vec<RecordBatch> =
-        parquet_reader.collect::<Result<Vec<RecordBatch>, ArrowError>>()?;
-
-    Ok((schema.as_ref().clone(), partition))
 }
 
 // We need the allow to silence the compiler: it asks us to add warp::generic::Tuple to the first

--- a/tests/http/mod.rs
+++ b/tests/http/mod.rs
@@ -21,15 +21,20 @@ use warp::hyper::Request;
 use warp::hyper::Response;
 use warp::hyper::StatusCode;
 
-use arrow::array::{Int32Array, StringArray};
+use arrow::array::{
+    BooleanArray, Float64Array, Int32Array, StringArray, TimestampMicrosecondArray,
+    TimestampNanosecondArray,
+};
 use arrow::csv::WriterBuilder;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+use arrow_integration_test::schema_to_json;
 use arrow_schema::TimeUnit;
 use datafusion::assert_batches_eq;
 use datafusion::from_slice::FromSlice;
 use datafusion::parquet::arrow::ArrowWriter;
 use itertools::Itertools;
+use rstest::rstest;
 use seafowl::context::{DefaultSeafowlContext, SeafowlContext};
 use std::net::SocketAddr;
 use tempfile::Builder;


### PR DESCRIPTION
Instead of buffering the entire file in memory, stream the incoming bits to a local temp file, and then scan it when appending to the target table.

Memory implications (using a [160MB parquet file](https://seafowl-public.s3.eu-west-1.amazonaws.com/tutorial/trase-supply-chains.parquet)):
- Load-file-in-memory approach (current state)
<img width="1388" alt="slika" src="https://github.com/splitgraph/seafowl/assets/45558892/f4ccc343-3b0c-4798-82f0-62deec4f367d">
- With streaming to disk (this PR)
<img width="1376" alt="slika" src="https://github.com/splitgraph/seafowl/assets/45558892/21a9d9a9-55c4-482e-a6b5-f26a8c2a7641">

In addition, bump DataFussion to post-26 version to pick up [schema coercion in Parquet reader](https://github.com/apache/arrow-datafusion/pull/6458), and thus close #179. Also add some tests demonstrating the new flexibility of the upload endpoint (implicit type casting, column skipping etc.).
