### PR TITLE
Add support for dynamic object store usage via clade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,25 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup pre-commit
-      - name: Install pre-commit and protoc
+      - name: Install pre-commit
         run: |
           sudo apt-get update
-          sudo apt-get install -y pre-commit protobuf-compiler
+          sudo apt-get install -y pre-commit
       - name: Configure pre-commit cache
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+      - name: Install protoc
+        run: |
+          mkdir -p $HOME/d/protoc
+          cd $HOME/d/protoc
+          export PROTO_ZIP="protoc-21.4-linux-x86_64.zip"
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
+          unzip $PROTO_ZIP
+          echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
+          export PATH=$PATH:$HOME/d/protoc/bin
+          protoc --version
 
       # Use https://github.com/marketplace/actions/rust-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       RUSTFLAGS: "-C debuginfo=1"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Setup pre-commit
       - name: Install pre-commit
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pre-commit
       - name: Configure pre-commit cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,15 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup pre-commit
-      - name: Install pre-commit
+      - name: Install pre-commit and protoc
         run: |
           sudo apt-get update
-          sudo apt-get install -y pre-commit
+          sudo apt-get install -y pre-commit protobuf-compiler
       - name: Configure pre-commit cache
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
-      - name: Install protoc
-        run: sudo apt install -y protobuf-compiler
 
       # Use https://github.com/marketplace/actions/rust-cache
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,15 +16,15 @@ jobs:
 
     strategy:
       matrix:
-        build: [linux, macos, win-msvc]
+        build: [linux-x86_64, osx-x86_64, win64]
         include:
-          - build: linux
+          - build: linux-x86_64
             os: ubuntu-20.04 # We can update to 22.04 once we're comfortable dropping libssl 1.x support
             target: x86_64-unknown-linux-gnu
-          - build: macos
+          - build: osx-x86_64
             os: macos-latest
             target: x86_64-apple-darwin
-          - build: win-msvc
+          - build: win64
             os: windows-latest
             target: x86_64-pc-windows-msvc
 
@@ -33,40 +33,24 @@ jobs:
         # Taken from https://github.com/apache/arrow-datafusion/blob/master/.github/workflows/rust.yml
         shell: bash
         run: |
-          if [ "${{ matrix.build }}" = "win-msvc" ]; then
-            mkdir -p $HOME/d/protoc
-            cd $HOME/d/protoc
-            export PROTO_ZIP="protoc-21.4-win64.zip"
-            curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
-            unzip $PROTO_ZIP
-            echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
-            export PATH=$PATH:$HOME/d/protoc/bin
-            protoc.exe --version
+          mkdir -p $HOME/d/protoc
+          cd $HOME/d/protoc
+          export PROTO_ZIP="protoc-21.4-${{ matrix.build }}.zip"
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
+          unzip $PROTO_ZIP
+          echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
+          export PATH=$PATH:$HOME/d/protoc/bin
 
+          if [ "${{ matrix.build }}" = "win64" ]; then
+            protoc.exe --version
             vcpkg integrate install
             vcpkg.exe install openssl:x64-windows-static-md
-          elif [ "${{ matrix.build }}" = "linux" ]; then
-            mkdir -p $HOME/d/protoc
-            cd $HOME/d/protoc
-            export PROTO_ZIP="protoc-21.4-linux-x86_64.zip"
-            curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
-            unzip $PROTO_ZIP
-            echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
-            export PATH=$PATH:$HOME/d/protoc/bin
-            protoc --version
-          else
-            mkdir -p $HOME/d/protoc
-            cd $HOME/d/protoc
-            export PROTO_ZIP="protoc-21.4-osx-x86_64.zip"
-            curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
-            unzip $PROTO_ZIP
-            echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
-            export PATH=$PATH:$HOME/d/protoc/bin
+          else 
             protoc --version
           fi
 
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: |
           rustup toolchain install nightly --profile minimal
           rustup default nightly
@@ -114,23 +98,23 @@ jobs:
           fi
 
       - name: Login to DockerHub (Linux only)
