### PR TITLE
Add support for inline-ing metastore over Flight

### DIFF
--- a/clade/proto/schema.proto
+++ b/clade/proto/schema.proto
@@ -36,3 +36,8 @@ service SchemaStoreService {
   // List the available schemas
   rpc ListSchemas(ListSchemaRequest) returns (ListSchemaResponse);
 }
+
+message InlineMetastoreCommandStatementQuery {
+  string query = 1;
+  ListSchemaResponse schemas = 2;
+}

--- a/clade/src/lib.rs
+++ b/clade/src/lib.rs
@@ -1,7 +1,24 @@
 pub mod schema {
+    use arrow_flight::sql::{Any, ProstMessageExt};
+    use prost::Message;
+
     tonic::include_proto!("clade.schema");
     pub const FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("clade_descriptor");
+
+    // Same reasoning as below, but for `get_flight_info_fallback` instead
+    impl ProstMessageExt for InlineMetastoreCommandStatementQuery {
+        fn type_url() -> &'static str {
+            "InlineMetastoreCommandStatementQuery"
+        }
+
+        fn as_any(&self) -> Any {
+            Any {
+                type_url: InlineMetastoreCommandStatementQuery::type_url().to_string(),
+                value: self.encode_to_vec().into(),
+            }
+        }
+    }
 }
 
 pub mod sync {
@@ -24,7 +41,7 @@ pub mod sync {
 
         fn as_any(&self) -> Any {
             Any {
-                type_url: "DataSyncCommand".to_string(),
+                type_url: DataSyncCommand::type_url().to_string(),
                 value: self.encode_to_vec().into(),
             }
         }

--- a/src/catalog/external.rs
+++ b/src/catalog/external.rs
@@ -1,18 +1,11 @@
 use crate::catalog::{
-    not_impl, CatalogResult, CatalogStore, FunctionStore, SchemaStore, TableStore,
+    CatalogResult, CatalogStore, FunctionStore, SchemaStore, TableStore,
 };
-use crate::repository::interface::{
-    AllDatabaseFunctionsResult, CollectionRecord, DatabaseRecord,
-    DroppedTableDeletionStatus, DroppedTablesResult, TableId, TableRecord,
-    TableVersionId, TableVersionsResult,
-};
-use crate::wasm_udf::data_types::CreateFunctionDetails;
-use arrow_schema::Schema;
+use crate::repository::interface::AllDatabaseFunctionsResult;
 use clade::schema::schema_store_service_client::SchemaStoreServiceClient;
 use clade::schema::{ListSchemaRequest, ListSchemaResponse};
 use tonic::transport::{channel::Channel, Endpoint, Error};
 use tonic::Request;
-use uuid::Uuid;
 
 // An external store, facilitated via a remote clade server implementation
 #[derive(Clone)]
@@ -37,26 +30,10 @@ impl ExternalStore {
 }
 
 #[tonic::async_trait]
-impl CatalogStore for ExternalStore {
-    async fn create(&self, _name: &str) -> CatalogResult<()> {
-        not_impl()
-    }
-
-    async fn get(&self, _name: &str) -> CatalogResult<DatabaseRecord> {
-        not_impl()
-    }
-
-    async fn delete(&self, _name: &str) -> CatalogResult<()> {
-        not_impl()
-    }
-}
+impl CatalogStore for ExternalStore {}
 
 #[tonic::async_trait]
 impl SchemaStore for ExternalStore {
-    async fn create(&self, _catalog_name: &str, _schema_name: &str) -> CatalogResult<()> {
-        not_impl()
-    }
-
     async fn list(&self, catalog_name: &str) -> CatalogResult<ListSchemaResponse> {
         let req = Request::new(ListSchemaRequest {
             catalog_name: catalog_name.to_string(),
@@ -65,133 +42,17 @@ impl SchemaStore for ExternalStore {
         let response = self.client().list_schemas(req).await?;
         Ok(response.into_inner())
     }
-
-    async fn get(
-        &self,
-        _catalog_name: &str,
-        _schema_name: &str,
-    ) -> CatalogResult<CollectionRecord> {
-        not_impl()
-    }
-
-    async fn delete(&self, _catalog_name: &str, _schema_name: &str) -> CatalogResult<()> {
-        not_impl()
-    }
 }
 
 #[tonic::async_trait]
-impl TableStore for ExternalStore {
-    async fn create(
-        &self,
-        _catalog_name: &str,
-        _schema_name: &str,
-        _table_name: &str,
-        _schema: &Schema,
-        _uuid: Uuid,
-    ) -> CatalogResult<(TableId, TableVersionId)> {
-        not_impl()
-    }
-
-    async fn get(
-        &self,
-        _catalog_name: &str,
-        _schema_name: &str,
-        _table_name: &str,
-    ) -> CatalogResult<TableRecord> {
-        not_impl()
-    }
-
-    async fn create_new_version(
-        &self,
-        _uuid: Uuid,
-        _version: i64,
-    ) -> CatalogResult<TableVersionId> {
-        not_impl()
-    }
-
-    async fn delete_old_versions(
-        &self,
-        _catalog_name: &str,
-        _schema_name: &str,
-        _table_name: &str,
-    ) -> CatalogResult<u64> {
-        not_impl()
-    }
-
-    async fn get_all_versions(
-        &self,
-        _catalog_name: &str,
-        _table_names: Option<Vec<String>>,
-    ) -> CatalogResult<Vec<TableVersionsResult>> {
-        not_impl()
-    }
-
-    async fn update(
-        &self,
-        _old_catalog_name: &str,
-        _old_schema_name: &str,
-        _old_table_name: &str,
-        _new_catalog_name: &str,
-        _new_schema_name: &str,
-        _new_table_name: &str,
-    ) -> CatalogResult<()> {
-        not_impl()
-    }
-
-    async fn delete(
-        &self,
-        _catalog_name: &str,
-        _schema_name: &str,
-        _table_name: &str,
-    ) -> CatalogResult<()> {
-        not_impl()
-    }
-
-    async fn get_dropped_tables(
-        &self,
-        _catalog_name: Option<String>,
-    ) -> CatalogResult<Vec<DroppedTablesResult>> {
-        not_impl()
-    }
-
-    async fn update_dropped_table(
-        &self,
-        _uuid: Uuid,
-        _deletion_status: DroppedTableDeletionStatus,
-    ) -> CatalogResult<()> {
-        not_impl()
-    }
-
-    async fn delete_dropped_table(&self, _uuid: Uuid) -> CatalogResult<()> {
-        not_impl()
-    }
-}
+impl TableStore for ExternalStore {}
 
 #[tonic::async_trait]
 impl FunctionStore for ExternalStore {
-    async fn create(
-        &self,
-        _catalog_name: &str,
-        _function_name: &str,
-        _or_replace: bool,
-        _details: &CreateFunctionDetails,
-    ) -> CatalogResult<()> {
-        not_impl()
-    }
-
     async fn list(
         &self,
         _catalog_name: &str,
     ) -> CatalogResult<Vec<AllDatabaseFunctionsResult>> {
         Ok(vec![])
-    }
-
-    async fn delete(
-        &self,
-        _catalog_name: &str,
-        _if_exists: bool,
-        _func_names: &[String],
-    ) -> CatalogResult<()> {
-        not_impl()
     }
 }

--- a/src/catalog/memory.rs
+++ b/src/catalog/memory.rs
@@ -1,0 +1,33 @@
+use crate::catalog::{
+    CatalogResult, CatalogStore, FunctionStore, SchemaStore, TableStore,
+};
+use crate::repository::interface::AllDatabaseFunctionsResult;
+use clade::schema::ListSchemaResponse;
+
+#[derive(Clone)]
+pub struct MemoryStore {
+    pub schemas: ListSchemaResponse,
+}
+
+#[tonic::async_trait]
+impl CatalogStore for MemoryStore {}
+
+#[tonic::async_trait]
+impl SchemaStore for MemoryStore {
+    async fn list(&self, _catalog_name: &str) -> CatalogResult<ListSchemaResponse> {
+        Ok(self.schemas.clone())
+    }
+}
+
+#[tonic::async_trait]
+impl TableStore for MemoryStore {}
+
+#[tonic::async_trait]
+impl FunctionStore for MemoryStore {
+    async fn list(
+        &self,
+        _catalog_name: &str,
+    ) -> CatalogResult<Vec<AllDatabaseFunctionsResult>> {
+        Ok(vec![])
+    }
+}

--- a/src/catalog/metastore.rs
+++ b/src/catalog/metastore.rs
@@ -18,6 +18,7 @@ use dashmap::DashMap;
 use datafusion::catalog::schema::MemorySchemaProvider;
 use datafusion::datasource::TableProvider;
 
+use crate::catalog::memory::MemoryStore;
 use deltalake::DeltaTable;
 use futures::{stream, StreamExt, TryStreamExt};
 use std::collections::HashMap;
@@ -66,6 +67,21 @@ impl Metastore {
             schemas: external_store.clone(),
             tables: external_store.clone(),
             functions: external_store,
+            staging_schema,
+            object_stores,
+        }
+    }
+
+    pub fn new_from_memory(
+        memory_store: Arc<MemoryStore>,
+        object_stores: Arc<ObjectStoreFactory>,
+    ) -> Self {
+        let staging_schema = Arc::new(MemorySchemaProvider::new());
+        Self {
+            catalogs: memory_store.clone(),
+            schemas: memory_store.clone(),
+            tables: memory_store.clone(),
+            functions: memory_store,
             staging_schema,
             object_stores,
         }

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -12,6 +12,7 @@ use tonic::Status;
 use uuid::Uuid;
 
 pub mod external;
+pub mod memory;
 pub mod metastore;
 mod repository;
 
@@ -137,115 +138,155 @@ pub type CatalogResult<T> = Result<T, CatalogError>;
 
 #[async_trait]
 pub trait CatalogStore: Sync + Send {
-    async fn create(&self, name: &str) -> CatalogResult<()>;
+    async fn create(&self, _name: &str) -> CatalogResult<()> {
+        not_impl()
+    }
 
-    async fn get(&self, name: &str) -> CatalogResult<DatabaseRecord>;
+    async fn get(&self, _name: &str) -> CatalogResult<DatabaseRecord> {
+        not_impl()
+    }
 
-    async fn delete(&self, name: &str) -> CatalogResult<()>;
+    async fn delete(&self, _name: &str) -> CatalogResult<()> {
+        not_impl()
+    }
 }
 
 #[async_trait]
 pub trait SchemaStore: Sync + Send {
-    async fn create(&self, catalog_name: &str, schema_name: &str) -> CatalogResult<()>;
+    async fn create(&self, _catalog_name: &str, _schema_name: &str) -> CatalogResult<()> {
+        not_impl()
+    }
 
-    async fn list(&self, catalog_name: &str) -> CatalogResult<ListSchemaResponse>;
+    async fn list(&self, _catalog_name: &str) -> CatalogResult<ListSchemaResponse> {
+        not_impl()
+    }
 
     async fn get(
         &self,
-        catalog_name: &str,
-        schema_name: &str,
-    ) -> CatalogResult<CollectionRecord>;
+        _catalog_name: &str,
+        _schema_name: &str,
+    ) -> CatalogResult<CollectionRecord> {
+        not_impl()
+    }
 
-    async fn delete(&self, catalog_name: &str, schema_name: &str) -> CatalogResult<()>;
+    async fn delete(&self, _catalog_name: &str, _schema_name: &str) -> CatalogResult<()> {
+        not_impl()
+    }
 }
 
 #[async_trait]
 pub trait TableStore: Sync + Send {
     async fn create(
         &self,
-        catalog_name: &str,
-        schema_name: &str,
-        table_name: &str,
-        schema: &Schema,
-        uuid: Uuid,
-    ) -> CatalogResult<(TableId, TableVersionId)>;
+        _catalog_name: &str,
+        _schema_name: &str,
+        _table_name: &str,
+        _schema: &Schema,
+        _uuid: Uuid,
+    ) -> CatalogResult<(TableId, TableVersionId)> {
+        not_impl()
+    }
 
     async fn get(
         &self,
-        catalog_name: &str,
-        schema_name: &str,
-        table_name: &str,
-    ) -> CatalogResult<TableRecord>;
+        _catalog_name: &str,
+        _schema_name: &str,
+        _table_name: &str,
+    ) -> CatalogResult<TableRecord> {
+        not_impl()
+    }
 
     async fn create_new_version(
         &self,
-        uuid: Uuid,
-        version: i64,
-    ) -> CatalogResult<TableVersionId>;
+        _uuid: Uuid,
+        _version: i64,
+    ) -> CatalogResult<TableVersionId> {
+        not_impl()
+    }
 
     async fn delete_old_versions(
         &self,
-        catalog_name: &str,
-        schema_name: &str,
-        table_name: &str,
-    ) -> CatalogResult<u64>;
+        _catalog_name: &str,
+        _schema_name: &str,
+        _table_name: &str,
+    ) -> CatalogResult<u64> {
+        not_impl()
+    }
 
     async fn get_all_versions(
         &self,
-        catalog_name: &str,
-        table_names: Option<Vec<String>>,
-    ) -> CatalogResult<Vec<TableVersionsResult>>;
+        _catalog_name: &str,
+        _table_names: Option<Vec<String>>,
+    ) -> CatalogResult<Vec<TableVersionsResult>> {
+        not_impl()
+    }
 
     async fn update(
         &self,
-        old_catalog_name: &str,
-        old_schema_name: &str,
-        old_table_name: &str,
-        new_catalog_name: &str,
-        new_schema_name: &str,
-        new_table_name: &str,
-    ) -> CatalogResult<()>;
+        _old_catalog_name: &str,
+        _old_schema_name: &str,
+        _old_table_name: &str,
+        _new_catalog_name: &str,
+        _new_schema_name: &str,
+        _new_table_name: &str,
+    ) -> CatalogResult<()> {
+        not_impl()
+    }
 
     async fn delete(
         &self,
-        catalog_name: &str,
-        schema_name: &str,
-        table_name: &str,
-    ) -> CatalogResult<()>;
+        _catalog_name: &str,
+        _schema_name: &str,
+        _table_name: &str,
+    ) -> CatalogResult<()> {
+        not_impl()
+    }
 
     async fn get_dropped_tables(
         &self,
-        catalog_name: Option<String>,
-    ) -> CatalogResult<Vec<DroppedTablesResult>>;
+        _catalog_name: Option<String>,
+    ) -> CatalogResult<Vec<DroppedTablesResult>> {
+        not_impl()
+    }
 
     async fn update_dropped_table(
         &self,
-        uuid: Uuid,
-        deletion_status: DroppedTableDeletionStatus,
-    ) -> CatalogResult<()>;
+        _uuid: Uuid,
+        _deletion_status: DroppedTableDeletionStatus,
+    ) -> CatalogResult<()> {
+        not_impl()
+    }
 
