### PR TITLE
Add various object store cache Prometheus metrics

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1,24 +1,22 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+
 use std::{
     fmt::{self, Display},
     path::{Path, PathBuf},
-    time::Duration,
 };
 
 use crate::catalog::DEFAULT_SCHEMA;
 use crate::object_store::cache::{
-    CachingObjectStore, DEFAULT_CACHE_CAPACITY, DEFAULT_CACHE_ENTRY_TTL,
-    DEFAULT_MIN_FETCH_SIZE,
+    DEFAULT_CACHE_CAPACITY, DEFAULT_CACHE_ENTRY_TTL, DEFAULT_MIN_FETCH_SIZE,
 };
 use config::{Config, ConfigError, Environment, File, FileFormat, Map};
 use hex::encode;
-use object_store::DynObjectStore;
+
 use rand::distributions::{Alphanumeric, DistString};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use sqlx::sqlite::SqliteJournalMode;
-use tempfile::TempDir;
+
 use tracing::{info, warn};
 
 pub const DEFAULT_DATA_DIR: &str = "seafowl-data";
@@ -394,21 +392,6 @@ impl Default for ObjectCacheProperties {
             min_fetch_size: DEFAULT_MIN_FETCH_SIZE,
             ttl: DEFAULT_CACHE_ENTRY_TTL.as_secs(),
         }
-    }
-}
-
-impl ObjectCacheProperties {
-    pub fn wrap_store(&self, inner: Arc<DynObjectStore>) -> Arc<DynObjectStore> {
-        let tmp_dir = TempDir::new().unwrap();
-        let path = tmp_dir.into_path();
-
-        Arc::new(CachingObjectStore::new(
-            inner,
-            &path,
-            self.min_fetch_size,
-            self.capacity,
-            Duration::from_secs(self.ttl),
-        ))
     }
 }
 

--- a/src/object_store/cache.rs
+++ b/src/object_store/cache.rs
@@ -788,10 +788,11 @@ mod tests {
     use crate::object_store::http::HttpObjectStore;
     use crate::{
         config::schema::str_to_hex_hash, object_store::cache::CachingObjectStore,
+        utils::assert_metric,
     };
     use itertools::Itertools;
     use metrics::with_local_recorder;
-    use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusRecorder};
+    use metrics_exporter_prometheus::PrometheusBuilder;
     use object_store::{path::Path, ObjectStore};
     use std::path::Path as FSPath;
     use std::sync::Arc;
@@ -874,15 +875,6 @@ mod tests {
             i += 1;
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
-    }
-
-    fn assert_metric(recorder: &PrometheusRecorder, key: &str, value: u64) {
-        let rendered = recorder.handle().render();
-        let metric_line = rendered
-            .lines()
-            .find(|l| l.starts_with(&format!("{key} ")))
-            .unwrap_or_else(|| panic!("no metric {key} found"));
-        assert_eq!(metric_line, format!("{key} {value}"))
     }
 
     #[rstest]

