### PR TITLE
Use tokio-graceful-shutdown for SIGINT / SIGTERM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1100,20 @@ name = "bytemuck"
 version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "byteorder"
@@ -3625,6 +3648,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5430,6 +5476,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-graceful-shutdown",
  "tonic",
  "tonic-reflection",
  "tower",
@@ -6368,6 +6415,23 @@ dependencies = [
  "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-graceful-shutdown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355cba3af46ced8ef2f8c6f7bf6cff2f38ae5f3bbe78392fdba71712e062152c"
+dependencies = [
+ "async-trait",
+ "atomic",
+ "bytemuck",
+ "miette",
+ "pin-project-lite",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ strum_macros = ">=0.24"
 tempfile = "3"
 thiserror = "1"
 tokio = { workspace = true }
+tokio-graceful-shutdown = { version = "0.14" }
 tonic = { version = "0.10.0", optional = true }
 tower = { version = "0.4", optional = true }
 tracing = { workspace = true }

--- a/src/frontend/flight/mod.rs
+++ b/src/frontend/flight/mod.rs
@@ -7,13 +7,20 @@ use crate::config::schema::FlightFrontend;
 use crate::context::SeafowlContext;
 use crate::frontend::flight::handler::SeafowlFlightHandler;
 use arrow_flight::flight_service_server::FlightServiceServer;
+use futures::Future;
 #[cfg(feature = "metrics")]
 use metrics::MetricsLayer;
+
 use std::net::SocketAddr;
 use std::sync::Arc;
+
 use tonic::transport::Server;
 
-pub async fn run_flight_server(context: Arc<SeafowlContext>, config: FlightFrontend) {
+pub async fn run_flight_server(
+    context: Arc<SeafowlContext>,
+    config: FlightFrontend,
+    shutdown: impl Future<Output = ()> + 'static,
+) {
     let addr: SocketAddr = format!("{}:{}", config.bind_host, config.bind_port)
         .parse()
         .expect("Error parsing the Arrow Flight listen address");
@@ -26,5 +33,9 @@ pub async fn run_flight_server(context: Arc<SeafowlContext>, config: FlightFront
     #[cfg(feature = "metrics")]
     let mut server = server.layer(MetricsLayer {});
 
-    server.add_service(svc).serve(addr).await.unwrap();
+    server
+        .add_service(svc)
+        .serve_with_shutdown(addr, shutdown)
+        .await
+        .unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,6 @@ async fn main() {
 
     Toplevel::new(|s: SubsystemHandle<Infallible>| async move {
         let mut any_frontends: bool = false;
-
         #[cfg(feature = "frontend-arrow-flight")]
         if let Some(flight) = &context.config.frontend.flight {
             let context = context.clone();
@@ -189,7 +188,6 @@ async fn main() {
                 Ok::<(), Infallible>(())
             }));
         };
-    
         #[cfg(feature = "frontend-postgres")]
         if let Some(pg) = &context.config.frontend.postgres {
             let context = context.clone();
@@ -207,11 +205,9 @@ async fn main() {
                     e = run_pg_server(context, pg) => e,
                     _ = h.on_shutdown_requested() => (),
                 };
-                
                 Ok::<(), Infallible>(())
             }));
         };
-    
         if let Some(http) = &context.config.frontend.http {
             let context = context.clone();
             let http = http.clone();
@@ -256,8 +252,10 @@ async fn main() {
                 };
             }));
         };
-    }).catch_signals()
+    })
+    .catch_signals()
     .handle_shutdown_requests(Duration::from_secs(5))
-    .await.unwrap();
+    .await
+    .unwrap();
     info!("Exiting cleanly.");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,18 @@
 #![feature(let_chains)]
 
 use clap::AppSettings::NoAutoVersion;
+use tokio::select;
+
+use std::convert::Infallible;
 use std::process::exit;
 use std::{
     env, fs, io,
     path::{Path, PathBuf},
-    pin::Pin,
     sync::Arc,
 };
+use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 use clap::Parser;
-
-use futures::{future::join_all, Future, FutureExt};
 
 use seafowl::config::context::setup_metrics;
 #[cfg(feature = "frontend-arrow-flight")]
@@ -22,14 +23,10 @@ use seafowl::{
         context::build_context,
         schema::{build_default_config, load_config, DEFAULT_DATA_DIR},
     },
-    context::SeafowlContext,
     frontend::http::run_server,
     utils::{gc_databases, run_one_off_command},
 };
