### PR TITLE
Add flush task

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -415,7 +415,8 @@ impl Default for ObjectCacheProperties {
 pub struct DataSyncConfig {
     pub max_in_memory_bytes: usize,
     pub max_replication_lag_s: u64,
-    pub sync_lock_timeout_s: u64,
+    pub write_lock_timeout_s: u64,
+    pub flush_task_interval_s: u64,
 }
 
 impl Default for DataSyncConfig {
@@ -423,7 +424,8 @@ impl Default for DataSyncConfig {
         Self {
             max_in_memory_bytes: 3 * 1024 * 1024 * 1024,
             max_replication_lag_s: 600,
-            sync_lock_timeout_s: 3,
+            write_lock_timeout_s: 3,
+            flush_task_interval_s: 900,
         }
     }
 }

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -44,18 +44,18 @@ lazy_static! {
 pub(super) struct SeafowlFlightHandler {
     pub context: Arc<SeafowlContext>,
     pub results: Arc<DashMap<String, Mutex<SendableRecordBatchStream>>>,
-    sync_manager: Arc<RwLock<SeafowlDataSyncWriter>>,
+    sync_writer: Arc<RwLock<SeafowlDataSyncWriter>>,
 }
 
 impl SeafowlFlightHandler {
     pub fn new(
         context: Arc<SeafowlContext>,
-        sync_manager: Arc<RwLock<SeafowlDataSyncWriter>>,
+        sync_writer: Arc<RwLock<SeafowlDataSyncWriter>>,
     ) -> Self {
         Self {
             context: context.clone(),
             results: Arc::new(Default::default()),
-            sync_manager,
+            sync_writer,
         }
     }
 
@@ -164,7 +164,7 @@ impl SeafowlFlightHandler {
             // Get the current volatile and durable sequence numbers
             debug!("Received empty batches, returning current sequence numbers");
             let (mem_seq, dur_seq) =
-                self.sync_manager.read().await.stored_sequences(&cmd.origin);
+                self.sync_writer.read().await.stored_sequences(&cmd.origin);
             return Ok(DataSyncResult {
                 accepted: true,
                 memory_sequence_number: mem_seq,
@@ -175,21 +175,23 @@ impl SeafowlFlightHandler {
         debug!("Processing data change with {num_rows} rows for url {url}");
         match tokio::time::timeout(
             Duration::from_secs(self.context.config.misc.sync_conf.write_lock_timeout_s),
-            self.sync_manager.write(),
+            self.sync_writer.write(),
         )
         .await
         {
-            Ok(mut sync_manager) => {
-                let (mem_seq, dur_seq) = sync_manager
-                    .enqueue_sync(
-                        log_store,
-                        cmd.sequence_number,
-                        cmd.origin,
-                        sync_schema.expect("Schema available"),
-                        cmd.last,
-                        batches,
-                    )
-                    .await?;
+            Ok(mut sync_writer) => {
+                sync_writer.enqueue_sync(
+                    log_store,
+                    cmd.sequence_number,
+                    cmd.origin,
+                    sync_schema.expect("Schema available"),
+                    cmd.last,
+                    batches,
+                )?;
+
+                sync_writer.flush().await?;
+
+                let (mem_seq, dur_seq) = sync_writer.stored_sequences(&cmd.origin);
                 Ok(DataSyncResult {
                     accepted: true,
                     memory_sequence_number: mem_seq,

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -48,11 +48,14 @@ pub(super) struct SeafowlFlightHandler {
 }
 
 impl SeafowlFlightHandler {
-    pub fn new(context: Arc<SeafowlContext>) -> Self {
+    pub fn new(
+        context: Arc<SeafowlContext>,
+        sync_manager: Arc<RwLock<SeafowlDataSyncWriter>>,
+    ) -> Self {
         Self {
             context: context.clone(),
             results: Arc::new(Default::default()),
-            sync_manager: Arc::new(RwLock::new(SeafowlDataSyncWriter::new(context))),
+            sync_manager,
         }
     }
 
@@ -171,7 +174,7 @@ impl SeafowlFlightHandler {
 
         debug!("Processing data change with {num_rows} rows for url {url}");
         match tokio::time::timeout(
-            Duration::from_secs(self.context.config.misc.sync_conf.sync_lock_timeout_s),
+            Duration::from_secs(self.context.config.misc.sync_conf.write_lock_timeout_s),
             self.sync_manager.write(),
         )
         .await

--- a/src/frontend/flight/sync/mod.rs
+++ b/src/frontend/flight/sync/mod.rs
@@ -1,3 +1,9 @@
+use crate::frontend::flight::sync::writer::SeafowlDataSyncWriter;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tracing::warn;
+
 mod metrics;
 pub mod schema;
 mod utils;
@@ -7,4 +13,25 @@ pub(crate) mod writer;
 pub enum SyncError {
     #[error("Invalid sync schema: {reason}")]
     SchemaError { reason: String },
+}
+
+pub async fn flush_task(
+    interval: Duration,
+    write_timeout: Duration,
+    sync_writer: Arc<RwLock<SeafowlDataSyncWriter>>,
+) {
+    loop {
+        tokio::time::sleep(interval).await;
+
+        if let Ok(mut writer) =
+            tokio::time::timeout(write_timeout, sync_writer.write()).await
+        {
+            let _ = writer
+                .flush()
+                .await
+                .map_err(|e| warn!("Error flushing syncs: {e}"));
+        } else {
+            warn!("Failed to acquire write lock for sync flush");
+        }
+    }
 }

--- a/tests/flight/mod.rs
+++ b/tests/flight/mod.rs
@@ -64,7 +64,8 @@ bind_port = {}
 
 [misc.sync_conf]
 max_in_memory_bytes = 2500
-max_replication_lag_s = 1"#,
+max_replication_lag_s = 1
+flush_task_interval_s = 1"#,
         addr.port()
     );
 

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -139,10 +139,15 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
         .await
         .unwrap();
 
-    // Ensure table is empty
-    let plan = ctx.plan_query("SELECT * FROM replicated_table").await?;
-    let results = ctx.collect(plan.clone()).await?;
-    assert!(results.is_empty());
+    // Ensure table doesn't exist yet
+    let err = ctx
+        .plan_query("SELECT * FROM replicated_table")
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "External error: Not a Delta table: no log files".to_string()
+    );
 
     //
     // Now go for sync #2; this will flush both it and the first sync as well


### PR DESCRIPTION
Try to flush on a regular interval, so as not to rely on sync calls to do the pushing.

Also:
- make `enqueue_sync` non-async by decoupling table creation and flushing from it
- make table creation lazy (done during actual flushing)
- explicit `flush` method is to be used by the handler