### PR TITLE
workflow_dispatch trigger for nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,7 @@ on:
       - main
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   build_binary:
@@ -98,8 +99,9 @@ jobs:
           tags: |
             type=raw,value=nightly,enable={{is_default_branch}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},enable=${{startsWith(github.event.ref, 'refs/tags/v')}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{startsWith(github.event.ref, 'refs/tags/v')}}
+            type=raw,value=commit-{{sha}}
 
       - name: Build and push Docker image (Linux only)
         if: matrix.build == 'linux-x86_64'


### PR DESCRIPTION
## What
- Allow the `nightly` workflow to be triggered manually
- Push branch builds to Dockerhub

## Why
- Allow branch builds to be referenced by other projects

## Testing
- Trigger a workflow on this branch:
```
gh workflow run 'Build nightly binaries and perform releases' --ref SergeiPatiakin/workflow-dispatch
```
- Verify build is pushed to Dockerhub under the tag `commit-<sha>`

![Screenshot 2024-07-10 132138](https://github.com/splitgraph/seafowl/assets/22116935/f4389305-e8ab-4773-8f11-4f6882594e8a)
![Screenshot 2024-07-10 131949](https://github.com/splitgraph/seafowl/assets/22116935/aba10b70-5c23-4129-89b9-528eca88b2d4)
