### PR TITLE
Add support for public S3 buckets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,10 @@ services:
       /usr/bin/mc rm -r --force test-minio/seafowl-test-bucket;  /usr/bin/mc mb
       test-minio/seafowl-test-bucket; /usr/bin/mc cp test-data/table_with_ns_column.parquet
       test-minio/seafowl-test-bucket/table_with_ns_column.parquet; /usr/bin/mc anonymous set public
-      test-minio/seafowl-test-bucket/table_with_ns_column.parquet; exit 0; "
+      test-minio/seafowl-test-bucket/table_with_ns_column.parquet; 
+
+      /usr/bin/mc mb test-minio/seafowl-test-bucket-public; /usr/bin/mc anonymous set public
+      test-minio/seafowl-test-bucket-public; exit 0; "
 
   fake-gcs:
     image: tustvold/fake-gcs-server

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -102,14 +102,22 @@ pub fn build_object_store(
             ..
         }) => {
             let mut builder = AmazonS3Builder::new()
-                .with_access_key_id(access_key_id)
-                .with_secret_access_key(secret_access_key)
                 .with_region(region.clone().unwrap_or_default())
                 .with_bucket_name(bucket)
                 .with_allow_http(true);
 
             if let Some(endpoint) = endpoint {
                 builder = builder.with_endpoint(endpoint);
+            }
+
+            if let (Some(access_key_id), Some(secret_access_key)) =
+                (&access_key_id, &secret_access_key)
+            {
+                builder = builder
+                    .with_access_key_id(access_key_id)
+                    .with_secret_access_key(secret_access_key)
+            } else {
+                builder = builder.with_skip_signature(true)
             }
 
             let store = builder.build()?;

--- a/src/object_store/wrapped.rs
+++ b/src/object_store/wrapped.rs
@@ -358,8 +358,8 @@ mod tests {
     ) -> Result<()> {
         let config = ObjectStore::S3(S3 {
             region: None,
-            access_key_id: "access_key_id".to_string(),
-            secret_access_key: "secret_access_key".to_string(),
+            access_key_id: Some("access_key_id".to_string()),
+            secret_access_key: Some("secret_access_key".to_string()),
             bucket: bucket.to_string(),
             prefix: prefix.map(|p| p.to_string()),
             endpoint: endpoint.clone(),

--- a/tests/statements/ddl.rs
+++ b/tests/statements/ddl.rs
@@ -3,7 +3,11 @@ use crate::statements::*;
 #[rstest]
 #[tokio::test]
 async fn test_create_table(
-    #[values(ObjectStoreType::InMemory, ObjectStoreType::Gcs)]
+    #[values(
+        ObjectStoreType::InMemory,
+        ObjectStoreType::Gcs,
+        ObjectStoreType::S3Public
+    )]
     object_store_type: ObjectStoreType,
 ) {
     let (context, _) = make_context_with_pg(object_store_type).await;

--- a/tests/statements/mod.rs
+++ b/tests/statements/mod.rs
@@ -50,6 +50,8 @@ enum ObjectStoreType {
     InMemory,
     // S3 object store with an optional path to the actual data folder
     S3(Option<&'static str>),
+    // Publicly-accessible S3 bucket
+    S3Public,
 }
 
 /// Make a SeafowlContext that's connected to a real PostgreSQL database
@@ -90,6 +92,16 @@ ttl = 30
                     "".to_string()
                 }
             ),
+            None,
+        ),
+        ObjectStoreType::S3Public => (
+            r#"type = "s3"
+endpoint = "http://127.0.0.1:9000"
+bucket = "seafowl-test-bucket-public"
+[object_store.cache_properties]
+ttl = 30
+"#
+            .to_string(),
             None,
         ),
         ObjectStoreType::Gcs => {


### PR DESCRIPTION
If the access_key/secret_key aren't set, skip signing the requests and treat the bucket as public.