### PR TITLE
Implement a crude replacement for SET search_path in Flight SQL frontend

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -30,7 +30,7 @@ impl SeafowlCli {
         rl.load_history(SEAFOWL_CLI_HISTORY).ok();
 
         loop {
-            match rl.readline(format!("{}> ", self.ctx.database).as_str()) {
+            match rl.readline(format!("{}> ", self.ctx.default_catalog).as_str()) {
                 Ok(line) if line.starts_with('\\') => {
                     rl.add_history_entry(line.trim_end())?;
                     let command = line.split_whitespace().collect::<Vec<_>>().join(" ");

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -208,7 +208,8 @@ pub async fn build_context(cfg: &schema::SeafowlConfig) -> Result<SeafowlContext
         inner: context,
         metastore: Arc::new(metastore),
         internal_object_store,
-        database: DEFAULT_DB.to_string(),
+        default_catalog: DEFAULT_DB.to_string(),
+        default_schema: DEFAULT_SCHEMA.to_string(),
         max_partition_size: cfg.misc.max_partition_size,
     })
 }

--- a/src/frontend/flight/sql.rs
+++ b/src/frontend/flight/sql.rs
@@ -81,7 +81,7 @@ impl FlightSqlService for SeafowlFlightHandler {
         let query_id = Uuid::new_v4().to_string();
 
         let schema = self
-            .query_to_stream(&query.query, query_id.clone())
+            .query_to_stream(&query.query, query_id.clone(), request.metadata())
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -159,8 +159,8 @@ pub async fn uncached_read_write_query(
 
     // If a specific DB name was used as a parameter in the route, scope the context to it,
     // effectively making it the default DB for the duration of the session.
-    if database_name != context.database {
-        context = context.scope_to_database(database_name);
+    if database_name != context.default_catalog {
+        context = context.scope_to_catalog(database_name);
     }
 
     let statements = context.parse_query(&query).await?;
@@ -324,8 +324,8 @@ pub async fn cached_read_query(
 
     // If a specific DB name was used as a parameter in the route, scope the context to it,
     // effectively making it the default DB for the duration of the session.
-    if database_name != context.database {
-        context = context.scope_to_database(database_name);
+    if database_name != context.default_catalog {
+        context = context.scope_to_catalog(database_name);
     }
 
     // Plan the query
@@ -382,8 +382,8 @@ pub async fn upload(
         return Err(ApiError::WriteForbidden);
     };
 
-    if database_name != context.database {
-        context = context.scope_to_database(database_name.clone());
+    if database_name != context.default_catalog {
+        context = context.scope_to_catalog(database_name.clone());
     }
 
     let mut has_header = true;
@@ -661,7 +661,7 @@ pub mod tests {
                 .await
                 .unwrap();
 
-            context = context.scope_to_database(db_name.to_string());
+            context = context.scope_to_catalog(db_name.to_string());
         }
 
         context
@@ -676,7 +676,7 @@ pub mod tests {
 
         if new_db.is_some() {
             // Re-scope to the original DB
-            return context.scope_to_database(DEFAULT_DB.to_string());
+            return context.scope_to_catalog(DEFAULT_DB.to_string());
         }
 
         context
@@ -688,7 +688,7 @@ pub mod tests {
         let mut context = in_memory_context_with_single_table(new_db).await;
 
         if let Some(db_name) = new_db {
-            context = context.scope_to_database(db_name.to_string());
+            context = context.scope_to_catalog(db_name.to_string());
         }
 
         context
@@ -698,7 +698,7 @@ pub mod tests {
 
         if new_db.is_some() {
             // Re-scope to the original DB
-            return context.scope_to_database(DEFAULT_DB.to_string());
+            return context.scope_to_catalog(DEFAULT_DB.to_string());
         }
 
         context

--- a/tests/flight/client.rs
+++ b/tests/flight/client.rs
@@ -1,30 +1,5 @@
 use crate::flight::*;
 
-async fn get_flight_batches(
-    client: &mut FlightClient,
-    query: String,
-) -> Result<Vec<RecordBatch>> {
-    let cmd = CommandStatementQuery {
-        query,
-        transaction_id: None,
-    };
-    let request = FlightDescriptor::new_cmd(cmd.as_any().encode_to_vec());
-    let response = client.get_flight_info(request).await?;
-
-    // Get the returned ticket
-    let ticket = response.endpoint[0]
-        .ticket
-        .clone()
-        .expect("expected ticket");
-
-    // Retrieve the corresponding Flight stream and collect into batches
-    let flight_stream = client.do_get(ticket).await?;
-
-    let batches = flight_stream.try_collect().await?;
-
-    Ok(batches)
-}
-
 #[tokio::test]
 async fn test_basic_queries() -> Result<()> {
     let (context, addr, flight) = start_flight_server().await;

--- a/tests/flight/search_path.rs
+++ b/tests/flight/search_path.rs
@@ -1,0 +1,52 @@
+use crate::flight::*;
+
+#[tokio::test]
+async fn test_default_schema_override(
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let (context, addr, flight) = start_flight_server().await;
+
+    context.plan_query("CREATE SCHEMA some_schema").await?;
+    create_table_and_insert(context.as_ref(), "some_schema.flight_table").await;
+    tokio::task::spawn(flight);
+
+    let mut client = create_flight_client(addr).await;
+
+    // Trying to run the query without the search_path set will error out
+    let err = get_flight_batches(&mut client, "SELECT * FROM flight_table".to_string())
+        .await
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("table 'default.public.flight_table' not found"));
+
+    // Now set the search_path header and re-run the query
+    client
+        .metadata_mut()
+        .insert("search-path", MetadataValue::from_static("some_schema"));
+
+    let results =
+        get_flight_batches(&mut client, "SELECT * FROM flight_table".to_string()).await?;
+
+    let expected = [
+        "+---------------------+------------+------------------+-----------------+----------------+",
+        "| some_time           | some_value | some_other_value | some_bool_value | some_int_value |",
+        "+---------------------+------------+------------------+-----------------+----------------+",
+        "| 2022-01-01T20:01:01 | 42.0       | 1.0000000000     |                 | 1111           |",
+        "| 2022-01-01T20:02:02 | 43.0       | 1.0000000000     |                 | 2222           |",
+        "| 2022-01-01T20:03:03 | 44.0       | 1.0000000000     |                 | 3333           |",
+        "+---------------------+------------+------------------+-----------------+----------------+",
+    ];
+
+    assert_batches_eq!(expected, &results);
+
+    // Finally, client needs to remove the header explicitly to avoid default schema override
+    client.metadata_mut().remove("search-path");
+    let err = get_flight_batches(&mut client, "SELECT * FROM flight_table".to_string())
+        .await
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("table 'default.public.flight_table' not found"));
+
+    Ok(())
+}

--- a/tests/http/upload.rs
+++ b/tests/http/upload.rs
@@ -113,7 +113,7 @@ async fn test_upload_base(
 
     // Verify the newly created table contents
     if let Some(db_name) = db_prefix {
-        context = context.scope_to_database(db_name.to_string());
+        context = context.scope_to_catalog(db_name.to_string());
     }
     let plan = context
         .plan_query(format!("SELECT * FROM test_upload.{table_name}").as_str())


### PR DESCRIPTION
Closes #487 

Instead of adding a support for statement, enable equivalent functionality via tonic metadata values (gRPC request headers).