### PR TITLE
Add criteria for max separate sync calls to apply when flushing

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -480,6 +480,7 @@ impl Default for ObjectCacheProperties {
 pub struct DataSyncConfig {
     pub max_in_memory_bytes: usize,
     pub max_replication_lag_s: u64,
+    pub max_syncs_per_url: usize,
     pub write_lock_timeout_s: u64,
     pub flush_task_interval_s: u64,
 }
@@ -489,6 +490,7 @@ impl Default for DataSyncConfig {
         Self {
             max_in_memory_bytes: 3 * 1024 * 1024 * 1024,
             max_replication_lag_s: 600,
+            max_syncs_per_url: 50,
             write_lock_timeout_s: 3,
             flush_task_interval_s: 900,
         }


### PR DESCRIPTION
This is to avoid the stack overflow during plan tree walking in optimizations/physical plan conversion etc.