### PR TITLE
Remove obsolete key from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   postgres:
     image: postgres:16


### PR DESCRIPTION
## What
Remove obsolete 'version' key from from docker-compose.yml
Our CI configuration uses Docker Compose v2, which ignores the 'version' key.

## Why
Reduce noise when running docker compose

## Context
https://docs.docker.com/compose/intro/history/