-    async fn delete_dropped_table(&self, uuid: Uuid) -> CatalogResult<()>;
+    async fn delete_dropped_table(&self, _uuid: Uuid) -> CatalogResult<()> {
+        not_impl()
+    }
 }
 
 #[async_trait]
 pub trait FunctionStore: Sync + Send {
     async fn create(
         &self,
-        catalog_name: &str,
-        function_name: &str,
-        or_replace: bool,
-        details: &CreateFunctionDetails,
-    ) -> CatalogResult<()>;
+        _catalog_name: &str,
+        _function_name: &str,
+        _or_replace: bool,
+        _details: &CreateFunctionDetails,
+    ) -> CatalogResult<()> {
+        not_impl()
+    }
 
     async fn list(
         &self,
-        catalog_name: &str,
-    ) -> CatalogResult<Vec<AllDatabaseFunctionsResult>>;
+        _catalog_name: &str,
+    ) -> CatalogResult<Vec<AllDatabaseFunctionsResult>> {
+        not_impl()
+    }
 
     async fn delete(
         &self,
-        catalog_name: &str,
-        if_exists: bool,
-        func_names: &[String],
-    ) -> CatalogResult<()>;
+        _catalog_name: &str,
+        _if_exists: bool,
+        _func_names: &[String],
+    ) -> CatalogResult<()> {
+        not_impl()
+    }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -60,6 +60,17 @@ impl SeafowlContext {
         self.scope_to(self.default_catalog.clone(), schema)
     }
 
