### PR TITLE
Add Prometheus metrics to MemoryManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "moka",
  "object_store",
- "parking_lot",
  "percent-encoding",
  "prost",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,6 @@ metrics = { version = "0.22.1" }
 metrics-exporter-prometheus = { version = "0.13.1" }
 moka = { version = "0.12.5", default_features = false, features = ["future", "atomic64", "quanta"] }
 object_store = "0.9"
-parking_lot = "0.12.1"
 percent-encoding = "2.2.0"
 prost = "0.12.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,9 @@ include = [
 
 [features]
 catalog-postgres = ["sqlx/postgres"]
-default = ["catalog-postgres", "frontend-arrow-flight", "frontend-postgres", "metrics", "object-store-s3", "object-store-gcs", "remote-tables"]
+default = ["catalog-postgres", "frontend-arrow-flight", "frontend-postgres", "object-store-s3", "object-store-gcs", "remote-tables"]
 frontend-arrow-flight = ["dep:tonic", "dep:arrow-flight", "arrow-flight/flight-sql-experimental"]
 frontend-postgres = ["convergence", "convergence-arrow"]
-metrics = ["dep:metrics", "dep:metrics-exporter-prometheus", "dep:tower"]
 object-store-gcs = ["object_store/gcp"]
 object-store-s3 = ["object_store/aws"]
 remote-tables = ["dep:datafusion-remote-tables"]
@@ -104,9 +103,8 @@ futures = "0.3"
 hex = ">=0.4.0"
 itertools = { workspace = true }
 lazy_static = ">=1.4.0"
-# Pick up hashbrown >0.13.1 to resolve conflicts with wasm crates
-metrics = { version = "0.22.1", optional = true }
-metrics-exporter-prometheus = { version = "0.13.1", optional = true }
+metrics = { version = "0.22.1" }
+metrics-exporter-prometheus = { version = "0.13.1" }
 moka = { version = "0.12.5", default_features = false, features = ["future", "atomic64", "quanta"] }
 object_store = "0.9"
 parking_lot = "0.12.1"
@@ -134,7 +132,7 @@ thiserror = "1"
 tokio = { workspace = true }
 tokio-graceful-shutdown = { version = "0.14" }
 tonic = { version = "0.10.0", optional = true }
-tower = { version = "0.4", optional = true }
+tower = "0.4"
 tracing = { workspace = true }
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }

--- a/src/catalog/metastore.rs
+++ b/src/catalog/metastore.rs
@@ -14,11 +14,11 @@ use crate::wasm_udf::data_types::{
     CreateFunctionVolatility,
 };
 use clade::schema::{SchemaObject, TableObject};
+use dashmap::DashMap;
 use datafusion::catalog::schema::MemorySchemaProvider;
 use datafusion::datasource::TableProvider;
 
 use deltalake::DeltaTable;
-use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -111,13 +111,13 @@ impl Metastore {
             .tables
             .into_iter()
             .map(|table| self.build_table(table, store_options))
-            .collect::<CatalogResult<HashMap<_, _>>>()?;
+            .collect::<CatalogResult<DashMap<_, _>>>()?;
 
         Ok((
             Arc::from(schema_name.clone()),
             Arc::new(SeafowlSchema {
                 name: Arc::from(schema_name),
-                tables: RwLock::new(tables),
+                tables,
             }),
         ))
     }

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -15,9 +15,7 @@ use datafusion::{
 };
 use deltalake::delta_datafusion::DeltaTableFactory;
 use deltalake::storage::factories;
-#[cfg(feature = "metrics")]
 use metrics::describe_counter;
-#[cfg(feature = "metrics")]
 use metrics_exporter_prometheus::PrometheusBuilder;
 
 #[cfg(feature = "catalog-postgres")]
@@ -32,10 +30,7 @@ use datafusion_remote_tables::factory::RemoteTableFactory;
 
 use super::schema::{self, MEBIBYTES, MEMORY_FRACTION};
 
-#[cfg(feature = "metrics")]
 pub const HTTP_REQUESTS: &str = "http_requests";
