### PR TITLE
Add sync metrics

### DIFF
--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -1,12 +1,18 @@
-use metrics::{describe_gauge, gauge, Gauge};
+use metrics::{
+    counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram,
+    Gauge, Histogram,
+};
 
 const IN_MEMORY_SIZE: &str = "seafowl_sync_writer_in_memory_size";
 const IN_MEMORY_ROWS: &str = "seafowl_sync_writer_in_memory_rows";
+const COMPACTION_TIME: &str = "seafowl_sync_writer_compaction_time";
+const COMPACTED: &str = "seafowl_sync_writer_compacted";
 
 #[derive(Clone)]
 pub struct SyncMetrics {
     pub in_memory_size: Gauge,
     pub in_memory_rows: Gauge,
+    pub compaction_time: Histogram,
 }
 
 impl Default for SyncMetrics {
@@ -21,11 +27,27 @@ impl SyncMetrics {
             IN_MEMORY_SIZE,
             "The total size of all pending syncs in bytes"
         );
-        describe_gauge!(IN_MEMORY_ROWS, "The total row count of all pending sync");
+        describe_gauge!(IN_MEMORY_ROWS, "The total row count of all pending syncs");
+        describe_histogram!(COMPACTION_TIME, "The time taken to compact a sync");
+        describe_counter!(
+            COMPACTED,
+            "The reduction in rows and size due to batch compaction"
+        );
 
         Self {
             in_memory_size: gauge!(IN_MEMORY_SIZE),
             in_memory_rows: gauge!(IN_MEMORY_ROWS),
+            compaction_time: histogram!(COMPACTION_TIME),
         }
+    }
+
+    pub fn compacted_size(&self, size: u64) {
+        let compacted_size = counter!(COMPACTED, "unit" => "size");
+        compacted_size.increment(size);
+    }
+
+    pub fn compacted_rows(&self, rows: u64) {
+        let compacted_rows = counter!(COMPACTED, "unit" => "rows");
+        compacted_rows.increment(rows);
     }
 }

--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -1,0 +1,31 @@
+use metrics::{describe_gauge, gauge, Gauge};
+
+const IN_MEMORY_SIZE: &str = "seafowl_sync_writer_in_memory_size";
+const IN_MEMORY_ROWS: &str = "seafowl_sync_writer_in_memory_rows";
+
+#[derive(Clone)]
+pub struct SyncMetrics {
+    pub in_memory_size: Gauge,
+    pub in_memory_rows: Gauge,
+}
+
+impl Default for SyncMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncMetrics {
+    fn new() -> Self {
+        describe_gauge!(
+            IN_MEMORY_SIZE,
+            "The total size of all pending syncs in bytes"
+        );
+        describe_gauge!(IN_MEMORY_ROWS, "The total row count of all pending sync");
+
+        Self {
+            in_memory_size: gauge!(IN_MEMORY_SIZE),
+            in_memory_rows: gauge!(IN_MEMORY_ROWS),
+        }
+    }
+}

--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -3,17 +3,18 @@ use metrics::{
     Gauge, Histogram,
 };
 
-const IN_MEMORY_SIZE: &str = "seafowl_sync_writer_in_memory_size";
-const IN_MEMORY_ROWS: &str = "seafowl_sync_writer_in_memory_rows";
+const REQUEST: &str = "seafowl_sync_writer_request";
+const IN_MEMORY: &str = "seafowl_sync_writer_in_memory";
 const COMPACTION_TIME: &str = "seafowl_sync_writer_compaction_time";
 const COMPACTED: &str = "seafowl_sync_writer_compacted";
 const FLUSHING_TIME: &str = "seafowl_sync_writer_flushing_time";
 const FLUSHED: &str = "seafowl_sync_writer_flushed";
+const UNIT_LABEL: &str = "unit";
+const UNIT_SIZE: &str = "size";
+const UNIT_ROWS: &str = "rows";
 
 #[derive(Clone)]
 pub struct SyncMetrics {
-    pub in_memory_size: Gauge,
-    pub in_memory_rows: Gauge,
     pub compaction_time: Histogram,
     pub flushing_time: Histogram,
 }