-        if: matrix.build == 'linux'
-        uses: docker/login-action@v2
+        if: matrix.build == 'linux-x86_64'
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Test building and invoking the Docker image (Linux only)
-        if: matrix.build == 'linux'
+        if: matrix.build == 'linux-x86_64'
         run: |
           DOCKER_BUILDKIT=1 docker build . -t splitgraph/seafowl:test
           docker run --rm splitgraph/seafowl:test --version
 
       - name: Determine Docker tags (Linux only)
-        if: matrix.build == 'linux'
+        if: matrix.build == 'linux-x86_64'
         id: meta
         # https://github.com/docker/metadata-action
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             splitgraph/seafowl
@@ -143,8 +127,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image (Linux only)
-        if: matrix.build == 'linux'
-        uses: docker/build-push-action@v4
+        if: matrix.build == 'linux-x86_64'
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
@@ -152,7 +136,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.SOURCE }}
@@ -173,7 +157,7 @@ jobs:
 
       # Checkout required to access the release-notes.py script
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Generate release notes
         run: |
           ./.github/workflows/release-notes.py --tag ${{ env.RELEASE_VERSION }} --output notes-${{ env.RELEASE_VERSION }}.md

--- a/clade/proto/schema.proto
+++ b/clade/proto/schema.proto
@@ -4,12 +4,24 @@ package clade.schema;
 
 message SchemaObject {
   string name = 1;
-  repeated TableObject tables = 2;
+  repeated StorageLocation stores = 2;
+  repeated TableObject tables = 3;
 }
 
 message TableObject {
   string name = 1;
-  string location = 2;
+  // path within the provided storage location, if any
+  string path = 2;
+  // URL of the root storage location
+  optional string location = 3;
+}
+
+// A single root storage location, hosting many individual tables
+message StorageLocation {
+  // URL of the root storage location
+  string location = 1;
+  // Connection options for the object store client
+  map<string, string> options = 2;
 }
 
 message ListSchemaRequest {

--- a/clade/proto/schema.proto
+++ b/clade/proto/schema.proto
@@ -4,13 +4,12 @@ package clade.schema;
 
 message SchemaObject {
   string name = 1;
-  repeated StorageLocation stores = 2;
-  repeated TableObject tables = 3;
+  repeated TableObject tables = 2;
 }
 
 message TableObject {
   string name = 1;
-  // path within the provided storage location, if any
+  // Path within the provided storage location, if any
   string path = 2;
   // URL of the root storage location
   optional string location = 3;
@@ -30,6 +29,7 @@ message ListSchemaRequest {
 
 message ListSchemaResponse {
   repeated SchemaObject schemas = 1;
+  repeated StorageLocation stores = 2;
 }
 
 service SchemaStoreService {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,9 @@ services:
     entrypoint: >
       /bin/sh -c " /usr/bin/mc config host add test-minio http://minio:9000 minioadmin minioadmin;
       /usr/bin/mc rm -r --force test-minio/seafowl-test-bucket;  /usr/bin/mc mb
-      test-minio/seafowl-test-bucket; /usr/bin/mc cp test-data/table_with_ns_column.parquet
-      test-minio/seafowl-test-bucket/table_with_ns_column.parquet; /usr/bin/mc anonymous set public
-      test-minio/seafowl-test-bucket/table_with_ns_column.parquet; 
+      test-minio/seafowl-test-bucket; /usr/bin/mc cp -r test-data test-minio/seafowl-test-bucket;
+      /usr/bin/mc anonymous set public
+      test-minio/seafowl-test-bucket/test-data/table_with_ns_column.parquet;
 
       /usr/bin/mc mb test-minio/seafowl-test-bucket-public; /usr/bin/mc anonymous set public
       test-minio/seafowl-test-bucket-public; exit 0; "

--- a/src/catalog/metastore.rs
+++ b/src/catalog/metastore.rs
@@ -12,14 +12,20 @@ use crate::wasm_udf::data_types::{
     CreateFunctionDataType, CreateFunctionDetails, CreateFunctionLanguage,
     CreateFunctionVolatility,
 };
-use clade::schema::SchemaObject;
+use clade::schema::{SchemaObject, TableObject};
 use datafusion::catalog::schema::MemorySchemaProvider;
 use datafusion::datasource::TableProvider;
-use deltalake::DeltaTable;
+use deltalake::logstore::default_logstore;
+use deltalake::storage::{ObjectStoreFactory, ObjectStoreRef, StorageOptions};
+use deltalake::{DeltaResult, DeltaTable, DeltaTableError};
+use object_store::path::Path;
+use object_store::prefix::PrefixStore;
+use object_store::{parse_url_opts, ObjectStore};
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
+use url::Url;
 
 // This is the main entrypoint to all individual catalogs for various objects types.
 // The intention is to make it extensible and de-coupled from the underlying metastore
@@ -31,13 +37,13 @@ pub struct Metastore {
     pub tables: Arc<dyn TableStore>,
     pub functions: Arc<dyn FunctionStore>,
     staging_schema: Arc<MemorySchemaProvider>,
-    object_store: Arc<InternalObjectStore>,
+    default_store: Arc<InternalObjectStore>,
 }
 
 impl Metastore {
     pub fn new_from_repository(
         repository: Arc<dyn Repository>,
-        object_store: Arc<InternalObjectStore>,
+        default_store: Arc<InternalObjectStore>,
     ) -> Self {
         let repository_store = Arc::new(RepositoryStore { repository });
 
@@ -48,13 +54,13 @@ impl Metastore {
             tables: repository_store.clone(),
             functions: repository_store,
             staging_schema,
-            object_store,
+            default_store,
         }
     }
 
     pub fn new_from_external(
         external_store: Arc<ExternalStore>,
-        object_store: Arc<InternalObjectStore>,
+        default_store: Arc<InternalObjectStore>,
     ) -> Self {
         let staging_schema = Arc::new(MemorySchemaProvider::new());
         Self {
@@ -63,7 +69,7 @@ impl Metastore {
             tables: external_store.clone(),
             functions: external_store,
             staging_schema,
-            object_store,
+            default_store,
         }
     }
 
@@ -73,16 +79,12 @@ impl Metastore {
     ) -> CatalogResult<SeafowlDatabase> {
         let catalog_schemas = self.schemas.list(catalog_name).await?;
 
-        // NB we can't distinguish between a database without tables and a database
-        // that doesn't exist at all due to our query.
-
         // Turn the list of all collections, tables and their columns into a nested map.
-
-        let schemas: HashMap<Arc<str>, Arc<SeafowlSchema>> = catalog_schemas
+        let schemas = catalog_schemas
             .schemas
             .into_iter()
             .map(|schema| self.build_schema(schema))
-            .collect();
+            .collect::<CatalogResult<HashMap<_, _>>>()?;
 
         let name: Arc<str> = Arc::from(catalog_name);
 
@@ -94,38 +96,70 @@ impl Metastore {
         })
     }
 
-    fn build_schema(&self, schema: SchemaObject) -> (Arc<str>, Arc<SeafowlSchema>) {
+    fn build_schema(
+        &self,
+        schema: SchemaObject,
+    ) -> CatalogResult<(Arc<str>, Arc<SeafowlSchema>)> {
         let schema_name = schema.name;
+
+        // Collect all provided object store locations into corresponding clients
+        // TODO: cache this using location (+ options?) as key, potentially with
+        // a TTL, and re-use when building table log stores below.
+        let stores = schema
+            .stores
+            .into_iter()
+            .map(|store| {
+                let url = Url::parse(&store.location)?;
+                Ok((
+                    store.location.clone(),
+                    parse_url_opts(&url, store.options)?.0.into(),
+                ))
+            })
+            .collect::<CatalogResult<_>>()?;
 
         let tables = schema
             .tables
             .into_iter()
-            .map(|table| self.build_table(table.name, &table.location))
-            .collect::<HashMap<_, _>>();
+            .map(|table| self.build_table(table, &stores))
+            .collect::<CatalogResult<HashMap<_, _>>>()?;
 
-        (
+        Ok((
             Arc::from(schema_name.clone()),
             Arc::new(SeafowlSchema {
                 name: Arc::from(schema_name),
                 tables: RwLock::new(tables),
             }),
-        )
+        ))
     }
 
     fn build_table(
         &self,
-        table_name: String,
-        table_uuid: &str,
-    ) -> (Arc<str>, Arc<dyn TableProvider>) {
+        table: TableObject,
+        stores: &HashMap<String, Arc<dyn ObjectStore>>,
+    ) -> CatalogResult<(Arc<str>, Arc<dyn TableProvider>)> {
         // Build a delta table but don't load it yet; we'll do that only for tables that are
         // actually referenced in a statement, via the async `table` method of the schema provider.
         // TODO: this means that any `information_schema.columns` query will serially load all
         // delta tables present in the database. The real fix for this is to make DF use `TableSource`
         // for the information schema, and then implement `TableSource` for `DeltaTable` in delta-rs.
-        let table_log_store = self.object_store.get_log_store(table_uuid);
 
-        let table = DeltaTable::new(table_log_store, Default::default());
-        (Arc::from(table_name), Arc::new(table) as _)
+        let table_log_store = match table.location {
+            // Use the provided customized location
+            Some(location) => {
+                let store = stores.get(&location).expect("store for location exists");
+                let prefixed_store: PrefixStore<Arc<dyn ObjectStore>> =
+                    PrefixStore::new(store.clone(), &*table.path);
+
+                let url = Url::parse(&format!("{location}/{}", table.path))?;
+
+                default_logstore(Arc::from(prefixed_store), &url, &Default::default())
+            }
+            // Use the configured, default, object store
+            None => self.default_store.get_log_store(&table.path),
+        };
+
+        let delta_table = DeltaTable::new(table_log_store, Default::default());
+        Ok((Arc::from(table.name), Arc::new(delta_table) as _))
     }
 
     pub async fn build_functions(
@@ -176,5 +210,23 @@ impl Metastore {
             data: data.to_string(),
             volatility: CreateFunctionVolatility::from_str(volatility.as_str())?,
         })
+    }
+}
+
+impl ObjectStoreFactory for Metastore {
+    fn parse_url_opts(
+        &self,
+        url: &Url,
+        _options: &StorageOptions,
+    ) -> DeltaResult<(ObjectStoreRef, Path)> {
+        if self.default_store.root_uri.scheme() == url.scheme() {
+            Ok((
+                Arc::new(self.default_store.as_ref().clone()),
+                Path::from("/"),
+            ))
+        } else {
+            // TODO: this won't work if the default store has the same scheme as the queried one
+            Err(DeltaTableError::InvalidTableLocation(url.clone().into()))
+        }
     }
 }

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -63,11 +63,17 @@ pub enum CatalogError {
     NotImplemented { reason: String },
 
     // Metastore implementation errors
+    #[error(transparent)]
+    ObjectStoreError(#[from] object_store::Error),
+
     #[error("Internal SQL error: {0:?}")]
     SqlxError(sqlx::Error),
 
     #[error(transparent)]
     TonicStatus(#[from] Status),
+
+    #[error("Failed parsing URL: {0}")]
+    UrlParseError(#[from] url::ParseError),
 }
 
 /// Implement a global converter into a DataFusionError from the catalog error type.

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -21,6 +21,9 @@ pub const STAGING_SCHEMA: &str = "staging";
 
 #[derive(Debug, thiserror::Error)]
 pub enum CatalogError {
+    #[error("{reason}")]
+    Generic { reason: String },
+
     // Catalog errors
     #[error("Catalog {name:?} doesn't exist")]
     CatalogDoesNotExist { name: String },

--- a/src/catalog/repository.rs
+++ b/src/catalog/repository.rs
@@ -119,7 +119,6 @@ impl SchemaStore for RepositoryStore {
             .into_iter()
             .map(|(cn, ct)| SchemaObject {
                 name: cn.clone(),
-                stores: vec![],
                 tables: ct
                     .into_iter()
                     .filter_map(|t| {
@@ -139,7 +138,10 @@ impl SchemaStore for RepositoryStore {
             })
             .collect();
 
-        Ok(ListSchemaResponse { schemas })
+        Ok(ListSchemaResponse {
+            schemas,
+            stores: vec![],
+        })
     }
 
     async fn get(

--- a/src/catalog/repository.rs
+++ b/src/catalog/repository.rs
@@ -109,6 +109,8 @@ impl SchemaStore for RepositoryStore {
     }
 
     async fn list(&self, catalog_name: &str) -> CatalogResult<ListSchemaResponse> {
+        // NB we can't distinguish between a database without tables and a database
+        // that doesn't exist at all due to our query.
         let cols = self.repository.list_collections(catalog_name).await?;
 
         let schemas = cols
@@ -117,6 +119,7 @@ impl SchemaStore for RepositoryStore {
             .into_iter()
             .map(|(cn, ct)| SchemaObject {
                 name: cn.clone(),
+                stores: vec![],
                 tables: ct
                     .into_iter()
                     .filter_map(|t| {
@@ -125,7 +128,8 @@ impl SchemaStore for RepositoryStore {
                         {
                             Some(TableObject {
                                 name: name.clone(),
-                                location: uuid.to_string(),
+                                path: uuid.to_string(),
+                                location: None,
                             })
                         } else {
                             None

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -232,11 +232,6 @@ pub async fn build_context(cfg: schema::SeafowlConfig) -> Result<SeafowlContext>
         metastore.schemas.create(DEFAULT_DB, DEFAULT_SCHEMA).await?;
     }
 
-    #[cfg(feature = "metrics")]
-    if let Some(ref metrics) = cfg.misc.metrics {
-        setup_metrics(metrics);
-    }
-
     // Convergence doesn't support connecting to different DB names. We are supposed
     // to do one context per query (as we need to load the schema before executing every
     // query) and per database (since the context is supposed to be limited to the database

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(let_chains)]
+
 use clap::AppSettings::NoAutoVersion;
 use std::process::exit;
 use std::{
@@ -11,6 +13,7 @@ use clap::Parser;
 
 use futures::{future::join_all, Future, FutureExt};
 
+use seafowl::config::context::setup_metrics;
 #[cfg(feature = "frontend-arrow-flight")]
 use seafowl::frontend::flight::run_flight_server;
 use seafowl::{
@@ -216,6 +219,13 @@ async fn main() {
 
         config
     };
+
+    #[cfg(feature = "metrics")]
+    if !args.cli
+        && let Some(ref metrics) = config.misc.metrics
+    {
+        setup_metrics(metrics);
+    }
 
     let context = Arc::new(build_context(config).await.unwrap());
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -106,6 +106,7 @@ impl SchemaProvider for SeafowlSchema {
 
         if let Err(err) = delta_table.load().await {
             warn!("Failed to load table {name}: {err}");
+            println!("{err}");
             return None;
         }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -106,7 +106,6 @@ impl SchemaProvider for SeafowlSchema {
 
         if let Err(err) = delta_table.load().await {
             warn!("Failed to load table {name}: {err}");
-            println!("{err}");
             return None;
         }
 

--- a/tests/clade/mod.rs
+++ b/tests/clade/mod.rs
@@ -1,3 +1,4 @@
+use crate::fixtures::fake_gcs_creds;
 use clade::schema::{
     schema_store_service_server::{SchemaStoreService, SchemaStoreServiceServer},
     ListSchemaRequest, ListSchemaResponse, SchemaObject, StorageLocation, TableObject,
@@ -5,6 +6,7 @@ use clade::schema::{
 };
 use datafusion_common::assert_batches_eq;
 use object_store::aws::AmazonS3ConfigKey;
+use object_store::gcp::GoogleConfigKey;
 use rstest::rstest;
 use seafowl::catalog::DEFAULT_DB;
 use seafowl::config::context::build_context;
@@ -67,14 +69,13 @@ dsn = "http://{addr}""#,
 }
 
 async fn run_clade_server(addr: SocketAddr) {
-    // Setup a test metastore with some tables and object stores.
+    // Setup a test metastore with some fake tables in test object stores.
     let metastore = TestCladeMetastore {
         catalog: DEFAULT_DB.to_string(),
         schemas: ListSchemaResponse {
             schemas: vec![
                 SchemaObject {
                     name: "local".to_string(),
-
                     tables: vec![TableObject {
                         name: "file".to_string(),
                         path: "delta-0.8.0-partitioned".to_string(),
@@ -89,30 +90,47 @@ async fn run_clade_server(addr: SocketAddr) {
                         location: Some("s3://seafowl-test-bucket".to_string()),
                     }],
                 },
+                SchemaObject {
+                    name: "gcs".to_string(),
+                    tables: vec![TableObject {
+                        name: "fake".to_string(),
+                        path: "delta-0.8.0-partitioned".to_string(),
+                        location: Some("gs://test-data".to_string()),
+                    }],
+                },
             ],
-            stores: vec![StorageLocation {
-                location: "s3://seafowl-test-bucket".to_string(),
-                options: HashMap::from([
-                    (
-                        AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
-                        "http://127.0.0.1:9000".to_string(),
-                    ),
-                    (
-                        AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
-                        "minioadmin".to_string(),
-                    ),
-                    (
-                        AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
-                        "minioadmin".to_string(),
-                    ),
-                    (
-                        // This has been removed from the config enum, but it can
-                        // still be picked up via `AmazonS3ConfigKey::from_str`
-                        "aws_allow_http".to_string(),
-                        "true".to_string(),
-                    ),
-                ]),
-            }],
+            stores: vec![
+                StorageLocation {
+                    location: "s3://seafowl-test-bucket".to_string(),
+                    options: HashMap::from([
+                        (
+                            AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
+                            "http://127.0.0.1:9000".to_string(),
+                        ),
+                        (
+                            AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
+                            "minioadmin".to_string(),
+                        ),
+                        (
+                            AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
+                            "minioadmin".to_string(),
+                        ),
+                        (
+                            // This has been removed from the config enum, but it can
+                            // still be picked up via `AmazonS3ConfigKey::from_str`
+                            "aws_allow_http".to_string(),
+                            "true".to_string(),
+                        ),
+                    ]),
+                },
+                StorageLocation {
+                    location: "gs://test-data".to_string(),
+                    options: HashMap::from([(
+                        GoogleConfigKey::ServiceAccount.as_ref().to_string(),
+                        fake_gcs_creds(),
+                    )]),
+                },
+            ],
         },
     };
 

--- a/tests/clade/mod.rs
+++ b/tests/clade/mod.rs
@@ -1,13 +1,16 @@
 use clade::schema::{
     schema_store_service_server::{SchemaStoreService, SchemaStoreServiceServer},
-    ListSchemaRequest, ListSchemaResponse, SchemaObject, TableObject,
+    ListSchemaRequest, ListSchemaResponse, SchemaObject, StorageLocation, TableObject,
     FILE_DESCRIPTOR_SET,
 };
 use datafusion_common::assert_batches_eq;
+use object_store::aws::AmazonS3ConfigKey;
+use rstest::rstest;
 use seafowl::catalog::DEFAULT_DB;
 use seafowl::config::context::build_context;
 use seafowl::config::schema::load_config_from_string;
 use seafowl::context::SeafowlContext;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -67,13 +70,48 @@ async fn run_clade_server(addr: SocketAddr) {
     let metastore = TestCladeMetastore {
         catalog: DEFAULT_DB.to_string(),
         schemas: ListSchemaResponse {
-            schemas: vec![SchemaObject {
-                name: "some_schema".to_string(),
-                tables: vec![TableObject {
-                    name: "some_table".to_string(),
-                    location: "delta-0.8.0-partitioned".to_string(),
-                }],
-            }],
+            schemas: vec![
+                SchemaObject {
+                    name: "local".to_string(),
+                    stores: vec![],
+                    tables: vec![TableObject {
+                        name: "file".to_string(),
+                        path: "delta-0.8.0-partitioned".to_string(),
+                        location: None,
+                    }],
+                },
+                SchemaObject {
+                    name: "s3".to_string(),
+                    stores: vec![StorageLocation {
+                        location: "s3://seafowl-test-bucket".to_string(),
+                        options: HashMap::from([
+                            (
+                                AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
+                                "http://127.0.0.1:9000".to_string(),
+                            ),
+                            (
+                                AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
+                                "minioadmin".to_string(),
+                            ),
+                            (
+                                AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
+                                "minioadmin".to_string(),
+                            ),
+                            (
+                                // This has been removed from the config enum, but it can
+                                // still be picked up via `AmazonS3ConfigKey::from_str`
+                                "aws_allow_http".to_string(),
+                                "true".to_string(),
+                            ),
+                        ]),
+                    }],
+                    tables: vec![TableObject {
+                        name: "minio".to_string(),
+                        path: "test-data/delta-0.8.0-partitioned".to_string(),
+                        location: Some("s3://seafowl-test-bucket".to_string()),
+                    }],
+                },
+            ],
         },
     };
 

--- a/tests/clade/mod.rs
+++ b/tests/clade/mod.rs
@@ -67,13 +67,14 @@ dsn = "http://{addr}""#,
 }
 
 async fn run_clade_server(addr: SocketAddr) {
+    // Setup a test metastore with some tables and object stores.
     let metastore = TestCladeMetastore {
         catalog: DEFAULT_DB.to_string(),
         schemas: ListSchemaResponse {
             schemas: vec![
                 SchemaObject {
                     name: "local".to_string(),
-                    stores: vec![],
+
                     tables: vec![TableObject {
                         name: "file".to_string(),
                         path: "delta-0.8.0-partitioned".to_string(),
@@ -82,29 +83,6 @@ async fn run_clade_server(addr: SocketAddr) {
                 },
                 SchemaObject {
                     name: "s3".to_string(),
-                    stores: vec![StorageLocation {
-                        location: "s3://seafowl-test-bucket".to_string(),
-                        options: HashMap::from([
-                            (
-                                AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
-                                "http://127.0.0.1:9000".to_string(),
-                            ),
-                            (
-                                AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
-                                "minioadmin".to_string(),
-                            ),
-                            (
-                                AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
-                                "minioadmin".to_string(),
-                            ),
-                            (
-                                // This has been removed from the config enum, but it can
-                                // still be picked up via `AmazonS3ConfigKey::from_str`
-                                "aws_allow_http".to_string(),
-                                "true".to_string(),
-                            ),
-                        ]),
-                    }],
                     tables: vec![TableObject {
                         name: "minio".to_string(),
                         path: "test-data/delta-0.8.0-partitioned".to_string(),
@@ -112,6 +90,29 @@ async fn run_clade_server(addr: SocketAddr) {
                     }],
                 },
             ],
+            stores: vec![StorageLocation {
+                location: "s3://seafowl-test-bucket".to_string(),
+                options: HashMap::from([
+                    (
+                        AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
+                        "http://127.0.0.1:9000".to_string(),
+                    ),
+                    (
+                        AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
+                        "minioadmin".to_string(),
+                    ),
+                    (
+                        AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
+                        "minioadmin".to_string(),
+                    ),
+                    (
+                        // This has been removed from the config enum, but it can
+                        // still be picked up via `AmazonS3ConfigKey::from_str`
+                        "aws_allow_http".to_string(),
+                        "true".to_string(),
+                    ),
+                ]),
+            }],
         },
     };
 

--- a/tests/clade/query.rs
+++ b/tests/clade/query.rs
@@ -3,7 +3,7 @@ use crate::clade::*;
 #[rstest]
 #[tokio::test]
 async fn test_basic_select(
-    #[values("local.file", "s3.minio")] table: &str,
+    #[values("local.file", "s3.minio", "gcs.fake")] table: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let context = start_clade_server().await;
 

--- a/tests/clade/query.rs
+++ b/tests/clade/query.rs
@@ -1,7 +1,10 @@
 use crate::clade::*;
 
+#[rstest]
 #[tokio::test]
-async fn test_basic_select() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_basic_select(
+    #[values("local.file", "s3.minio")] table: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let context = start_clade_server().await;
 
     // Before proceeding with the test swallow up a single initial
@@ -10,7 +13,7 @@ async fn test_basic_select() -> Result<(), Box<dyn std::error::Error>> {
     let _r = context.metastore.schemas.list(DEFAULT_DB).await;
 
     let plan = context
-        .plan_query("SELECT * FROM some_schema.some_table ORDER BY value")
+        .plan_query(&format!("SELECT * FROM {table} ORDER BY value"))
         .await
         .unwrap();
     let results = context.collect(plan).await.unwrap();

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -1,0 +1,17 @@
+use serde_json::json;
+use std::path::Path;
+
+pub const FAKE_GCS_CREDS_PATH: &str = "/tmp/fake-gcs-server.json";
+
+pub fn fake_gcs_creds() -> String {
+    let creds_json = json!({"gcs_base_url": "http://localhost:4443", "disable_oauth": true, "client_email": "", "private_key": "", "private_key_id": ""});
+    // gcs_base_url should match docker-compose.yml:fake-gcs-server
+    let google_application_credentials_path = Path::new(FAKE_GCS_CREDS_PATH);
+    std::fs::write(
+        google_application_credentials_path,
+        serde_json::to_vec(&creds_json).expect("Unable to serialize creds JSON"),
+    )
+    .expect("Unable to write application credentials JSON file");
+
+    google_application_credentials_path.display().to_string()
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -14,6 +14,7 @@ use tonic::transport::Channel;
 
 mod clade;
 mod cli;
+mod fixtures;
 mod flight;
 mod http;
 mod statements;

--- a/tests/statements/ddl.rs
+++ b/tests/statements/ddl.rs
@@ -499,14 +499,14 @@ async fn test_create_table_in_staging_schema() {
 #[rstest]
 #[case::in_mem_from_mock_http(None, "", ObjectStoreType::InMemory)]
 #[case::in_mem_from_minio_http(
-    Some("http://localhost:9000/seafowl-test-bucket/table_with_ns_column.parquet"),
+    Some("http://localhost:9000/seafowl-test-bucket/test-data/table_with_ns_column.parquet"),
     "",
     ObjectStoreType::InMemory
 )]
 // Tests the case of inheriting the credentials from the native object store, since none are
 // provided via the `OPTIONS` clause.
 #[case::in_minio_s3_from_minio_s3(
-    Some("s3://seafowl-test-bucket/table_with_ns_column.parquet"),
+    Some("s3://seafowl-test-bucket/test-data/table_with_ns_column.parquet"),
     "",
     ObjectStoreType::S3(None)
 )]
@@ -518,12 +518,12 @@ async fn test_create_table_in_staging_schema() {
 // Tests the case of explicitly specifying the `OPTIONS` clause to construct a dynamic object store.
 // so we can use anything other than the native object store.
 #[case::in_mem_from_minio_s3_with_options(
-    Some("s3://seafowl-test-bucket/table_with_ns_column.parquet"),
+    Some("s3://seafowl-test-bucket/test-data/table_with_ns_column.parquet"),
     " OPTIONS ('access_key_id' 'minioadmin', 'secret_access_key' 'minioadmin', 'endpoint' 'http://127.0.0.1:9000') ",
     ObjectStoreType::InMemory,
 )]
 #[case::in_gcs_from_minio_s3_with_options(
-    Some("s3://seafowl-test-bucket/table_with_ns_column.parquet"),
+    Some("s3://seafowl-test-bucket/test-data/table_with_ns_column.parquet"),
     " OPTIONS ('access_key_id' 'minioadmin', 'secret_access_key' 'minioadmin', 'endpoint' 'http://127.0.0.1:9000') ",
     ObjectStoreType::Gcs,
 )]


### PR DESCRIPTION
This enables metastore to setup delta tables with a different object store than the one configured in the toml file.

Currently does not support writes, due to metastore limitations.