-use tokio::signal::ctrl_c;
-#[cfg(unix)]
-use tokio::signal::unix::{signal, SignalKind};
-use tokio::sync::broadcast::{channel, Sender};
+
 use tokio::time::{interval, Duration};
 use tracing::level_filters::LevelFilter;
 use tracing::{error, info, subscriber, warn};
@@ -88,73 +85,6 @@ fn prepare_tracing(json_logs: bool) {
         subscriber::set_global_default(sub.compact().finish())
     }
     .expect("Global logging config set");
-}
-
-fn prepare_frontends(
-    context: Arc<SeafowlContext>,
-    shutdown: &Sender<()>,
-) -> Vec<Pin<Box<dyn Future<Output = ()> + Send>>> {
-    let mut result: Vec<Pin<Box<dyn Future<Output = ()> + Send>>> = Vec::new();
-
-    #[cfg(feature = "frontend-arrow-flight")]
-    if let Some(flight) = &context.config.frontend.flight {
-        let server = run_flight_server(context.clone(), flight.clone());
-        info!(
-            "Starting the Arrow Flight frontend on {}:{}",
-            flight.bind_host, flight.bind_port
-        );
-        warn!(
-            "The Arrow Flight frontend doesn't have authentication or encryption and should only be used in development!"
-        );
-
-        let mut shutdown_r = shutdown.subscribe();
-        result.push(Box::pin(async move {
-            let handle = tokio::spawn(server);
-
-            shutdown_r.recv().await.unwrap();
-            info!("Shutting down the Arrow Flight frontend");
-            handle.abort()
-        }));
-    };
-
-    #[cfg(feature = "frontend-postgres")]
-    if let Some(pg) = &context.config.frontend.postgres {
-        let server = run_pg_server(context.clone(), pg.to_owned());
-        info!(
-            "Starting the PostgreSQL frontend on {}:{}",
-            pg.bind_host, pg.bind_port
-        );
-        warn!(
-            "The PostgreSQL frontend doesn't have authentication or encryption and should only be used in development!"
-        );
-
-        let mut shutdown_r = shutdown.subscribe();
-        result.push(Box::pin(async move {
-            let handle = tokio::spawn(server);
-
-            shutdown_r.recv().await.unwrap();
-            info!("Shutting down the PostgreSQL frontend");
-            handle.abort()
-        }));
-    };
-
-    if let Some(http) = &context.config.frontend.http {
-        let http = http.clone();
-        let shutdown_r = shutdown.subscribe();
-
-        let server = run_server(context, http.clone(), shutdown_r);
-        info!(
-            "Starting the HTTP frontend on {}:{}",
-            http.bind_host, http.bind_port
-        );
-        info!(
-            "HTTP access settings: read {}, write {}",
-            http.read_access, http.write_access
-        );
-        result.push(server.boxed());
-    };
-
-    result
 }
 
 fn print_version_info(f: &mut impl std::io::Write) -> std::io::Result<()> {
@@ -239,72 +169,95 @@ async fn main() {
         return cli::SeafowlCli::new(context).command_loop().await.unwrap();
     }
 
-    // Ref: https://tokio.rs/tokio/topics/shutdown#waiting-for-things-to-finish-shutting-down
-    let (shutdown, _) = channel(1);
+    Toplevel::new(|s: SubsystemHandle<Infallible>| async move {
+        let mut any_frontends: bool = false;
 
-    let mut tasks = prepare_frontends(context.clone(), &shutdown);
+        #[cfg(feature = "frontend-arrow-flight")]
+        if let Some(flight) = &context.config.frontend.flight {
+            let context = context.clone();
+            let flight = flight.clone();
+            any_frontends = true;
+            s.start(SubsystemBuilder::new("Arrow Flight frontend", move |h| async move {
+                info!(
+                    "Starting the Arrow Flight frontend on {}:{}",
+                    flight.bind_host, flight.bind_port
+                );
+                run_flight_server(context, flight, async move {
+                    h.on_shutdown_requested().await;
+                    info!("Shutting down Flight frontend...");
+                }).await;
+                Ok::<(), Infallible>(())
+            }));
+        };
+    
+        #[cfg(feature = "frontend-postgres")]
+        if let Some(pg) = &context.config.frontend.postgres {
+            let context = context.clone();
+            let pg = pg.clone();
+            any_frontends = true;
+            s.start(SubsystemBuilder::new("PostgreSQL frontend", move |h| async move {
+                info!(
+                    "Starting the PostgreSQL frontend on {}:{}",
+                    pg.bind_host, pg.bind_port
+                );
+                warn!(
+                    "The PostgreSQL frontend doesn't have authentication or encryption and should only be used in development!"
+                );
+                select! {
+                    e = run_pg_server(context, pg) => e,
+                    _ = h.on_shutdown_requested() => (),
+                };
+                
+                Ok::<(), Infallible>(())
+            }));
+        };
+    
+        if let Some(http) = &context.config.frontend.http {
+            let context = context.clone();
+            let http = http.clone();
+            any_frontends = true;
+            s.start(
+                SubsystemBuilder::new("HTTP frontend", move |h| async move {
+                let server = run_server(context, http.clone(), async move {
+                    h.on_shutdown_requested().await;
+                    info!("Shutting down HTTP frontend...");
+                });
+                info!(
+                    "Starting the HTTP frontend on {}:{}",
+                    http.bind_host, http.bind_port
+                );
+                info!(
+                    "HTTP access settings: read {}, write {}",
+                    http.read_access, http.write_access
+                );
+                server.await;
+                Ok::<(), Infallible>(())
+            }));
+        };
 
-    if tasks.is_empty() {
-        error!(
-            "No frontends configured. You will not be able to connect to Seafowl.\n
-Run Seafowl with --one-off instead to run a one-off command from the CLI."
-        );
-        exit(-1);
-    }
-
-    // Add a GC task for purging obsolete objects from the catalog and the store
-    if context.config.misc.gc_interval > 0 {
-        let mut shutdown_r = shutdown.subscribe();
-        let mut interval = interval(Duration::from_secs(
-            (context.config.misc.gc_interval * 3600) as u64,
-        ));
-        tasks.push(
-            async move {
-                loop {
-                    tokio::select! {
-                        _ = interval.tick() => gc_databases(&context, None).await,
-                        _ = shutdown_r.recv() => {
-                            info!("GC task received shutdown signal, exiting");
-                            break;
-                        }
-                    }
-                }
-            }
-            .boxed(),
-        );
-    }
-
-    // Add a task that will wait for a termination signal and tell frontends to stop
-    tasks.push(
-        async move {
-            // Wait for a termination signal
-            #[cfg(unix)]
-            {
-                let mut sigterm = signal(SignalKind::terminate())
-                    .expect("Error subscribing to the SIGTERM signal");
-                tokio::select! {
-                    // Ctrl+C: SIGINT
-                    _ = ctrl_c() => {},
-                    // SIGTERM
-                    _ = sigterm.recv() => {},
-                }
-            }
-
-            #[cfg(not(unix))]
-            {
-                tokio::select! {
-                    // Ctrl+C: termination request on Windows (?)
-                    _ = ctrl_c() => {},
-                }
-            }
-
-            info!("Shutting down...");
-            shutdown.send(()).expect("Error during graceful shutdown");
+        if !any_frontends {
+            error!(
+                "No frontends configured. You will not be able to connect to Seafowl.\n
+    Run Seafowl with --one-off instead to run a one-off command from the CLI."
+            );
+            exit(-1);
         }
-        .boxed(),
-    );
 
-    // Start everything and wait for it to exit (gracefully or ungracefully)
-    join_all(tasks).await;
+        // Add a GC task for purging obsolete objects from the catalog and the store
+        if context.config.misc.gc_interval > 0 {
+            let mut interval = interval(Duration::from_secs(
+                (context.config.misc.gc_interval * 3600) as u64,
+            ));
+
+            s.start::<Infallible, _, _>(SubsystemBuilder::new("Table garbage collection", move |_h| async move {
+                loop {
+                    interval.tick().await;
+                    gc_databases(&context, None).await;
+                };
+            }));
+        };
+    }).catch_signals()
+    .handle_shutdown_requests(Duration::from_secs(5))
+    .await.unwrap();
     info!("Exiting cleanly.");
 }

--- a/tests/flight/mod.rs
+++ b/tests/flight/mod.rs
@@ -7,6 +7,7 @@ use futures::TryStreamExt;
 use prost::Message;
 use reqwest::StatusCode;
 use rstest::rstest;
+use std::future;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tonic::metadata::MetadataValue;
@@ -62,7 +63,8 @@ async fn flight_server() -> (Arc<SeafowlContext>, FlightClient) {
         .expect("Arrow Flight frontend configured")
         .clone();
 
-    let flight = run_flight_server(context.clone(), flight_cfg.clone());
+    let flight =
+        run_flight_server(context.clone(), flight_cfg.clone(), future::pending());
     tokio::task::spawn(flight);
 
     // Create the channel for the client


### PR DESCRIPTION
This simplifies shutdown handling and means that if a subsystem fails to start (panics), Seafowl exits.

Tested manually (set flight port to an already-used one):

```
2024-04-11T12:26:00.638088Z  INFO main ThreadId(01) seafowl: Starting Seafowl 0.5.5
2024-04-11T12:26:00.638236Z  INFO main ThreadId(01) seafowl: Loading the configuration from seafowl.toml
2024-04-11T12:26:00.658400Z  INFO tokio-runtime-worker ThreadId(19) seafowl: Starting the Arrow Flight frontend on 127.0.0.1:9000
2024-04-11T12:26:00.658437Z  INFO tokio-runtime-worker ThreadId(15) seafowl: Starting the PostgreSQL frontend on 127.0.0.1:6432
2024-04-11T12:26:00.658486Z  WARN tokio-runtime-worker ThreadId(15) seafowl: The PostgreSQL frontend doesn't have authentication or encryption and should only be used in development!
2024-04-11T12:26:00.658480Z  INFO tokio-runtime-worker ThreadId(20) seafowl: Starting the HTTP frontend on 0.0.0.0:8080
2024-04-11T12:26:00.658540Z  INFO tokio-runtime-worker ThreadId(20) seafowl: HTTP access settings: read any, write off
thread 'tokio-runtime-worker' panicked at [...]seafowl/src/frontend/flight/mod.rs:43:10:
called `Result::unwrap()` on an `Err` value: tonic::transport::Error(Transport, hyper::Error(Listen, Os { code: 98, kind: AddrInUse, message: "Address already in use" }))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2024-04-11T12:26:00.658851Z ERROR tokio-runtime-worker ThreadId(19) tokio_graceful_shutdown::toplevel: Uncaught panic from subsytem '/Arrow Flight frontend'.
2024-04-11T12:26:00.658944Z  INFO tokio-runtime-worker ThreadId(20) seafowl::frontend::http: Shutting down Warp...
2024-04-11T12:26:00.658950Z  INFO                 main ThreadId(01) tokio_graceful_shutdown::toplevel: Shutting down ...
2024-04-11T12:26:00.660439Z  WARN                 main ThreadId(01) tokio_graceful_shutdown::toplevel: Shutdown finished with errors.
thread 'main' panicked at src/main.rs:255:12:
called `Result::unwrap()` on an `Err` value: SubsystemsFailed([Panicked("/Arrow Flight frontend")])
```

normal shutdown:

```
2024-04-11T12:41:52.156355Z  INFO main ThreadId(01) seafowl: Starting Seafowl 0.5.5
2024-04-11T12:41:52.156622Z  INFO main ThreadId(01) seafowl: Loading the configuration from seafowl.toml
2024-04-11T12:41:52.183805Z  INFO tokio-runtime-worker ThreadId(21) seafowl: Starting the Arrow Flight frontend on 127.0.0.1:47470
2024-04-11T12:41:52.183844Z  INFO tokio-runtime-worker ThreadId(19) seafowl: Starting the PostgreSQL frontend on 127.0.0.1:6432
2024-04-11T12:41:52.183895Z  WARN tokio-runtime-worker ThreadId(19) seafowl: The PostgreSQL frontend doesn't have authentication or encryption and should only be used in development!
2024-04-11T12:41:52.183924Z  INFO tokio-runtime-worker ThreadId(15) seafowl: Starting the HTTP frontend on 0.0.0.0:8080
2024-04-11T12:41:52.183986Z  INFO tokio-runtime-worker ThreadId(15) seafowl: HTTP access settings: read any, write off

^C

2024-04-11T12:41:53.264914Z  INFO tokio-runtime-worker ThreadId(04) seafowl::frontend::flight: Shutting down Flight frontend...
2024-04-11T12:41:53.264981Z  INFO tokio-runtime-worker ThreadId(15) seafowl::frontend::http: Shutting down Warp...
2024-04-11T12:41:53.265353Z  INFO                 main ThreadId(01) tokio_graceful_shutdown::toplevel: Shutting down ...
2024-04-11T12:41:53.269040Z  INFO                 main ThreadId(01) tokio_graceful_shutdown::toplevel: Shutdown finished.
2024-04-11T12:41:53.269133Z  INFO                 main ThreadId(01) seafowl: Exiting cleanly.
```