-
-#[cfg(feature = "metrics")]
 pub const GRPC_REQUESTS: &str = "grpc_requests";
 
 async fn build_metastore(
@@ -102,7 +97,6 @@ pub fn build_state_with_table_factories(
     state
 }
 
-#[cfg(feature = "metrics")]
 pub fn setup_metrics(metrics: &schema::Metrics) {
     let addr: SocketAddr = format!("{}:{}", metrics.host, metrics.port)
         .parse()

--- a/src/frontend/flight/mod.rs
+++ b/src/frontend/flight/mod.rs
@@ -1,5 +1,4 @@
 mod handler;
-#[cfg(feature = "metrics")]
 mod metrics;
 mod sql;
 
@@ -8,7 +7,6 @@ use crate::context::SeafowlContext;
 use crate::frontend::flight::handler::SeafowlFlightHandler;
 use arrow_flight::flight_service_server::FlightServiceServer;
 use futures::Future;
-#[cfg(feature = "metrics")]
 use metrics::MetricsLayer;
 
 use std::net::SocketAddr;
@@ -29,8 +27,6 @@ pub async fn run_flight_server(
     let svc = FlightServiceServer::new(handler);
 
     let server = Server::builder();
-
-    #[cfg(feature = "metrics")]
     let mut server = server.layer(MetricsLayer {});
 
     server

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -41,7 +41,6 @@ use warp::{hyper::header, hyper::StatusCode, Filter, Reply};
 use super::http_utils::{handle_rejection, into_response, ApiError};
 use crate::auth::{token_to_principal, AccessPolicy, Action, UserContext};
 use crate::catalog::DEFAULT_DB;
-#[cfg(feature = "metrics")]
 use crate::config::context::HTTP_REQUESTS;
 use crate::config::schema::{AccessSettings, HttpFrontend, MEBIBYTES};
 use crate::{
@@ -525,7 +524,6 @@ pub fn filters(
     let log = warp::log::custom(|info: Info<'_>| {
         let path = info.path();
 
-        #[cfg(feature = "metrics")]
         {
             let route = if path.contains("/upload/") {
                 "/upload".to_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod context;
 pub mod datafusion;
 pub mod frontend;
+pub mod memory_pool;
 pub mod nodes;
 pub mod object_store;
 pub mod provider;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(let_chains)]
 
 use clap::AppSettings::NoAutoVersion;
+use seafowl::config::context::setup_metrics;
 use tokio::select;
 
 use std::convert::Infallible;
@@ -14,7 +15,6 @@ use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 use clap::Parser;
 
-use seafowl::config::context::setup_metrics;
 #[cfg(feature = "frontend-arrow-flight")]
 use seafowl::frontend::flight::run_flight_server;
 use seafowl::{
@@ -150,7 +150,6 @@ async fn main() {
         config
     };
 
-    #[cfg(feature = "metrics")]
     if !args.cli
         && let Some(ref metrics) = config.misc.metrics
     {

--- a/src/memory_pool.rs
+++ b/src/memory_pool.rs
@@ -40,7 +40,6 @@ impl Metrics {
         size: usize,
         success: bool,
     ) {
-        print!("register allocation");
         let name = extract_consumer_name(reservation.consumer().name()).to_string();
         let result = if success { "success" } else { "error" };
         counter!(ALLOCATIONS, "consumer" => name, "result" => result)

--- a/src/memory_pool.rs
+++ b/src/memory_pool.rs
@@ -1,0 +1,125 @@
+/// Wrapper around a DataFusion MemoryPool that records allocations,
+/// deallocations, usage. Note that not all query operators register
+/// themselves with the pool, so this isn't an exact limit or breakdown
+/// of the memory used by the query processing.
+use std::sync::Arc;
+
+use datafusion::execution::memory_pool::{MemoryConsumer, MemoryPool, MemoryReservation};
+use metrics::{counter, describe_gauge, gauge, Gauge};
+
+const ALLOCATIONS: &str = "seafowl_datafusion_memory_pool_allocated_bytes_total";
+const DEALLOCATIONS: &str = "seafowl_datafusion_memory_pool_freed_bytes_total";
+const RESERVED: &str = "seafowl_datafusion_memory_pool_reserved_bytes_current";
+
+struct Metrics {
+    memory_reserved: Gauge,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        describe_gauge!(
+            ALLOCATIONS,
+            "Memory allocated in DataFusion's managed memory pool"
+        );
+        describe_gauge!(
+            DEALLOCATIONS,
+            "Memory freed in DataFusion's managed memory pool"
+        );
+        describe_gauge!(
+            RESERVED,
+            "Current memory reserved in DataFusion's managed memory pool"
+        );
+
+        Self {
+            memory_reserved: gauge!(RESERVED),
+        }
+    }
+
+    pub fn register_allocation(
+        reservation: &MemoryReservation,
+        size: usize,
+        success: bool,
+    ) {
+        let name = extract_consumer_name(reservation.consumer().name()).to_string();
+        let result = if success { "success" } else { "error" };
+        counter!(ALLOCATIONS, "consumer" => name, "result" => result)
+            .increment(size.try_into().unwrap())
+    }
+
+    pub fn register_deallocation(reservation: &MemoryReservation, size: usize) {
+        let name = extract_consumer_name(reservation.consumer().name()).to_string();
+        counter!(DEALLOCATIONS, "consumer" => name).increment(size.try_into().unwrap())
+    }
+}
+
+// DataFusion's consumers usually register themselves as
+// e.g. ExternalSorterMerge[partition_id] where partition is basically the CPU core
+// so we just meld them all into one metric for the whole query operation type
+fn extract_consumer_name(name: &str) -> &str {
+    &name[0..name.find('[').unwrap_or(name.len())]
+}
+
+pub struct MemoryPoolMetrics {
+    inner: Arc<dyn MemoryPool>,
+    metrics: Metrics,
+}
+
+impl std::fmt::Debug for MemoryPoolMetrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryPoolMetrics").finish()
+    }
+}
+
+impl MemoryPoolMetrics {
+    pub fn new(inner: Arc<dyn MemoryPool>) -> Self {
+        let metrics = Metrics::new();
+        metrics.memory_reserved.set(0.0);
+
+        Self { inner, metrics }
+    }
+}
+
+impl MemoryPool for MemoryPoolMetrics {
+    fn register(&self, consumer: &MemoryConsumer) {
+        self.inner.register(consumer)
+    }
+
+    fn unregister(&self, consumer: &MemoryConsumer) {
+        self.inner.unregister(consumer)
+    }
+
+    fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+        self.inner.grow(reservation, additional);
+        self.metrics
+            .memory_reserved
+            .set(self.inner.reserved() as f64);
+        Metrics::register_allocation(reservation, additional, true)
+    }
+
+    fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+        self.inner.shrink(reservation, shrink);
+        self.metrics
+            .memory_reserved
+            .set(self.inner.reserved() as f64);
+        Metrics::register_deallocation(reservation, shrink)
+    }
+
+    fn try_grow(
+        &self,
+        reservation: &MemoryReservation,
+        additional: usize,
+    ) -> datafusion_common::Result<()> {
+        let result = self.inner.try_grow(reservation, additional);
+        self.metrics
+            .memory_reserved
+            .set(self.inner.reserved() as f64);
+
+        Metrics::register_allocation(reservation, additional, result.is_ok());
+
+        result
+    }
+
+    fn reserved(&self) -> usize {
+        self.inner.reserved()
+    }
+}


### PR DESCRIPTION
Make the metrics feature non-optional (there's a lot of code coming that exposes metrics and it'll get painful/pointless to maintain the ability to opt out of compiling metrics support at the cargo feature level

Add a special `MemoryPool` that wraps the default DataFusion `MemoryPool` (that setting defaults to `GreedyMemoryPool`, so construct that explicitly) and logs the total allocated/released bytes by each DataFusion query tree node.

Also replace all uses of `RwLock<HashMap>` to `DashMap` as @gruuya proposed.

Sample output:

```
# HELP seafowl_datafusion_memory_pool_reserved_bytes_current Current memory reserved in DataFusion's managed memory pool
# TYPE seafowl_datafusion_memory_pool_reserved_bytes_current gauge
seafowl_datafusion_memory_pool_reserved_bytes_current 0
# HELP seafowl_datafusion_memory_pool_freed_bytes_total Memory freed in DataFusion's managed memory pool
# TYPE seafowl_datafusion_memory_pool_freed_bytes_total counter
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="RepartitionExec"} 2033677121
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="NestedLoopJoinLoad"} 15072
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="TopK"} 5951438
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="GroupedHashAggregateStream"} 89032440
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="CrossJoinExec"} 21184
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="HashJoinStream"} 18346
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="AggregateStream"} 3230
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="SortPreservingMergeExec"} 2932891
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="ExternalSorter"} 3268145
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="HashJoinInput"} 112437164
seafowl_datafusion_memory_pool_freed_bytes_total{consumer="ExternalSorterMerge"} 120259084288

# HELP seafowl_datafusion_memory_pool_allocated_bytes_total Memory allocated in DataFusion's managed memory pool
# TYPE seafowl_datafusion_memory_pool_allocated_bytes_total counter
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="TopK",result="success"} 5951438
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="SortPreservingMergeExec",result="success"} 2932891
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="ExternalSorter",result="success"} 3268145
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="HashJoinStream",result="success"} 18346
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="ExternalSorterMerge",result="success"} 120259084288
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="HashJoinInput",result="success"} 112437164
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="NestedLoopJoinLoad",result="success"} 15072
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="AggregateStream",result="success"} 3230
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="GroupedHashAggregateStream",result="success"} 89032440
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="RepartitionExec",result="success"} 2033677121
seafowl_datafusion_memory_pool_allocated_bytes_total{consumer="CrossJoinExec",result="success"} 21184