+    pub fn with_metastore(&self, metastore: Arc<Metastore>) -> Arc<SeafowlContext> {
+        Arc::from(SeafowlContext {
+            config: self.config.clone(),
+            inner: self.inner.clone(),
+            metastore,
+            internal_object_store: self.internal_object_store.clone(),
+            default_catalog: self.default_catalog.clone(),
+            default_schema: self.default_schema.clone(),
+        })
+    }
+
     pub fn inner(&self) -> &SessionContext {
         &self.inner
     }

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -1,18 +1,20 @@
+use crate::catalog::memory::MemoryStore;
+use crate::catalog::metastore::Metastore;
 use arrow::record_batch::RecordBatch;
 use arrow_flight::sql::metadata::{SqlInfoData, SqlInfoDataBuilder};
-use arrow_flight::sql::SqlInfo;
-use arrow_schema::SchemaRef;
+use arrow_flight::sql::{ProstMessageExt, SqlInfo, TicketStatementQuery};
+use arrow_flight::{FlightDescriptor, FlightEndpoint, FlightInfo, Ticket};
 use clade::sync::{DataSyncCommand, DataSyncResult};
 use dashmap::DashMap;
 use datafusion::common::Result;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion_common::DataFusionError;
 use lazy_static::lazy_static;
+use prost::Message;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
-use tonic::metadata::MetadataMap;
-use tonic::Status;
+use tonic::{Request, Status};
 use tracing::{debug, error, info};
 use url::Url;
 
