### PR TITLE
Fix condition for caching clade object stores

### DIFF
--- a/src/catalog/metastore.rs
+++ b/src/catalog/metastore.rs
@@ -166,7 +166,7 @@ impl Metastore {
                     })?
                     .clone();
 
-                if (location.starts_with("file://") || location.starts_with("memory://"))
+                if !(location.starts_with("file://") || location.starts_with("memory://"))
                     && let Some(ref cache) = self.object_store_cache
                 {
                     // Wrap the non-local store with the caching layer


### PR DESCRIPTION
Also uncomment the remote table tests that now pass.