### PR TITLE
Seafowl CLI initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # Memory profiler output
 memory-profiling_*
 profile-*
+
+# CLI history
+.history

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,6 +1909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum-iterator"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +1973,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2031,17 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix 0.38.22",
+ "windows-sys",
+]
 
 [[package]]
 name = "fd-lock"
@@ -3419,6 +3457,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,6 +4403,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4978,6 +5046,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "rustyline"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock 3.0.13",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5082,6 +5173,7 @@ dependencies = [
  "rmp-serde",
  "rmpv",
  "rstest",
+ "rustyline",
  "serde",
  "serde_json",
  "serial_test",
@@ -5677,6 +5769,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
 name = "stringprep"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5809,7 +5907,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cap-fs-ext",
  "cap-std",
- "fd-lock",
+ "fd-lock 4.0.0",
  "io-lifetimes 2.0.2",
  "rustix 0.38.22",
  "windows-sys",
@@ -6284,6 +6382,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +372,21 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates 3.0.4",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -654,6 +675,17 @@ checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -3300,7 +3332,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive",
- "predicates",
+ "predicates 2.1.5",
  "predicates-tree",
 ]
 
@@ -4116,6 +4148,18 @@ dependencies = [
  "normalize-line-endings",
  "predicates-core",
  "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools 0.11.0",
+ "predicates-core",
 ]
 
 [[package]]