--- a/src/object_store/cache.rs
+++ b/src/object_store/cache.rs
@@ -555,14 +555,6 @@ impl Display for CachingObjectStore {
 
 #[async_trait]
 impl ObjectStore for CachingObjectStore {
-    async fn put(
-        &self,
-        location: &object_store::path::Path,
-        bytes: Bytes,
-    ) -> object_store::Result<PutResult> {
-        self.inner.put(location, bytes).await
-    }
-
     async fn put_opts(
         &self,
         location: &object_store::path::Path,
@@ -585,13 +577,6 @@ impl ObjectStore for CachingObjectStore {
         multipart_id: &MultipartId,
     ) -> object_store::Result<()> {
         self.inner.abort_multipart(location, multipart_id).await
-    }
-
-    async fn get(
-        &self,
-        location: &object_store::path::Path,
-    ) -> object_store::Result<GetResult> {
-        self.inner.get(location).await
     }
 
     async fn get_opts(

--- a/src/object_store/cache.rs
+++ b/src/object_store/cache.rs
@@ -906,9 +906,7 @@ mod tests {
         assert_metric(&recorder, GET_RANGE_CACHE_HITS_DISK_BYTES, 16);
         assert_metric(&recorder, GET_RANGE_CACHE_HITS_MEMORY_BYTES, 0);
         assert_metric(&recorder, CACHE_USAGE, 48);
-        // TODO: for some reason here the eviction listener has already fired
-        // even though above we have evicted=0
-        assert_metric(&recorder, CACHE_EVICTED, 48);
+        assert_metric(&recorder, CACHE_EVICTED, 0);
 
         // Request 33..66 (chunks 2, 3, 4)
         let bytes = store
@@ -926,7 +924,7 @@ mod tests {
         assert_metric(&recorder, GET_RANGE_CACHE_HITS_DISK_BYTES, 48);
         assert_metric(&recorder, GET_RANGE_CACHE_HITS_MEMORY_BYTES, 0);
         assert_metric(&recorder, CACHE_USAGE, 48);
-        // assert_metric(&recorder, CACHE_EVICTED, 0);
+        assert_metric(&recorder, CACHE_EVICTED, 0);
 
         let mut on_disk_keys = wait_all_ranges_on_disk(on_disk_keys, &store).await;
         assert_ranges_in_cache(&store.base_path, &url, vec![1, 2, 3, 4]);
@@ -948,7 +946,7 @@ mod tests {
         assert_metric(&recorder, DISK_WRITTEN, 64);
         assert_metric(&recorder, DISK_READ, 48);
         assert_metric(&recorder, CACHE_USAGE, 48);
-        // assert_metric(&recorder, CACHE_EVICTED, 16);
+        assert_metric(&recorder, CACHE_EVICTED, 16);
 
         on_disk_keys.retain(|k| k.range.start >= 32); // The first chunk got LRU-evicted
         wait_all_ranges_on_disk(on_disk_keys, &store).await;
@@ -961,7 +959,6 @@ mod tests {
 
         assert_eq!(store.cache.entry_count(), 0);
         assert_ranges_in_cache(&store.base_path, &url, vec![]);
-        // TODO: why so many???
-        assert_metric(&recorder, CACHE_EVICTED, 160);
+        assert_metric(&recorder, CACHE_EVICTED, 80);
     }
 }

--- a/src/object_store/cache.rs
+++ b/src/object_store/cache.rs
@@ -282,14 +282,17 @@ impl CachingObjectStore {
             "An entry has been evicted. k: {:?}, v: {:?}, cause: {:?}",
             key, value, cause
         );
-        file_manager
-            .metrics
-            .cache_evicted
-            .increment(value.size().try_into().unwrap());
-        file_manager
-            .metrics
-            .cache_usage
-            .decrement(value.size() as f64);
+
+        if cause != RemovalCause::Replaced {
+            file_manager
+                .metrics
+                .cache_evicted
+                .increment(value.size().try_into().unwrap());
+            file_manager
+                .metrics
+                .cache_usage
+                .decrement(value.size() as f64);
+        };
 
         if let CacheValue::File(path, _) = value {
             // Remove the data file. We must handle error cases here to


### PR DESCRIPTION
Add a bunch of various timing / sizing metrics to the object store cache:

- Bytes read from disk and from memory for cache hits
- Bytes written to disk
- Bytes requested in get_range for DataFusion
- Success/error rate of all outbound object store calls and time-to-first-byte
- Cache consistency "warnings" (our mitigations against race conditions)

Limitations:

- Doesn't instrument the sizes returned by non-get-range methods (those return streams and we don't wrap them in an instrumenting wrapper)
- Because of this, some timings on certain methods are meaningless (e.g. list seems to return almost immediately and only loads data when the stream is polled) and should potentially be removed

This is based on top of https://github.com/splitgraph/seafowl/pull/518/ which has some DataFusion MemoryManager metrics

Sample metrics scrape from a TPC-H/DS run:

```
# HELP seafowl_object_store_cache_get_range_requested_bytes_total Bytes requested in get_range calls by DataFusion before caching
# TYPE seafowl_object_store_cache_get_range_requested_bytes_total counter
seafowl_object_store_cache_get_range_requested_bytes_total 1653431887

# HELP seafowl_object_store_requests_total Number of calls to the actual object store
# TYPE seafowl_object_store_requests_total counter
seafowl_object_store_requests_total{operation="get_range",status="success"} 73
seafowl_object_store_requests_total{operation="list",status="unknown"} 4587
seafowl_object_store_requests_total{operation="get",status="success"} 13761

# HELP seafowl_object_store_cache_hit_read_bytes_total Bytes read from the object store cache (hit)
# TYPE seafowl_object_store_cache_hit_read_bytes_total counter
seafowl_object_store_cache_hit_read_bytes_total{location="disk"} 3768333104
seafowl_object_store_cache_hit_read_bytes_total{location="memory"} 2763647

# HELP seafowl_object_store_cache_get_range_requests_total Number of get_range requests from DataFusion before caching
# TYPE seafowl_object_store_cache_get_range_requests_total counter
seafowl_object_store_cache_get_range_requests_total 23932

# HELP seafowl_object_store_cache_evicted_bytes Bytes evicted from cache
# TYPE seafowl_object_store_cache_evicted_bytes counter
seafowl_object_store_cache_evicted_bytes 0

# HELP seafowl_object_store_cache_disk_written_bytes_total Bytes written to on-disk cache
# TYPE seafowl_object_store_cache_disk_written_bytes_total counter
seafowl_object_store_cache_disk_written_bytes_total 13268070

# HELP grpc_requests Counter tracking gRPC request statistics
# TYPE grpc_requests counter
grpc_requests{path="/arrow.flight.protocol.FlightService/GetFlightInfo",status="13"} 373
grpc_requests{path="/arrow.flight.protocol.FlightService/GetFlightInfo",status="0"} 4661
grpc_requests{path="/arrow.flight.protocol.FlightService/DoGet",status="0"} 4661

# HELP seafowl_object_store_cache_warnings_total Number of times various cache race conditions were discovered (read-after-evict, double-write, double-delete)
# TYPE seafowl_object_store_cache_warnings_total counter
seafowl_object_store_cache_warnings_total{error="deletion"} 0
seafowl_object_store_cache_warnings_total{error="double_write"} 0
seafowl_object_store_cache_warnings_total{error="redownload"} 0

# HELP seafowl_object_store_cache_get_range_read_bytes_total Bytes downloaded from the upstream object store for get_range cache misses
# TYPE seafowl_object_store_cache_get_range_read_bytes_total counter
seafowl_object_store_cache_get_range_read_bytes_total 15893361

# HELP seafowl_object_store_cache_usage_bytes Approximate current occupation of the cache
# TYPE seafowl_object_store_cache_usage_bytes gauge
seafowl_object_store_cache_usage_bytes 13267128

# HELP seafowl_object_store_cache_capacity_bytes Total cache capacity
# TYPE seafowl_object_store_cache_capacity_bytes gauge
seafowl_object_store_cache_capacity_bytes 268435456

# HELP seafowl_object_store_request_latency_seconds Time-to-first-byte of various requests to the actual object store
# TYPE seafowl_object_store_request_latency_seconds summary
seafowl_object_store_request_latency_seconds{operation="get_range",status="success",quantile="0"} 0
seafowl_object_store_request_latency_seconds{operation="get_range",status="success",quantile="0.5"} 0
seafowl_object_store_request_latency_seconds{operation="get_range",status="success",quantile="0.9"} 0
seafowl_object_store_request_latency_seconds{operation="get_range",status="success",quantile="0.95"} 0
seafowl_object_store_request_latency_seconds{operation="get_range",status="success",quantile="0.99"} 0
seafowl_object_store_request_latency_seconds{operation="get_range",status="success",quantile="0.999"} 0
seafowl_object_store_request_latency_seconds{operation="get_range",status="success",quantile="1"} 0
seafowl_object_store_request_latency_seconds_sum{operation="get_range",status="success"} 0.23178057900000007
seafowl_object_store_request_latency_seconds_count{operation="get_range",status="success"} 73
seafowl_object_store_request_latency_seconds{operation="get",status="success",quantile="0"} 0.000781908
seafowl_object_store_request_latency_seconds{operation="get",status="success",quantile="0.5"} 0.0007819654274285743
seafowl_object_store_request_latency_seconds{operation="get",status="success",quantile="0.9"} 0.0007819654274285743
seafowl_object_store_request_latency_seconds{operation="get",status="success",quantile="0.95"} 0.0007819654274285743
seafowl_object_store_request_latency_seconds{operation="get",status="success",quantile="0.99"} 0.0007819654274285743
seafowl_object_store_request_latency_seconds{operation="get",status="success",quantile="0.999"} 0.0007819654274285743
seafowl_object_store_request_latency_seconds{operation="get",status="success",quantile="1"} 0.000781908
seafowl_object_store_request_latency_seconds_sum{operation="get",status="success"} 11.07166186999995
seafowl_object_store_request_latency_seconds_count{operation="get",status="success"} 13761
seafowl_object_store_request_latency_seconds{operation="list",status="unknown",quantile="0"} 0.000001859
seafowl_object_store_request_latency_seconds{operation="list",status="unknown",quantile="0.5"} 0.0000033102062906382345
seafowl_object_store_request_latency_seconds{operation="list",status="unknown",quantile="0.9"} 0.000004868619916292589
seafowl_object_store_request_latency_seconds{operation="list",status="unknown",quantile="0.95"} 0.000005156254853472572
seafowl_object_store_request_latency_seconds{operation="list",status="unknown",quantile="0.99"} 0.000006454712686792021
seafowl_object_store_request_latency_seconds{operation="list",status="unknown",quantile="0.999"} 0.000006454712686792021
seafowl_object_store_request_latency_seconds{operation="list",status="unknown",quantile="1"} 0.000012291
seafowl_object_store_request_latency_seconds_sum{operation="list",status="unknown"} 0.013296752000000018
seafowl_object_store_request_latency_seconds_count{operation="list",status="unknown"} 4587

# HELP seafowl_object_store_cache_disk_latency_seconds Time spent waiting for disk cache read / write
# TYPE seafowl_object_store_cache_disk_latency_seconds summary
seafowl_object_store_cache_disk_latency_seconds{operation="read",quantile="0"} 0.000084778
seafowl_object_store_cache_disk_latency_seconds{operation="read",quantile="0.5"} 0.00018950407426943935
seafowl_object_store_cache_disk_latency_seconds{operation="read",quantile="0.9"} 0.0002668830441480235
seafowl_object_store_cache_disk_latency_seconds{operation="read",quantile="0.95"} 0.00032911608360367857
seafowl_object_store_cache_disk_latency_seconds{operation="read",quantile="0.99"} 0.0004255619484064256
seafowl_object_store_cache_disk_latency_seconds{operation="read",quantile="0.999"} 0.0004255619484064256
seafowl_object_store_cache_disk_latency_seconds{operation="read",quantile="1"} 0.000481224
seafowl_object_store_cache_disk_latency_seconds_sum{operation="read"} 23.07007866300003
seafowl_object_store_cache_disk_latency_seconds_count{operation="read"} 29875
seafowl_object_store_cache_disk_latency_seconds{operation="write",quantile="0"} 0
seafowl_object_store_cache_disk_latency_seconds{operation="write",quantile="0.5"} 0
seafowl_object_store_cache_disk_latency_seconds{operation="write",quantile="0.9"} 0
seafowl_object_store_cache_disk_latency_seconds{operation="write",quantile="0.95"} 0
seafowl_object_store_cache_disk_latency_seconds{operation="write",quantile="0.99"} 0
seafowl_object_store_cache_disk_latency_seconds{operation="write",quantile="0.999"} 0
seafowl_object_store_cache_disk_latency_seconds{operation="write",quantile="1"} 0
seafowl_object_store_cache_disk_latency_seconds_sum{operation="write"} 0.030619615999999995
seafowl_object_store_cache_disk_latency_seconds_count{operation="write"} 81
```