### PR TITLE
Allow using `RUST_LOG_STYLE=never` to disable ANSI colors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,13 @@ fn prepare_tracing(json_logs: bool) {
         .from_env_lossy();
 
     let sub = tracing_subscriber::fmt()
+        .with_ansi(
+            env::var_os("RUST_LOG_STYLE")
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_ascii_lowercase()
+                != "never",
+        )
         .with_thread_names(true)
         .with_thread_ids(true)
         .with_env_filter(env_filter);


### PR DESCRIPTION
This is in line with the `env_logger` crate https://docs.rs/env_logger/latest/env_logger/#disabling-colors