@@ -5139,6 +5183,7 @@ dependencies = [
  "arrow-csv",
  "arrow-integration-test",
  "arrow-schema",
+ "assert_cmd",
  "assert_unordered",
  "async-trait",
  "base64 0.21.5",
@@ -6435,6 +6480,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ bytes = "1.4.0"
 chrono = { version = "0.4", default_features = false }
 clap = { version = "3.2.19", features = [ "derive" ] }
 config = "0.13.3"
-rustyline = "12.0"
 
 # PG wire protocol support
 convergence = { git = "https://github.com/splitgraph/convergence", branch = "datafusion-32-upgrade", optional = true }
@@ -78,6 +77,7 @@ reqwest = { version = "0.11.14", features = [ "stream" ] }
 rmp = "0.8.11"
 rmp-serde = "1.1.1"
 rmpv = { version = "1.0.0", features = ["with-serde"] }
+rustyline = "12.0"
 serde = "1.0.156"
 serde_json = "1.0.93"
 sha2 = ">=0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ wasmtime = "14.0.0"
 wasmtime-wasi = "14.0.0"
 
 [dev-dependencies]
+assert_cmd = "2"
 assert_unordered = "0.3"
 mockall = "0.11.1"
 rstest = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ bytes = "1.4.0"
 chrono = { version = "0.4", default_features = false }
 clap = { version = "3.2.19", features = [ "derive" ] }
 config = "0.13.3"
+rustyline = "12.0"
 
 # PG wire protocol support
 convergence = { git = "https://github.com/splitgraph/convergence", branch = "datafusion-32-upgrade", optional = true }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,42 @@ EOF
 ...
 ```
 
+## CLI
+
+Seafowl also provides a CLI to accommodate frictionless prototyping, troubleshooting and testing of
+the core features :
+
+```bash
+$ ./seafowl --cli -c /path/to/seafowl.toml
+default> CREATE TABLE t
+AS VALUES
+(1, 'one'),
+(2, 'two');
+Time: 0.021s
+default> SELECT * FROM t;
++---------+---------+
+| column1 | column2 |
++---------+---------+
+| 1       | one     |
+| 2       | two     |
++---------+---------+
+Time: 0.009s
+default> \d t
++---------------+--------------+------------+-------------+-----------+-------------+
+| table_catalog | table_schema | table_name | column_name | data_type | is_nullable |
++---------------+--------------+------------+-------------+-----------+-------------+
+| default       | public       | t          | column1     | Int64     | YES         |
+| default       | public       | t          | column2     | Utf8      | YES         |
++---------------+--------------+------------+-------------+-----------+-------------+
+Time: 0.005s
+default> \q
+$
+```
+
+It does so by circumventing Seafowl's primary HTTP interface, which involves properly formatting
+HTTP requests with queries, authentication, as well as dealing with potentially faulty networking
+setup, which can sometimes be too tedious for a quick manual interactive session.
+
 ## Documentation
 
 See the [documentation](https://www.splitgraph.com/docs/seafowl/getting-started/introduction) for

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ EOF
 ## CLI
 
 Seafowl also provides a CLI to accommodate frictionless prototyping, troubleshooting and testing of
-the core features :
+the core features:
 
 ```bash
 $ ./seafowl --cli -c /path/to/seafowl.toml
@@ -145,9 +145,9 @@ default> \q
 $
 ```
 
-It does so by circumventing Seafowl's primary HTTP interface, which involves properly formatting
-HTTP requests with queries, authentication, as well as dealing with potentially faulty networking
-setup, which can sometimes be too tedious for a quick manual interactive session.
+It does so by circumventing Seafowl's primary HTTP interface, which involves properly formatted HTTP
+requests with queries, authentication, as well as dealing with potentially faulty networking setups,
+and can sometimes be too tedious for a quick manual interactive session.
 
 ## Documentation
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,0 +1,30 @@
+use std::str::FromStr;
+
+
+/// Commands available inside the CLI
+#[derive(Debug)]
+pub enum Command {
+    Quit,
+    Help,
+    ListTables,
+    DescribeTable(String),
+}
+
+impl FromStr for Command {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (c, arg) = if let Some((a, b)) = s.split_once(' ') {
+            (a, Some(b))
+        } else {
+            (s, None)
+        };
+        Ok(match (c, arg) {
+            ("q", None) | ("quit", None) => Self::Quit,
+            ("d", None) => Self::ListTables,
+            ("d", Some(name)) => Self::DescribeTable(name.into()),
+            ("?", None) => Self::Help,
+            _ => return Err(()),
+        })
+    }
+}

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,6 +1,5 @@
 use std::str::FromStr;
 
-
 /// Commands available inside the CLI
 #[derive(Debug)]
 pub enum Command {

--- a/src/cli/helper.rs
+++ b/src/cli/helper.rs
@@ -13,12 +13,8 @@ pub struct CliHelper {}
 // The accompanying helper for SeafowlCli.
 // For now only supports multi-line statements through the `Validator` override.
 impl CliHelper {
-    #[allow(clippy::if_same_then_else)]
     fn validate_input(&self, input: &str) -> Result<ValidationResult> {
-        if input.ends_with(';') {
-            // TODO: actually perform validation here
-            Ok(ValidationResult::Valid(None))
-        } else if input.starts_with('\\') {
+        if input.ends_with(';') || input.starts_with('\\') {
             // command
             Ok(ValidationResult::Valid(None))
         } else {

--- a/src/cli/helper.rs
+++ b/src/cli/helper.rs
@@ -1,0 +1,47 @@
+use rustyline::completion::Completer;
+use rustyline::completion::Pair;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::ValidationContext;
+use rustyline::validate::ValidationResult;
+use rustyline::validate::Validator;
+use rustyline::Helper;
+use rustyline::Result;
+
+pub struct CliHelper {}
+
+// The accompanying helper for SeafowlCli.
+// For now only supports multi-line statements through the `Validator` override.
+impl CliHelper {
+    fn validate_input(&self, input: &str) -> Result<ValidationResult> {
+        if input.ends_with(';') {
+            // TODO: actually perform validation here
+            Ok(ValidationResult::Valid(None))
+        } else if input.starts_with('\\') {
+            // command
+            Ok(ValidationResult::Valid(None))
+        } else {
+            Ok(ValidationResult::Incomplete)
+        }
+    }
+}
+
+impl Highlighter for CliHelper {}
+
+impl Hinter for CliHelper {
+    type Hint = String;
+}
+
+
+impl Completer for CliHelper {
+    type Candidate = Pair;
+}
+
+impl Validator for CliHelper {
+    fn validate(&self, ctx: &mut ValidationContext<'_>) -> Result<ValidationResult> {
+        let input = ctx.input().trim_end();
+        self.validate_input(input)
+    }
+}
+
+impl Helper for CliHelper {}

--- a/src/cli/helper.rs
+++ b/src/cli/helper.rs
@@ -13,6 +13,7 @@ pub struct CliHelper {}
 // The accompanying helper for SeafowlCli.
 // For now only supports multi-line statements through the `Validator` override.
 impl CliHelper {
+    #[allow(clippy::if_same_then_else)]
     fn validate_input(&self, input: &str) -> Result<ValidationResult> {
         if input.ends_with(';') {
             // TODO: actually perform validation here
@@ -31,7 +32,6 @@ impl Highlighter for CliHelper {}
 impl Hinter for CliHelper {
     type Hint = String;
 }
-
 
 impl Completer for CliHelper {
     type Candidate = Pair;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,111 @@
+mod commands;
+mod helper;
+
+use crate::context::{DefaultSeafowlContext, SeafowlContext};
+use arrow::util::pretty::pretty_format_batches_with_options;
+use datafusion_common::Result;
+use rustyline::{error::ReadlineError, Editor};
+use std::sync::Arc;
+use std::time::Instant;
+use commands::Command;
+use helper::CliHelper;
+
+
+pub struct SeafowlCli {
+    ctx: Arc<DefaultSeafowlContext>
+}
+
+impl SeafowlCli {
+    // Instantiate new CLI instance
+    pub fn new(ctx: Arc<DefaultSeafowlContext>) -> Self {
+        SeafowlCli { ctx }
+    }
+
+    // Interactive loop for running commands from a CLI
+    pub async fn repl_loop(&self) -> rustyline::Result<()> {
+        let mut rl = Editor::new()?;
+        rl.set_helper(Some(CliHelper {}));
+        rl.load_history(".history").ok();
+
+        loop {
+            match rl.readline(format!("{}> ", self.ctx.database).as_str()) {
+                Ok(line) if line.starts_with('\\') => {
+                    rl.add_history_entry(line.trim_end())?;
+                    let command = line.split_whitespace().collect::<Vec<_>>().join(" ");
+                    if let Ok(cmd) = &command[1..].parse::<Command>() {
+                        match cmd {
+                            Command::Quit => break,
+                            _ => {
+                                if let Err(e) = self.handle_command(&cmd).await {
+                                    eprintln!("{e}")
+                                }
+                            }
+                        }
+                    } else {
+                        eprintln!("'\\{}' is not a valid command", &line[1..]);
+                    }
+                }
+                Ok(line) => {
+                    rl.add_history_entry(line.trim_end())?;
+
+                    match self.exec_and_print(&line).await {
+                        Ok(_) => {}
+                        Err(err) => eprintln!("{err}"),
+                    }
+                }
+                Err(ReadlineError::Interrupted) => {
+                    println!("^C");
+                    continue;
+                }
+                Err(ReadlineError::Eof) => {
+                    println!("\\q");
+                    break;
+                }
+                Err(err) => {
+                    eprintln!("Error while reading input: {err:?}", );
+                    break;
+                }
+            }
+        }
+
+        rl.save_history(".history")
+    }
+
+    // Handle a client command
+    async fn handle_command(&self, cmd: &Command) -> Result<()> {
+        match cmd {
+            Command::Help => todo!(),
+            Command::ListTables => self.exec_and_print("SHOW TABLES").await,
+            Command::DescribeTable(name) => self.exec_and_print(&format!("SHOW COLUMNS FROM {name}")).await,
+            Command::Quit => panic!("Unexpected quit, this should be handled in the repl loop"),
+        }
+    }
+
+    // Execute provided statement(s) and print the output
+    async fn exec_and_print(&self, query: &str) -> Result<()> {
+        let now = Instant::now();
+        // Parse queries into statements
+        let statements = self.ctx.parse_query(query).await?;
+
+        // Generate physical plans from the statements
+        let mut plans = vec![];
+        for statement in statements {
+            let logical = self.ctx.create_logical_plan_from_statement(statement).await?;
+            plans.push(self.ctx.create_physical_plan(&logical).await?);
+        }
+
+        // Collect batches and print them
+        for plan in plans {
+            let batches = self.ctx.collect(plan).await?;
+            if !batches.is_empty() {
+                println!(
+                    "{}",
+                    pretty_format_batches_with_options(&batches, &Default::default())?
+                );
+            }
+        }
+        println!("Time: {:.3}s", now.elapsed().as_secs_f64());
+
+        Ok(())
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,8 @@ use rustyline::{error::ReadlineError, Editor};
 use std::sync::Arc;
 use std::time::Instant;
 
+const SEAFOWL_CLI_HISTORY: &str = ".history";
+
 pub struct SeafowlCli {
     ctx: Arc<DefaultSeafowlContext>,
 }
@@ -22,10 +24,10 @@ impl SeafowlCli {
     }
 
     // Interactive loop for running commands from a CLI
-    pub async fn repl_loop(&self) -> rustyline::Result<()> {
+    pub async fn command_loop(&self) -> rustyline::Result<()> {
         let mut rl = Editor::new()?;
         rl.set_helper(Some(CliHelper {}));
-        rl.load_history(".history").ok();
+        rl.load_history(SEAFOWL_CLI_HISTORY).ok();
 
         loop {
             match rl.readline(format!("{}> ", self.ctx.database).as_str()) {
@@ -68,7 +70,7 @@ impl SeafowlCli {
             }
         }
 
-        rl.save_history(".history")
+        rl.save_history(SEAFOWL_CLI_HISTORY)
     }
 
     // Handle a client command

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod helper;
 
+use crate::cli::commands::all_commands_info;
 use crate::context::{DefaultSeafowlContext, SeafowlContext};
 use arrow::util::pretty::pretty_format_batches_with_options;
 use commands::Command;
@@ -73,7 +74,14 @@ impl SeafowlCli {
     // Handle a client command
     async fn handle_command(&self, cmd: &Command) -> Result<()> {
         match cmd {
-            Command::Help => todo!(),
+            Command::Help => {
+                let help = all_commands_info();
+                println!(
+                    "{}",
+                    pretty_format_batches_with_options(&[help], &Default::default())?
+                );
+                Ok(())
+            }
             Command::ListTables => self.exec_and_print("SHOW TABLES").await,
             Command::DescribeTable(name) => {
                 self.exec_and_print(&format!("SHOW COLUMNS FROM {name}"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod auth;
 pub mod catalog;
+pub mod cli;
 pub mod config;
 pub mod context;
 pub mod data_types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ async fn main() {
         run_one_off_command(context, &one_off_cmd, io::stdout()).await;
         return;
     } else if args.cli {
-        return cli::SeafowlCli::new(context).repl_loop().await.unwrap();
+        return cli::SeafowlCli::new(context).command_loop().await.unwrap();
     }
 
     // Ref: https://tokio.rs/tokio/topics/shutdown#waiting-for-things-to-finish-shutting-down

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use futures::{future::join_all, Future, FutureExt};
 
 use pretty_env_logger::env_logger;
 use seafowl::{
+    cli,
     config::{
         context::build_context,
         schema::{build_default_config, load_config, SeafowlConfig, DEFAULT_DATA_DIR},
@@ -52,6 +53,13 @@ struct Args {
 
     #[clap(short, long, help = "Run a one-off command and exit")]
     one_off: Option<String>,
+
+    #[clap(
+        long,
+        help = "Run commands interactively from a CLI",
+        takes_value = false
+    )]
+    cli: bool,
 }
 
 fn prepare_frontends(
@@ -135,15 +143,17 @@ async fn main() {
         return;
     }
 
-    let mut builder = pretty_env_logger::formatted_timed_builder();
+    if !args.cli {
+        let mut builder = pretty_env_logger::formatted_timed_builder();
 
-    builder
-        .parse_filters(
-            env::var(env_logger::DEFAULT_FILTER_ENV)
-                .unwrap_or_else(|_| "sqlx=warn,info".to_string())
-                .as_str(),
-        )
-        .init();
+        builder
+            .parse_filters(
+                env::var(env_logger::DEFAULT_FILTER_ENV)
+                    .unwrap_or_else(|_| "sqlx=warn,info".to_string())
+                    .as_str(),
+            )
+            .init();
+    }
 
     info!("Starting Seafowl {}", env!("VERGEN_BUILD_SEMVER"));
 
@@ -173,7 +183,9 @@ async fn main() {
     if let Some(one_off_cmd) = args.one_off {
         run_one_off_command(context, &one_off_cmd, io::stdout()).await;
         return;
-    };
+    } else if args.cli {
+        return cli::SeafowlCli::new(context).repl_loop().await.unwrap();
+    }
 
     // Ref: https://tokio.rs/tokio/topics/shutdown#waiting-for-things-to-finish-shutting-down
     let (shutdown, _) = channel(1);

--- a/tests/cli/basic.rs
+++ b/tests/cli/basic.rs
@@ -69,6 +69,18 @@ fn test_cli_basic() -> std::io::Result<()> {
     ]);
 
     // Test some commands
+    writeln!(stdin, "\\?")?;
+    expected_stdout.extend(vec![
+        "+---------+------------------+",
+        "| Command | Description      |",
+        "+---------+------------------+",
+        "| \\q      | quit seafowl cli |",
+        "| \\?      | help             |",
+        "| \\d      | list tables      |",
+        "| \\d name | describe table   |",
+        "+---------+------------------+",
+    ]);
+
     writeln!(stdin, "\\d")?;
     expected_stdout.extend(vec![
         "+---------------+--------------------+----------------+------------+",

--- a/tests/cli/basic.rs
+++ b/tests/cli/basic.rs
@@ -1,0 +1,151 @@
+use crate::cli::*;
+
+// Seems like we can't read from stdout until we close stdin, at which point we can no longer
+// enter any commands.
+// Consequently, the test is structured such that we first issue all te commands and only then
+// do we assert on the output.
+#[test]
+fn test_cli_basic() -> std::io::Result<()> {
+    let temp_dir = setup_temp_config_and_data_dir()?;
+    let mut cmd = Command::cargo_bin("seafowl").expect("Seafowl bin exists");
+    cmd.arg("--cli")
+        .arg("-c")
+        .arg(temp_dir.path().join(TEST_CONFIG_FILE))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+
+    //
+    // First run all the input commands
+    //
+
+    // Send input to the command through stdin
+    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+    let mut expected_stdout: Vec<&str> = vec![];
+    let mut expected_stderr: Vec<&str> = vec![];
+
+    // Test a basic SELECT
+    writeln!(&stdin, "SELECT 'Hello World';")?;
+    expected_stdout.extend(vec![
+        "+---------------------+",
+        "| Utf8(\"Hello World\") |",
+        "+---------------------+",
+        "| Hello World         |",
+        "+---------------------+",
+    ]);
+
+    // Hit a missing table error
+    writeln!(stdin, "SELECT * FROM t;")?;
+    expected_stderr.push("Error during planning: table 'default.public.t' not found");
+
+    // Test multi-line query and create the table
+    writeln!(stdin, "CREATE TABLE t")?;
+    writeln!(stdin, "AS VALUES")?;
+    writeln!(stdin, "(1, 'one'),")?;
+    writeln!(stdin, "(2, 'two');")?;
+
+    // Hit syntax error
+    writeln!(stdin, "SELECT * FRM t;")?;
+    expected_stderr
+        .push("SQL error: ParserError(\"Expected end of statement, found: FRM\")");
+
+    // Now actually select from it and test multi-query execution
+    writeln!(stdin, "SELECT column1 FROM t; SELECT column2 FROM t;")?;
+    expected_stdout.extend(vec![
+        "+---------+",
+        "| column1 |",
+        "+---------+",
+        "| 1       |",
+        "| 2       |",
+        "+---------+",
+        "+---------+",
+        "| column2 |",
+        "+---------+",
+        "| one     |",
+        "| two     |",
+        "+---------+",
+    ]);
+
+    // Test some commands
+    writeln!(stdin, "\\d")?;
+    expected_stdout.extend(vec![
+        "+---------------+--------------------+----------------+------------+",
+        "| table_catalog | table_schema       | table_name     | table_type |",
+        "+---------------+--------------------+----------------+------------+",
+        "| default       | public             | t              | BASE TABLE |",
+        "| default       | system             | table_versions | VIEW       |",
+        "| default       | system             | dropped_tables | VIEW       |",
+        "| default       | information_schema | tables         | VIEW       |",
+        "| default       | information_schema | views          | VIEW       |",
+        "| default       | information_schema | columns        | VIEW       |",
+        "| default       | information_schema | df_settings    | VIEW       |",
+        "+---------------+--------------------+----------------+------------+",
+    ]);
+
+    writeln!(stdin, "\\d t")?;
+    expected_stdout.extend(
+        vec![
+            "+---------------+--------------+------------+-------------+-----------+-------------+",
+            "| table_catalog | table_schema | table_name | column_name | data_type | is_nullable |",
+            "+---------------+--------------+------------+-------------+-----------+-------------+",
+            "| default       | public       | t          | column1     | Int64     | YES         |",
+            "| default       | public       | t          | column2     | Utf8      | YES         |",
+            "+---------------+--------------+------------+-------------+-----------+-------------+",
+        ]
+    );
+
+    // Close the CLI
+    // NB: if we hadn't done it like this we'd need to call drop(stdin), since otherwise the
+    // test would hang.
+    writeln!(stdin, "\\q")?;
+
+    //
+    // Now examine the actual output and assert on expected values
+    //
+
+    let stdout = child.stdout.take().expect("Failed to open stdout");
+    let reader = BufReader::new(stdout);
+
+    // Read out all the lines from stdout
+    let mut actual = vec![];
+    for line in reader.lines() {
+        let l = line?;
+        // Don't assert on the timing info since that is not deterministic
+        if !l.starts_with("Time: ") {
+            actual.push(l);
+        }
+    }
+
+    assert_eq!(
+        expected_stdout, actual,
+        "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
+        expected_stdout, actual
+    );
+
+    //
+    // Finally examine the errors
+    //
+
+    let stderr = child.stderr.take().expect("Failed to open stderr");
+    let reader = BufReader::new(stderr);
+
+    // Read out all the lines from stderr
+    let mut actual = vec![];
+    for line in reader.lines() {
+        actual.push(line?);
+    }
+
+    assert_eq!(
+        expected_stderr, actual,
+        "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
+        expected_stderr, actual
+    );
+
+    // Wait for the command to finish
+    let status = child.wait().expect("Failed to wait for command");
+    assert!(status.success());
+
+    Ok(())
+}

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -1,0 +1,44 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use seafowl::config::schema::DEFAULT_SQLITE_DB;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Command, Stdio}; // Run programs
+use tempfile::{Builder, TempDir};
+
+mod basic;
+
+const TEST_CONFIG_FILE: &str = "seafowl-test.toml";
+
+fn setup_temp_config_and_data_dir() -> std::io::Result<TempDir> {
+    let temp_dir = Builder::new()
+        .prefix("seafowl-test-dir")
+        .rand_bytes(5)
+        .tempdir()?;
+
+    let file_path = temp_dir.path().join(TEST_CONFIG_FILE);
+    let mut conf_file = File::create(file_path)?;
+
+    let dsn = Path::new(&temp_dir.path().display().to_string())
+        .join(DEFAULT_SQLITE_DB)
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let config_str = format!(
+        r#"
+[object_store]
+type = "local"
+data_dir = "{}"
+
+[catalog]
+type = "sqlite"
+dsn = "{}"
+"#,
+        temp_dir.path().display(),
+        dsn.escape_default(),
+    );
+
+    write!(conf_file, "{}", config_str)?;
+    Ok(temp_dir)
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,5 +1,6 @@
 // Single main.rs for all integration tests
 // https://endler.dev/2020/rust-compile-times/#combine-all-integration-tests-in-a-single-binary
 
+mod cli;
 mod http;
 mod statements;


### PR DESCRIPTION
Add a basic CLI implementation  that supports searchable history, multi-line comments and multi-statement queries:

```bash
gruuya@markogrujics-MacBook-Pro seafowl % cargo run -- --cli                                            
   Compiling seafowl v0.5.2 (/Users/gruuya/Splitgraph/seafowl)
    Finished dev [unoptimized + debuginfo] target(s) in 5.06s
     Running `target/debug/seafowl --cli`
default> create table t as values (1, 'one'), (2, 'two');
Error during planning: Table "t" already exists
default> drop table t;
Time: 0.006s
default> create table t as values (1, 'one'), (2, 'two');
Time: 0.023s
default> select *
from t
where column1 > 1;
+---------+---------+
| column1 | column2 |
+---------+---------+
| 2       | two     |
+---------+---------+
Time: 0.024s
default> select column1 from t; select column2 from t;
+---------+
| column1 |
+---------+
| 1       |
| 2       |
+---------+
+---------+
| column2 |
+---------+
| one     |
| two     |
+---------+
Time: 0.018s
```

Validation and highlighting can be covered separately.

Closes #467