@@ -59,9 +61,10 @@ impl SeafowlFlightHandler {
         &self,
         query: &str,
         query_id: String,
-        metadata: &MetadataMap,
-    ) -> Result<SchemaRef> {
-        let ctx = if let Some(search_path) = metadata.get("search-path") {
+        request: Request<FlightDescriptor>,
+        memory_store: Option<MemoryStore>,
+    ) -> Result<FlightInfo> {
+        let mut ctx = if let Some(search_path) = request.metadata().get("search-path") {
             self.context.scope_to_schema(
                 search_path
                     .to_str()
@@ -74,6 +77,14 @@ impl SeafowlFlightHandler {
             self.context.clone()
         };
 
+        if let Some(memory_store) = memory_store {
+            // If metastore was inlined with the query use it for resolving tables/locations
+            ctx = ctx.with_metastore(Arc::new(Metastore::new_from_memory(
+                Arc::new(memory_store),
+                ctx.metastore.object_stores.clone(),
+            )));
+        }
+
         let plan = ctx
             .plan_query(query)
             .await
@@ -84,9 +95,23 @@ impl SeafowlFlightHandler {
             .inspect_err(|err| info!("Error executing query id {query_id}: {err}"))?;
         let schema = batch_stream.schema();
 
-        self.results.insert(query_id, Mutex::new(batch_stream));
+        self.results
+            .insert(query_id.clone(), Mutex::new(batch_stream));
 
-        Ok(schema)
+        // Issue a ticket for fetching the query stream
+        let ticket = TicketStatementQuery {
+            statement_handle: query_id.clone().into(),
+        };
+
+        let endpoint = FlightEndpoint::new()
+            .with_ticket(Ticket::new(ticket.as_any().encode_to_vec()));
+
+        let flight_info = FlightInfo::new()
+            .try_with_schema(&schema)?
+            .with_endpoint(endpoint)
+            .with_descriptor(request.into_inner());
+
+        Ok(flight_info)
     }
 
     // Get a specific stream from the map

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -1,4 +1,8 @@
+use clade::schema::{ListSchemaResponse, SchemaObject, StorageLocation, TableObject};
+use object_store::aws::AmazonS3ConfigKey;
+use object_store::gcp::GoogleConfigKey;
 use serde_json::json;
+use std::collections::HashMap;
 use std::path::Path;
 
 pub const FAKE_GCS_CREDS_PATH: &str = "/tmp/fake-gcs-server.json";
@@ -14,4 +18,68 @@ pub fn fake_gcs_creds() -> String {
     .expect("Unable to write application credentials JSON file");
 
     google_application_credentials_path.display().to_string()
+}
+
+// Return a list of schemas with actual tables and object store configs that are used in testing
+pub fn schemas() -> ListSchemaResponse {
+    ListSchemaResponse {
+        schemas: vec![
+            SchemaObject {
+                name: "local".to_string(),
+                tables: vec![TableObject {
+                    name: "file".to_string(),
+                    path: "delta-0.8.0-partitioned".to_string(),
+                    location: None,
+                }],
+            },
+            SchemaObject {
+                name: "s3".to_string(),
+                tables: vec![TableObject {
+                    name: "minio".to_string(),
+                    path: "test-data/delta-0.8.0-partitioned".to_string(),
+                    location: Some("s3://seafowl-test-bucket".to_string()),
+                }],
+            },
+            SchemaObject {
+                name: "gcs".to_string(),
+                tables: vec![TableObject {
+                    name: "fake".to_string(),
+                    path: "delta-0.8.0-partitioned".to_string(),
+                    location: Some("gs://test-data".to_string()),
+                }],
+            },
+        ],
+        stores: vec![
+            StorageLocation {
+                location: "s3://seafowl-test-bucket".to_string(),
+                options: HashMap::from([
+                    (
+                        AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
+                        "http://127.0.0.1:9000".to_string(),
+                    ),
+                    (
+                        AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
+                        "minioadmin".to_string(),
+                    ),
+                    (
+                        AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
+                        "minioadmin".to_string(),
+                    ),
+                    (
+                        // This has been removed from the config enum, but it can
+                        // still be picked up via `AmazonS3ConfigKey::from_str`
+                        "aws_allow_http".to_string(),
+                        "true".to_string(),
+                    ),
+                ]),
+            },
+            StorageLocation {
+                location: "gs://test-data".to_string(),
+                options: HashMap::from([(
+                    GoogleConfigKey::ServiceAccount.as_ref().to_string(),
+                    fake_gcs_creds(),
+                )]),
+            },
+        ],
+    }
 }

--- a/tests/flight/client.rs
+++ b/tests/flight/client.rs
@@ -2,7 +2,7 @@ use crate::flight::*;
 
 #[tokio::test]
 async fn test_basic_queries() -> Result<()> {
-    let (context, mut client) = flight_server().await;
+    let (context, mut client) = flight_server(false).await;
     create_table_and_insert(context.as_ref(), "flight_table").await;
 
     // Test the handshake works
@@ -28,7 +28,7 @@ async fn test_basic_queries() -> Result<()> {
 
 #[tokio::test]
 async fn test_ddl_types_roundtrip() -> Result<()> {
-    let (_context, mut client) = flight_server().await;
+    let (_context, mut client) = flight_server(false).await;
 
     let all_types_query = r#"
 SELECT

--- a/tests/flight/inline_metastore.rs
+++ b/tests/flight/inline_metastore.rs
@@ -1,0 +1,35 @@
+use crate::flight::*;
+
+#[rstest]
+#[should_panic(expected = "External error: Not a Delta table: no log files")]
+#[case("local.file", false)]
+#[case("local.file", true)]
+#[case("s3.minio", true)]
+#[case("gcs.fake", true)]
+#[tokio::test]
+async fn test_inline_query(#[case] table: &str, #[case] local_store: bool) -> () {
+    let (_context, mut client) = flight_server(local_store).await;
+
+    let batches = get_flight_batches_inlined(
+        &mut client,
+        format!("SELECT * FROM {table} ORDER BY value"),
+        schemas(),
+    )
+    .await
+    .unwrap();
+
+    let expected = [
+        "+-------+------+-------+-----+",
+        "| value | year | month | day |",
+        "+-------+------+-------+-----+",
+        "| 1     | 2020 | 1     | 1   |",
+        "| 2     | 2020 | 2     | 3   |",
+        "| 3     | 2020 | 2     | 5   |",
+        "| 4     | 2021 | 4     | 5   |",
+        "| 5     | 2021 | 12    | 4   |",
+        "| 6     | 2021 | 12    | 20  |",
+        "| 7     | 2021 | 12    | 20  |",
+        "+-------+------+-------+-----+",
+    ];
+    assert_batches_eq!(expected, &batches);
+}

--- a/tests/flight/mod.rs
+++ b/tests/flight/mod.rs
@@ -2,7 +2,7 @@ use arrow::array::{BooleanArray, Float64Array, Int32Array, StringArray};
 use arrow::record_batch::RecordBatch;
 use arrow_flight::encode::{FlightDataEncoder, FlightDataEncoderBuilder};
 use arrow_flight::error::{FlightError, Result};
-use arrow_flight::sql::{CommandStatementQuery, ProstMessageExt};
+use arrow_flight::sql::{Any, CommandStatementQuery, ProstMessageExt};
 use arrow_flight::{FlightClient, FlightDescriptor};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::{assert_batches_eq, assert_batches_sorted_eq};
@@ -20,8 +20,10 @@ use tonic::transport::Channel;
 use uuid::Uuid;
 use warp::hyper::Client;
 
+use clade::schema::{InlineMetastoreCommandStatementQuery, ListSchemaResponse};
 use clade::sync::{DataSyncCommand, DataSyncResult};
 
+use crate::fixtures::schemas;
 use crate::http::{get_metrics, response_text};
 use crate::statements::create_table_and_insert;
 use crate::{test_seafowl, TestSeafowl};
@@ -33,19 +35,28 @@ use seafowl::frontend::flight::run_flight_server;
 
 mod client;
 mod e2e;
+mod inline_metastore;
 mod search_path;
 mod sync;
 mod sync_fail;
 
-async fn make_test_context() -> Arc<SeafowlContext> {
+async fn make_test_context(local_store: bool) -> Arc<SeafowlContext> {
     // let OS choose a free port
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
+    let object_store_section = if local_store {
+        r#"[object_store]
+type = "local"
+data_dir = "tests/data""#
+    } else {
+        r#"[object_store]
+type = "memory""#
+    };
+
     let config_text = format!(
         r#"
-[object_store]
-type = "memory"
+{object_store_section}
 
 [catalog]
 type = "sqlite"
@@ -61,13 +72,13 @@ max_replication_lag_s = 1"#,
         addr.port()
     );
 
-    let config = load_config_from_string(&config_text, false, None).unwrap();
+    let config = load_config_from_string(&config_text, true, None).unwrap();
 
     Arc::from(build_context(config).await.unwrap())
 }
 
-async fn flight_server() -> (Arc<SeafowlContext>, FlightClient) {
-    let context = make_test_context().await;
+async fn flight_server(local_store: bool) -> (Arc<SeafowlContext>, FlightClient) {
+    let context = make_test_context(local_store).await;
 
     let flight_cfg = context
         .config
@@ -100,7 +111,26 @@ async fn get_flight_batches(
         query,
         transaction_id: None,
     };
-    let request = FlightDescriptor::new_cmd(cmd.as_any().encode_to_vec());
+    get_flight_batches_inner(client, cmd.as_any()).await
+}
+
+async fn get_flight_batches_inlined(
+    client: &mut FlightClient,
+    query: String,
+    schemas: ListSchemaResponse,
+) -> Result<Vec<RecordBatch>> {
+    let cmd = InlineMetastoreCommandStatementQuery {
+        query,
+        schemas: Some(schemas),
+    };
+    get_flight_batches_inner(client, cmd.as_any()).await
+}
+
+async fn get_flight_batches_inner(
+    client: &mut FlightClient,
+    message: Any,
+) -> Result<Vec<RecordBatch>> {
+    let request = FlightDescriptor::new_cmd(message.encode_to_vec());
     let response = client.get_flight_info(request).await?;
 
     // Get the returned ticket

--- a/tests/flight/search_path.rs
+++ b/tests/flight/search_path.rs
@@ -3,7 +3,7 @@ use crate::flight::*;
 #[tokio::test]
 async fn test_default_schema_override(
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let (context, mut client) = flight_server().await;
+    let (context, mut client) = flight_server(false).await;
 
     context.plan_query("CREATE SCHEMA some_schema").await?;
     create_table_and_insert(context.as_ref(), "some_schema.flight_table").await;

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -24,7 +24,7 @@ async fn do_put_sync(
 
 #[tokio::test]
 async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let (ctx, mut client) = flight_server().await;
+    let (ctx, mut client) = flight_server(false).await;
 
     //
     // Sync #1 that creates the table, and dictates the full schema for following syncs

--- a/tests/flight/sync_fail.rs
+++ b/tests/flight/sync_fail.rs
@@ -17,7 +17,7 @@ async fn assert_sync_error(
 
 #[tokio::test]
 async fn test_sync_errors() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let (_ctx, mut client) = flight_server().await;
+    let (_ctx, mut client) = flight_server(false).await;
 
     let schema = Arc::new(Schema::new(vec![Field::new(
         "old_c1",


### PR DESCRIPTION
## What

Adds support for discrete, temporary, metastores inlined with queries called over arrow flight. These can be used to resolve identifiers parsed from the query in an ad-hoc manner.

## How
- introduce a `MemoryStore` and implement all store traits for it
- encapsulate the `ListSchemaResponse` from regular clade metastore in a new message called `InlineMetastoreCommandStatementQuery` that also holds the query
- now when `get_sql_info` is called arrow fails to pattern match against known commands and uses the fallback method
- there we simply instantiate the `MemoryStore` for a one-off context that serves the query 