### PR TITLE
Convert to Delta table support

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
+use arrow_schema::Schema;
 use async_trait::async_trait;
 use datafusion::catalog::schema::MemorySchemaProvider;
 use datafusion::datasource::TableProvider;
@@ -27,7 +28,6 @@ use crate::{
         AllDatabaseColumnsResult, AllDatabaseFunctionsResult, Error as RepositoryError,
         Repository, TableVersionsResult,
     },
-    schema::Schema,
 };
 
 pub const DEFAULT_DB: &str = "default";

--- a/src/context/delta.rs
+++ b/src/context/delta.rs
@@ -274,7 +274,7 @@ pub async fn plan_to_object_store(
 }
 
 pub(super) enum CreateDeltaTableDetails {
-    WithSchema(Schema),
+    EmptyTable(Schema),
     FromPath(Path),
 }
 
@@ -300,7 +300,7 @@ impl SeafowlContext {
         // NB: there's also a uuid generated below for table's `DeltaTableMetaData::id`, so it would
         // be nice if those two could match somehow
         let (table_uuid, table) = match details {
-            CreateDeltaTableDetails::WithSchema(schema) => {
+            CreateDeltaTableDetails::EmptyTable(schema) => {
                 // TODO: we could be doing this inside the DB itself (i.e. `... DEFAULT gen_random_uuid()`
                 // in Postgres and `... DEFAULT (uuid())` in SQLite) however we won't be able to do it until
                 // sqlx 0.7 is released (which has libsqlite3-sys > 0.25, with the SQLite version that has

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -556,7 +556,7 @@ impl SeafowlContext {
                         }) => {
                             self.create_delta_table(
                                 name,
-                                CreateDeltaTableDetails::FromFiles(Path::from(
+                                CreateDeltaTableDetails::FromPath(Path::from(
                                     location.as_str(),
                                 )),
                             )

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -230,7 +230,7 @@ impl SeafowlContext {
                 // only one
                 self.create_delta_table(
                     name,
-                    CreateDeltaTableDetails::WithSchema(plan.schema().as_ref().clone()),
+                    CreateDeltaTableDetails::EmptyTable(plan.schema().as_ref().clone()),
                 )
                 .await?;
                 self.plan_to_delta_table(name, &plan).await?;
@@ -571,7 +571,7 @@ impl SeafowlContext {
                         }) => {
                             self.create_delta_table(
                                 name.as_str(),
-                                CreateDeltaTableDetails::WithSchema(schema.clone()),
+                                CreateDeltaTableDetails::EmptyTable(schema.clone()),
                             )
                             .await?;
 
@@ -896,7 +896,7 @@ impl SeafowlContext {
         if !table_exists {
             self.create_delta_table(
                 table_ref.clone(),
-                CreateDeltaTableDetails::WithSchema(plan.schema().as_ref().clone()),
+                CreateDeltaTableDetails::EmptyTable(plan.schema().as_ref().clone()),
             )
             .await?;
         }

--- a/src/repository/default.rs
+++ b/src/repository/default.rs
@@ -239,10 +239,16 @@ impl Repository for $repo {
 
         // Create columns
         // TODO this breaks if we have more than (bind limit) columns
-        if !schema.arrow_schema.fields().is_empty() {
+        if !schema.fields().is_empty() {
             let mut builder: QueryBuilder<_> =
                 QueryBuilder::new("INSERT INTO table_column(table_version_id, name, type) ");
-            builder.push_values(schema.to_column_names_types(), |mut b, col| {
+
+            let fields: Vec<(String, String)> = schema.fields()
+                .iter()
+                .map(|f| (f.name().clone(), field_to_json(f).to_string()))
+                .collect();
+
+            builder.push_values(fields, |mut b, col| {
                 b.push_bind(new_version_id)
                     .push_bind(col.0)
                     .push_bind(col.1);

--- a/src/repository/postgres.rs
+++ b/src/repository/postgres.rs
@@ -1,5 +1,7 @@
 use std::{fmt::Debug, time::Duration};
 
+use arrow_integration_test::field_to_json;
+use arrow_schema::Schema;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use sqlx::{
@@ -12,7 +14,6 @@ use uuid::Uuid;
 use crate::{
     data_types::{CollectionId, DatabaseId, FunctionId, TableId, TableVersionId},
     implement_repository,
-    schema::Schema,
     wasm_udf::data_types::CreateFunctionDetails,
 };
 

--- a/src/repository/sqlite.rs
+++ b/src/repository/sqlite.rs
@@ -1,5 +1,7 @@
 use std::{fmt::Debug, str::FromStr};
 
+use arrow_integration_test::field_to_json;
+use arrow_schema::Schema;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use sqlx::sqlite::SqliteJournalMode;
@@ -12,7 +14,6 @@ use uuid::Uuid;
 
 use crate::{
     data_types::{CollectionId, DatabaseId, FunctionId, TableId, TableVersionId},
-    schema::Schema,
     wasm_udf::data_types::CreateFunctionDetails,
 };
 

--- a/tests/statements/convert.rs
+++ b/tests/statements/convert.rs
@@ -1,0 +1,75 @@
+use crate::statements::*;
+
+#[tokio::test]
+async fn test_convert_from_flat_parquet_table() -> Result<(), DataFusionError> {
+    let (context, maybe_test_dir) = make_context_with_pg(ObjectStoreType::Local).await;
+
+    // Prepare a flat Parquet table
+    let table_uuid = Uuid::new_v4();
+    let temp_dir = maybe_test_dir.expect("temporary data dir exists");
+    let table_path = temp_dir.path().join(table_uuid.to_string());
+    // Create the directory as otherwise the COPY will fail
+    create_dir(table_path.clone()).await?;
+
+    // COPY some values multiple times to test converting flat table with more than one parquet file
+    context
+        .plan_query(&format!(
+            "COPY (VALUES (1, 'one'), (2, 'two')) TO '{}/file_1.parquet'",
+            table_path.display()
+        ))
+        .await?;
+    context
+        .plan_query(&format!(
+            "COPY (VALUES (3, 'three'), (4, 'four')) TO '{}/file_2.parquet'",
+            table_path.display()
+        ))
+        .await?;
+    context
+        .plan_query(&format!(
+            "COPY (VALUES (5, 'five'), (6, 'six')) TO '{}/file_3.parquet'",
+            table_path.display()
+        ))
+        .await?;
+
+    // Now test the actual conversion
+    context
+        .plan_query(&format!("CONVERT '{table_uuid}' TO DELTA table_converted"))
+        .await?;
+
+    // Finally test the contents of the converted table
+    let plan = context
+        .plan_query("SELECT * FROM table_converted ORDER BY column1")
+        .await?;
+    let results = context.collect(plan).await.unwrap();
+
+    let expected = [
+        "+---------+---------+",
+        "| column1 | column2 |",
+        "+---------+---------+",
+        "| 1       | one     |",
+        "| 2       | two     |",
+        "| 3       | three   |",
+        "| 4       | four    |",
+        "| 5       | five    |",
+        "| 6       | six     |",
+        "+---------+---------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    // Also check the final directory state
+    testutils::assert_uploaded_objects(
+        context
+            .internal_object_store
+            .get_log_store(table_uuid)
+            .object_store(),
+        vec![
+            Path::from("_delta_log/00000000000000000000.json"),
+            Path::from("file_1.parquet"),
+            Path::from("file_2.parquet"),
+            Path::from("file_3.parquet"),
+        ],
+    )
+    .await;
+
+    Ok(())
+}

--- a/tests/statements/mod.rs
+++ b/tests/statements/mod.rs
@@ -17,7 +17,9 @@ use serde_json::json;
 use sqlx::{any::install_default_drivers, AnyPool, Executor};
 #[cfg(feature = "remote-tables")]
 use tempfile::{NamedTempFile, TempPath};
+use tokio::fs::create_dir;
 use tokio::time::sleep;
+use uuid::Uuid;
 
 use rstest::rstest;
 use tempfile::TempDir;
@@ -34,6 +36,7 @@ mod dml;
 mod query;
 // Hack because integration tests do not set cfg(test)
 // https://users.rust-lang.org/t/sharing-helper-function-between-unit-and-integration-tests/9941/2
+mod convert;
 #[allow(dead_code)]
 #[path = "../../src/testutils.rs"]
 mod testutils;


### PR DESCRIPTION
Convert a parquet table, as specified by a particular path, into a Delta table. Syntax closely follows that of [Databricks](https://docs.databricks.com/en/sql/language-manual/delta-convert-to-delta.html).

- The present implementation supports only in-place conversion, meaning that the Parquet table should be stored in a UUID dir inside the object store root (meaning bucket + any prefix).
- Note that delta-rs [doesn't support](https://github.com/delta-io/delta-rs/blob/733b5ffdde99cbfb256b8f69ae4529aeb1174599/crates/deltalake-core/src/operations/convert_to_delta.rs#L245-L248) appending/overwriting existing tables for now.
- This also lacks support for partitioned parquet tables—those could in principle be supported by extending the proposed syntax to allow passing the partitioning scheme, but since we don't yet support partitioned tables in general (see #476) I have opted out of that.
- Finally one other thing that's missing support is on-the-fly casting/coercion to delta supported arrow types subset. In other words if a Parquet file contains timestamp columns with s, ms or ns resolution this will error out.

Closes #469.