@@ -26,12 +27,18 @@ impl Default for SyncMetrics {
 
 impl SyncMetrics {
     fn new() -> Self {
-        describe_gauge!(
-            IN_MEMORY_SIZE,
-            "The total size of all pending syncs in bytes"
+        describe_counter!(
+            REQUEST,
+            "The total byte size and row count of of all batches in the sync message"
         );
-        describe_gauge!(IN_MEMORY_ROWS, "The total row count of all pending syncs");
-        describe_histogram!(COMPACTION_TIME, "The time taken to compact a sync");
+        describe_gauge!(
+            IN_MEMORY,
+            "The total byte size and row count of all pending syncs"
+        );
+        describe_histogram!(
+            COMPACTION_TIME,
+            "The time taken to compact a single sync message"
+        );
         describe_counter!(
             COMPACTED,
             "The reduction in rows and size due to batch compaction"
@@ -43,30 +50,46 @@ impl SyncMetrics {
         describe_counter!(FLUSHED, "The total rows and size flushed");
 
         Self {
-            in_memory_size: gauge!(IN_MEMORY_SIZE),
-            in_memory_rows: gauge!(IN_MEMORY_ROWS),
             compaction_time: histogram!(COMPACTION_TIME),
             flushing_time: histogram!(FLUSHING_TIME),
         }
     }
 
+    pub fn request_size(&self, size: u64) {
+        let request_size = counter!(REQUEST, UNIT_LABEL => UNIT_SIZE);
+        request_size.increment(size);
+    }
+
+    pub fn request_rows(&self, rows: u64) {
+        let request_rows = counter!(REQUEST, UNIT_LABEL => UNIT_ROWS);
+        request_rows.increment(rows);
+    }
+
+    pub fn in_memory_size(&self) -> Gauge {
+        gauge!(IN_MEMORY, UNIT_LABEL => UNIT_SIZE)
+    }
+
+    pub fn in_memory_rows(&self) -> Gauge {
+        gauge!(IN_MEMORY, UNIT_LABEL => UNIT_ROWS)
+    }
+
     pub fn compacted_size(&self, size: u64) {
-        let compacted_size = counter!(COMPACTED, "unit" => "size");
+        let compacted_size = counter!(COMPACTED, UNIT_LABEL => UNIT_SIZE);
         compacted_size.increment(size);
     }
 
     pub fn compacted_rows(&self, rows: u64) {
-        let compacted_rows = counter!(COMPACTED, "unit" => "rows");
+        let compacted_rows = counter!(COMPACTED, UNIT_LABEL => UNIT_ROWS);
         compacted_rows.increment(rows);
     }
 
     pub fn flushed_size(&self, size: u64) {
-        let flushed_size = counter!(FLUSHED, "unit" => "size");
+        let flushed_size = counter!(FLUSHED, UNIT_LABEL => UNIT_SIZE);
         flushed_size.increment(size);
     }
 
     pub fn flushed_rows(&self, rows: u64) {
-        let flushed_rows = counter!(FLUSHED, "unit" => "rows");
+        let flushed_rows = counter!(FLUSHED, UNIT_LABEL => UNIT_ROWS);
         flushed_rows.increment(rows);
     }
 }

--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -1,22 +1,34 @@
 use metrics::{
     counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram,
-    Gauge, Histogram,
+    Counter, Gauge, Histogram,
 };
 
-const REQUEST: &str = "seafowl_sync_writer_request";
-const IN_MEMORY: &str = "seafowl_sync_writer_in_memory";
-const COMPACTION_TIME: &str = "seafowl_sync_writer_compaction_time";
-const COMPACTED: &str = "seafowl_sync_writer_compacted";
-const FLUSHING_TIME: &str = "seafowl_sync_writer_flushing_time";
-const FLUSHED: &str = "seafowl_sync_writer_flushed";
-const UNIT_LABEL: &str = "unit";
-const UNIT_SIZE: &str = "size";
-const UNIT_ROWS: &str = "rows";
+const REQUEST_BYTES: &str = "seafowl_changeset_writer_request_bytes";
+const REQUEST_ROWS: &str = "seafowl_changeset_writer_request_rows";
+const IN_MEMORY_BYTES: &str = "seafowl_changeset_writer_in_memory_bytes";
+const IN_MEMORY_ROWS: &str = "seafowl_changeset_writer_in_memory_rows";
+const COMPACTION_TIME: &str = "seafowl_changeset_writer_compaction_time";
+const COMPACTED_BYTES: &str = "seafowl_changeset_writer_compacted_bytes";
+const COMPACTED_ROWS: &str = "seafowl_changeset_writer_compacted_rows";
+const FLUSHING_TIME: &str = "seafowl_changeset_writer_flushing_time";
+const FLUSHED_BYTES: &str = "seafowl_changeset_writer_flushed_bytes";
+const FLUSHED_ROWS: &str = "seafowl_changeset_writer_flushed_rows";
+const FLUSHED_LAST: &str =
+    "seafowl_changeset_writer_last_successful_flush_timestamp_seconds";
 
 #[derive(Clone)]
 pub struct SyncMetrics {
+    pub request_bytes: Counter,
+    pub request_rows: Counter,
+    pub in_memory_bytes: Gauge,
+    pub in_memory_rows: Gauge,
     pub compaction_time: Histogram,
+    pub compacted_bytes: Counter,
+    pub compacted_rows: Counter,
     pub flushing_time: Histogram,
+    pub flushed_bytes: Counter,
+    pub flushed_rows: Counter,
+    pub flushed_last: Gauge,
 }
 
 impl Default for SyncMetrics {
@@ -28,68 +40,53 @@ impl Default for SyncMetrics {
 impl SyncMetrics {
     fn new() -> Self {
         describe_counter!(
-            REQUEST,
-            "The total byte size and row count of of all batches in the sync message"
+            REQUEST_BYTES,
+            "The total byte size of all batches in the sync message"
+        );
+        describe_counter!(
+            REQUEST_BYTES,
+            "The total row count of of all batches in the sync message"
         );
         describe_gauge!(
-            IN_MEMORY,
-            "The total byte size and row count of all pending syncs"
+            IN_MEMORY_BYTES,
+            "The total byte size of all pending batches in memory"
+        );
+        describe_gauge!(
+            IN_MEMORY_BYTES,
+            "The total row count of all pending batches in memory"
         );
         describe_histogram!(
             COMPACTION_TIME,
             "The time taken to compact a single sync message"
         );
         describe_counter!(
-            COMPACTED,
-            "The reduction in rows and size due to batch compaction"
+            COMPACTED_BYTES,
+            "The reduction in byte size due to batch compaction"
+        );
+        describe_counter!(
+            COMPACTED_BYTES,
+            "The reduction in row count due to batch compaction"
         );
         describe_histogram!(
             FLUSHING_TIME,
             "The time taken to flush a collections of syncs"
         );
-        describe_counter!(FLUSHED, "The total rows and size flushed");
+        describe_counter!(FLUSHED_BYTES, "The total byte size flushed");
+        describe_counter!(FLUSHED_ROWS, "The total row count flushed");
+        describe_counter!(FLUSHED_LAST, "The timestamp of the last successful flush");
 
         Self {
+            request_bytes: counter!(REQUEST_BYTES),
+            request_rows: counter!(REQUEST_ROWS),
+            in_memory_bytes: gauge!(IN_MEMORY_BYTES),
+            in_memory_rows: gauge!(IN_MEMORY_ROWS),
             compaction_time: histogram!(COMPACTION_TIME),
+            compacted_bytes: counter!(COMPACTED_BYTES),
+            compacted_rows: counter!(COMPACTED_ROWS),
             flushing_time: histogram!(FLUSHING_TIME),
+            flushed_bytes: counter!(FLUSHED_BYTES),
+            flushed_rows: counter!(FLUSHED_ROWS),
+            flushed_last: gauge!(FLUSHED_LAST),
         }
-    }
-
-    pub fn request_size(&self, size: u64) {
-        let request_size = counter!(REQUEST, UNIT_LABEL => UNIT_SIZE);
-        request_size.increment(size);
-    }
-
-    pub fn request_rows(&self, rows: u64) {
-        let request_rows = counter!(REQUEST, UNIT_LABEL => UNIT_ROWS);
-        request_rows.increment(rows);
-    }
-
-    pub fn in_memory_size(&self) -> Gauge {
-        gauge!(IN_MEMORY, UNIT_LABEL => UNIT_SIZE)
-    }
-
-    pub fn in_memory_rows(&self) -> Gauge {
-        gauge!(IN_MEMORY, UNIT_LABEL => UNIT_ROWS)
-    }
-
-    pub fn compacted_size(&self, size: u64) {
-        let compacted_size = counter!(COMPACTED, UNIT_LABEL => UNIT_SIZE);
-        compacted_size.increment(size);
-    }
-
-    pub fn compacted_rows(&self, rows: u64) {
-        let compacted_rows = counter!(COMPACTED, UNIT_LABEL => UNIT_ROWS);
-        compacted_rows.increment(rows);
-    }
-
-    pub fn flushed_size(&self, size: u64) {
-        let flushed_size = counter!(FLUSHED, UNIT_LABEL => UNIT_SIZE);
-        flushed_size.increment(size);
-    }
-
-    pub fn flushed_rows(&self, rows: u64) {
-        let flushed_rows = counter!(FLUSHED, UNIT_LABEL => UNIT_ROWS);
-        flushed_rows.increment(rows);
     }
 }

--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -4,19 +4,20 @@ use metrics::{
     Counter, Gauge, Histogram,
 };
 
-const REQUEST_BYTES: &str = "seafowl_changeset_writer_request_bytes";
-const REQUEST_ROWS: &str = "seafowl_changeset_writer_request_rows";
-const IN_MEMORY_BYTES: &str = "seafowl_changeset_writer_in_memory_bytes";
-const IN_MEMORY_ROWS: &str = "seafowl_changeset_writer_in_memory_rows";
-const IN_MEMORY_OLDEST: &str = "seafowl_changeset_writer_in_memory_oldest";
-const COMPACTION_TIME: &str = "seafowl_changeset_writer_compaction_time";
-const COMPACTED_BYTES: &str = "seafowl_changeset_writer_compacted_bytes";
-const COMPACTED_ROWS: &str = "seafowl_changeset_writer_compacted_rows";
-const FLUSH_TIME: &str = "seafowl_changeset_writer_flush_time";
-const FLUSH_BYTES: &str = "seafowl_changeset_writer_flush_bytes";
-const FLUSH_ROWS: &str = "seafowl_changeset_writer_flush_rows";
+const REQUEST_BYTES: &str = "seafowl_changeset_writer_request_bytes_total";
+const REQUEST_ROWS: &str = "seafowl_changeset_writer_request_rows_total";
+const IN_MEMORY_BYTES: &str = "seafowl_changeset_writer_in_memory_bytes_current";
+const IN_MEMORY_ROWS: &str = "seafowl_changeset_writer_in_memory_rows_current";
+const IN_MEMORY_OLDEST: &str =
+    "seafowl_changeset_writer_in_memory_oldest_timestamp_seconds_current";
+const COMPACTION_TIME: &str = "seafowl_changeset_writer_compaction_time_seconds";
+const COMPACTED_BYTES: &str = "seafowl_changeset_writer_compacted_bytes_total";
+const COMPACTED_ROWS: &str = "seafowl_changeset_writer_compacted_rows_total";
+const FLUSH_TIME: &str = "seafowl_changeset_writer_flush_time_seconds";
+const FLUSH_BYTES: &str = "seafowl_changeset_writer_flush_bytes_total";
+const FLUSH_ROWS: &str = "seafowl_changeset_writer_flush_rows_total";
 const FLUSH_LAST: &str =
-    "seafowl_changeset_writer_last_successful_flush_timestamp_seconds";
+    "seafowl_changeset_writer_last_successful_flush_timestamp_seconds_current";
 const FLUSH_LAG: &str = "seafowl_changeset_writer_flush_lag_seconds";
 const SEQUENCE_DURABLE: &str = "seafowl_changeset_writer_sequence_durable_bytes";
 const SEQUENCE_MEMORY: &str = "seafowl_changeset_writer_sequence_memory_bytes";

--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -7,12 +7,15 @@ const IN_MEMORY_SIZE: &str = "seafowl_sync_writer_in_memory_size";
 const IN_MEMORY_ROWS: &str = "seafowl_sync_writer_in_memory_rows";
 const COMPACTION_TIME: &str = "seafowl_sync_writer_compaction_time";
 const COMPACTED: &str = "seafowl_sync_writer_compacted";
+const FLUSHING_TIME: &str = "seafowl_sync_writer_flushing_time";
+const FLUSHED: &str = "seafowl_sync_writer_flushed";
 
 #[derive(Clone)]
 pub struct SyncMetrics {
     pub in_memory_size: Gauge,
     pub in_memory_rows: Gauge,
     pub compaction_time: Histogram,
+    pub flushing_time: Histogram,
 }
 
 impl Default for SyncMetrics {
@@ -33,11 +36,17 @@ impl SyncMetrics {
             COMPACTED,
             "The reduction in rows and size due to batch compaction"
         );
+        describe_histogram!(
+            FLUSHING_TIME,
+            "The time taken to flush a collections of syncs"
+        );
+        describe_counter!(FLUSHED, "The total rows and size flushed");
 
         Self {
             in_memory_size: gauge!(IN_MEMORY_SIZE),
             in_memory_rows: gauge!(IN_MEMORY_ROWS),
             compaction_time: histogram!(COMPACTION_TIME),
+            flushing_time: histogram!(FLUSHING_TIME),
         }
     }
 
@@ -49,5 +58,15 @@ impl SyncMetrics {
     pub fn compacted_rows(&self, rows: u64) {
         let compacted_rows = counter!(COMPACTED, "unit" => "rows");
         compacted_rows.increment(rows);
+    }
+
+    pub fn flushed_size(&self, size: u64) {
+        let flushed_size = counter!(FLUSHED, "unit" => "size");
+        flushed_size.increment(size);
+    }
+
+    pub fn flushed_rows(&self, rows: u64) {
+        let flushed_rows = counter!(FLUSHED, "unit" => "rows");
+        flushed_rows.increment(rows);
     }
 }

--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -9,7 +9,7 @@ const REQUEST_ROWS: &str = "seafowl_changeset_writer_request_rows_total";
 const IN_MEMORY_BYTES: &str = "seafowl_changeset_writer_in_memory_bytes_current";
 const IN_MEMORY_ROWS: &str = "seafowl_changeset_writer_in_memory_rows_current";
 const IN_MEMORY_OLDEST: &str =
-    "seafowl_changeset_writer_in_memory_oldest_timestamp_seconds_current";
+    "seafowl_changeset_writer_in_memory_oldest_timestamp_seconds";
 const COMPACTION_TIME: &str = "seafowl_changeset_writer_compaction_time_seconds";
 const COMPACTED_BYTES: &str = "seafowl_changeset_writer_compacted_bytes_total";
 const COMPACTED_ROWS: &str = "seafowl_changeset_writer_compacted_rows_total";
@@ -52,7 +52,7 @@ impl SyncMetrics {
             "The total byte size of all batches in the sync message"
         );
         describe_counter!(
-            REQUEST_BYTES,
+            REQUEST_ROWS,
             "The total row count of of all batches in the sync message"
         );
         describe_gauge!(
@@ -60,7 +60,7 @@ impl SyncMetrics {
             "The total byte size of all pending batches in memory"
         );
         describe_gauge!(
-            IN_MEMORY_BYTES,
+            IN_MEMORY_ROWS,
             "The total row count of all pending batches in memory"
         );
         describe_gauge!(
@@ -76,7 +76,7 @@ impl SyncMetrics {
             "The reduction in byte size due to batch compaction"
         );
         describe_counter!(
-            COMPACTED_BYTES,
+            COMPACTED_ROWS,
             "The reduction in row count due to batch compaction"
         );
         describe_histogram!(FLUSH_TIME, "The time taken to flush a collections of syncs");

--- a/src/frontend/flight/sync/mod.rs
+++ b/src/frontend/flight/sync/mod.rs
@@ -1,3 +1,4 @@
+mod metrics;
 pub mod schema;
 mod utils;
 pub(crate) mod writer;

--- a/src/frontend/flight/sync/writer.rs
+++ b/src/frontend/flight/sync/writer.rs
@@ -190,12 +190,14 @@ impl SeafowlDataSyncWriter {
             .or_insert(IndexMap::from([(sequence_number, sequence)]));
 
         // Compactify the batches and measure the time it took and the reduction in rows/size
-        let old_rows = batches
-            .iter()
-            .fold(0, |rows, batch| rows + batch.num_rows());
-        let old_size = batches
-            .iter()
-            .fold(0, |size, batch| size + batch.get_array_memory_size());
+        let (old_size, old_rows) = batches.iter().fold((0, 0), |(size, rows), batch| {
+            (
+                size + batch.get_array_memory_size(),
+                rows + batch.num_rows(),
+            )
+        });
+        self.metrics.request_size(old_size as u64);
+        self.metrics.request_rows(old_rows as u64);
         let start = Instant::now();
         let batch = compact_batches(&sync_schema, batches)?;
         let duration = start.elapsed().as_millis();
@@ -233,8 +235,8 @@ impl SeafowlDataSyncWriter {
 
         // Update the total size and metrics
         self.size += size;
-        self.metrics.in_memory_size.increment(size as f64);
-        self.metrics.in_memory_rows.increment(rows as f64);
+        self.metrics.in_memory_size().increment(size as f64);
+        self.metrics.in_memory_rows().increment(rows as f64);
         self.metrics.compaction_time.record(duration as f64);
         self.metrics.compacted_size((old_size - size) as u64);
         self.metrics.compacted_rows((old_rows - rows) as u64);
@@ -611,8 +613,8 @@ impl SeafowlDataSyncWriter {
     fn remove_sync(&mut self, url: &String) {
         if let Some(sync) = self.syncs.shift_remove(url) {
             self.size -= sync.size;
-            self.metrics.in_memory_size.decrement(sync.size as f64);
-            self.metrics.in_memory_rows.decrement(sync.rows as f64);
+            self.metrics.in_memory_size().decrement(sync.size as f64);
+            self.metrics.in_memory_rows().decrement(sync.rows as f64);
         }
     }
 

--- a/src/frontend/flight/sync/writer.rs
+++ b/src/frontend/flight/sync/writer.rs
@@ -200,7 +200,7 @@ impl SeafowlDataSyncWriter {
         self.metrics.request_rows.increment(old_rows as u64);
         let start = Instant::now();
         let batch = compact_batches(&sync_schema, batches)?;
-        let duration = start.elapsed().as_millis();
+        let duration = start.elapsed().as_secs();
 
         // Get new size and row count
         let size = batch.get_array_memory_size();

--- a/src/frontend/flight/sync/writer.rs
+++ b/src/frontend/flight/sync/writer.rs
@@ -303,6 +303,9 @@ impl SeafowlDataSyncWriter {
             }
         };
 
+        let start = Instant::now();
+        let rows = entry.rows;
+        let size = entry.size;
         let url = url.clone();
         let log_store = entry.log_store.clone();
 
@@ -404,6 +407,12 @@ impl SeafowlDataSyncWriter {
         self.remove_sequence_locations(url.clone(), orseq);
         self.remove_sync(&url);
         self.advance_durable();
+
+        // Record flush metrics
+        let flush_duration = start.elapsed().as_millis();
+        self.metrics.flushing_time.record(flush_duration as f64);
+        self.metrics.flushed_size(size as u64);
+        self.metrics.flushed_rows(rows as u64);
 
         Ok(())
     }


### PR DESCRIPTION
Add metrics tracking byte size/row count for:
- incoming request
- compaction
- flushing
as well as timings for the last two ops.