### PR TITLE
Make `object_store` confgi section optional

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -215,7 +215,7 @@ pub mod test_utils {
     /// Build a real (not mocked) in-memory context that uses SQLite
     pub async fn in_memory_context() -> SeafowlContext {
         let config = SeafowlConfig {
-            object_store: schema::ObjectStore::InMemory(schema::InMemory {}),
+            object_store: Some(schema::ObjectStore::InMemory(schema::InMemory {})),
             catalog: Catalog::Sqlite(Sqlite {
                 dsn: "sqlite://:memory:".to_string(),
                 journal_mode: SqliteJournalMode::Wal,

--- a/tests/clade/mod.rs
+++ b/tests/clade/mod.rs
@@ -43,16 +43,22 @@ impl SchemaStoreService for TestCladeMetastore {
     }
 }
 
-async fn start_clade_server() -> Arc<SeafowlContext> {
-    // let OS choose a a free port
+async fn start_clade_server(object_store: bool) -> Arc<SeafowlContext> {
+    // let OS choose a free port
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
+    let object_store_section = if object_store {
+        r#"[object_store]
+type = "local"
+data_dir = "tests/data""#
+    } else {
+        ""
+    };
+
     let config_text = format!(
         r#"
-[object_store]
-type = "local"
-data_dir = "tests/data"
+{object_store_section}
 
 [catalog]
 type = "clade"

--- a/tests/clade/query.rs
+++ b/tests/clade/query.rs
@@ -1,11 +1,14 @@
 use crate::clade::*;
 
 #[rstest]
+#[should_panic(expected = "table 'default.local.file' not found")]
+#[case("local.file", false)]
+#[case("local.file", true)]
+#[case("s3.minio", true)]
+#[case("gcs.fake", true)]
 #[tokio::test]
-async fn test_basic_select(
-    #[values("local.file", "s3.minio", "gcs.fake")] table: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let context = start_clade_server().await;
+async fn test_basic_select(#[case] table: &str, #[case] object_store: bool) -> () {
+    let context = start_clade_server(object_store).await;
 
     // Before proceeding with the test swallow up a single initial
     // ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })
@@ -32,6 +35,4 @@ async fn test_basic_select(
         "+-------+------+-------+-----+",
     ];
     assert_batches_eq!(expected, &results);
-
-    Ok(())
 }


### PR DESCRIPTION
Conditional on using the Clade catalog, in which case it is internally set to use an in-memory store.