### PR TITLE
BEAC-167: Move object store configs to object_store_factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,6 +4381,7 @@ dependencies = [
  "async-trait",
  "futures",
  "object_store 0.10.2",
+ "serde",
  "tempfile",
  "tracing",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ tracing-log = "0.2"
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 url = "2.5"
 
+
+
 [patch.crates-io]
 # Pick up backport of https://github.com/apache/arrow-datafusion/pull/11386
 datafusion = { git = "https://github.com/splitgraph/arrow-datafusion", branch = "backport-pr11386" }
@@ -65,11 +67,9 @@ include = [
 
 [features]
 catalog-postgres = ["sqlx/postgres"]
-default = ["catalog-postgres", "frontend-arrow-flight", "frontend-postgres", "object-store-s3", "object-store-gcs", "remote-tables"]
+default = ["catalog-postgres", "frontend-arrow-flight", "frontend-postgres", "remote-tables"]
 frontend-arrow-flight = ["dep:tonic", "dep:arrow-flight", "arrow-flight/flight-sql-experimental"]
 frontend-postgres = ["convergence", "convergence-arrow"]
-object-store-gcs = ["object_store/gcp"]
-object-store-s3 = ["object_store/aws"]
 remote-tables = ["dep:datafusion-remote-tables"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ rmp = "0.8.11"
 rmp-serde = "1.1.1"
 rmpv = { version = "1.0.0", features = ["with-serde"] }
 rustyline = "13.0"
-serde = "1.0.156"
+serde = { workspace = true }
 serde_json = "1.0.93"
 sha2 = ">=0.10.1"
 sqlparser = { version = "0.47", features = ["visitor"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ futures = "0.3"
 
 itertools = ">=0.10.0"
 object_store = { version = "0.10.2", features = ["aws", "azure", "gcp"] }
+
+serde = "1.0.156"
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "signal", "process"] }
 tracing = { version = "0.1", features = ["log"] }

--- a/object_store_factory/Cargo.toml
+++ b/object_store_factory/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 async-trait = { workspace = true }
 futures = { workspace = true }
 object_store = { workspace = true }
+serde = { workspace = true }
 tempfile = { workspace = true }
 
 tracing = { workspace = true }

--- a/object_store_factory/src/aws.rs
+++ b/object_store_factory/src/aws.rs
@@ -3,6 +3,7 @@ use object_store::{
     aws::resolve_bucket_region, aws::AmazonS3Builder, aws::AmazonS3ConfigKey,
     ClientOptions, ObjectStore,
 };
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
@@ -10,6 +11,7 @@ use std::sync::Arc;
 use tracing::info;
 use url::Url;
 
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct S3Config {
     pub region: Option<String>,
     pub access_key_id: Option<String>,
@@ -17,7 +19,7 @@ pub struct S3Config {
     pub session_token: Option<String>,
     pub endpoint: Option<String>,
     pub bucket: String,
-    pub _prefix: Option<String>,
+    pub prefix: Option<String>,
 }
 
 impl S3Config {
@@ -31,7 +33,7 @@ impl S3Config {
             session_token: map.get("session_token").map(|s| s.to_string()),
             endpoint: map.get("endpoint").map(|s| s.to_string()),
             bucket: map.get("bucket").unwrap().clone(),
-            _prefix: map.get("prefix").map(|s| s.to_string()),
+            prefix: map.get("prefix").map(|s| s.to_string()),
         })
     }
 }
@@ -164,7 +166,7 @@ mod tests {
         assert_eq!(config.session_token, Some("session_token".to_string()));
         assert_eq!(config.endpoint, Some("http://localhost:9000".to_string()));
         assert_eq!(config.bucket, "my-bucket".to_string());
-        assert_eq!(config._prefix, Some("my-prefix".to_string()));
+        assert_eq!(config.prefix, Some("my-prefix".to_string()));
     }
 
     #[test]
@@ -181,7 +183,7 @@ mod tests {
         assert!(config.session_token.is_none());
         assert!(config.endpoint.is_none());
         assert_eq!(config.bucket, "my-bucket".to_string());
-        assert!(config._prefix.is_none());
+        assert!(config.prefix.is_none());
     }
 
     #[test]
@@ -200,7 +202,7 @@ mod tests {
             session_token: Some("session_token".to_string()),
             endpoint: Some("http://localhost:9000".to_string()),
             bucket: "my-bucket".to_string(),
-            _prefix: Some("my-prefix".to_string()),
+            prefix: Some("my-prefix".to_string()),
         };
 
         let result = build_amazon_s3_from_config(&config);
@@ -227,7 +229,7 @@ mod tests {
             session_token: None,
             endpoint: None,
             bucket: "my-bucket".to_string(),
-            _prefix: None,
+            prefix: None,
         };
 
         let result = build_amazon_s3_from_config(&config);

--- a/object_store_factory/src/aws.rs
+++ b/object_store_factory/src/aws.rs
@@ -36,6 +36,21 @@ impl S3Config {
             prefix: map.get("prefix").map(|s| s.to_string()),
         })
     }
+
+    pub fn from_bucket_and_options(
+        bucket: String,
+        map: &mut HashMap<String, String>,
+    ) -> Result<Self, object_store::Error> {
+        Ok(Self {
+            region: map.remove("format.region"),
+            access_key_id: map.remove("format.access_key_id"),
+            secret_access_key: map.remove("format.secret_access_key"),
+            session_token: map.remove("format.session_token"),
+            endpoint: map.remove("format.endpoint"),
+            bucket,
+            prefix: None,
+        })
+    }
 }
 
 pub fn build_amazon_s3_from_config(

--- a/object_store_factory/src/google.rs
+++ b/object_store_factory/src/google.rs
@@ -24,6 +24,18 @@ impl GCSConfig {
                 .map(|s| s.to_string()),
         })
     }
+
+    pub fn from_bucket_and_options(
+        bucket: String,
+        map: &mut HashMap<String, String>,
+    ) -> Result<Self, object_store::Error> {
+        Ok(Self {
+            bucket,
+            prefix: None,
+            google_application_credentials: map
+                .remove("format.google_application_credentials"),
+        })
+    }
 }
 
 pub fn build_google_cloud_storage_from_config(

--- a/object_store_factory/src/google.rs
+++ b/object_store_factory/src/google.rs
@@ -1,12 +1,14 @@
 use object_store::{gcp::GoogleCloudStorageBuilder, gcp::GoogleConfigKey, ObjectStore};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
 use std::sync::Arc;
 
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GCSConfig {
     pub bucket: String,
-    pub _prefix: Option<String>,
+    pub prefix: Option<String>,
     pub google_application_credentials: Option<String>,
 }
 
@@ -16,7 +18,7 @@ impl GCSConfig {
     ) -> Result<Self, object_store::Error> {
         Ok(Self {
             bucket: map.get("bucket").unwrap().clone(),
-            _prefix: map.get("prefix").map(|s| s.to_string()),
+            prefix: map.get("prefix").map(|s| s.to_string()),
             google_application_credentials: map
                 .get("google_application_credentials")
                 .map(|s| s.to_string()),
@@ -97,7 +99,7 @@ mod tests {
         let config =
             GCSConfig::from_hashmap(&map).expect("Failed to create config from hashmap");
         assert_eq!(config.bucket, "my-bucket");
-        assert_eq!(config._prefix, Some("my-prefix".to_string()));
+        assert_eq!(config.prefix, Some("my-prefix".to_string()));
         assert_eq!(
             config.google_application_credentials,
             Some("/path/to/credentials.json".to_string())
@@ -112,7 +114,7 @@ mod tests {
         let config =
             GCSConfig::from_hashmap(&map).expect("Failed to create config from hashmap");
         assert_eq!(config.bucket, "my-bucket");
-        assert!(config._prefix.is_none());
+        assert!(config.prefix.is_none());
         assert!(config.google_application_credentials.is_none());
     }
 
@@ -147,7 +149,7 @@ mod tests {
 
         let config = GCSConfig {
             bucket: "my-bucket".to_string(),
-            _prefix: Some("my-prefix".to_string()),
+            prefix: Some("my-prefix".to_string()),
             google_application_credentials: Some(
                 temp_file.path().to_str().unwrap().to_string(),
             ),
@@ -167,7 +169,7 @@ mod tests {
     fn test_build_google_cloud_storage_from_config_with_missing_optional_fields() {
         let config = GCSConfig {
             bucket: "my-bucket".to_string(),
-            _prefix: None,
+            prefix: None,
             google_application_credentials: None,
         };
 

--- a/object_store_factory/src/lib.rs
+++ b/object_store_factory/src/lib.rs
@@ -62,13 +62,6 @@ pub enum ObjectStoreConfig {
 /// This function returns an error if the specified object store cannot be created,
 /// which might happen due to misconfiguration, invalid credentials, or other issues
 /// specific to the object store's backend.
-///
-/// # Examples
-///
-/// ```
-/// let config = ObjectStoreConfig::AmazonS3(s3_config);
-/// let object_store = build_object_store(&config)?;
-/// ```
 pub fn build_object_store(
     config: &ObjectStoreConfig,
 ) -> Result<Arc<dyn ObjectStore>, object_store::Error> {

--- a/object_store_factory/src/lib.rs
+++ b/object_store_factory/src/lib.rs
@@ -1,7 +1,11 @@
-mod aws;
-mod google;
-mod local;
+pub mod aws;
+pub mod google;
+pub mod local;
 mod memory;
+
+use aws::S3Config;
+use google::GCSConfig;
+use local::LocalConfig;
 
 use object_store::parse_url_opts;
 use object_store::prefix::PrefixStore;
@@ -13,48 +17,71 @@ use std::sync::Arc;
 use tracing::warn;
 use url::Url;
 
-/// Configuration for object storage, holding settings in a key-value format.
-pub type StorageConfig = HashMap<String, String>;
+use serde::Deserialize;
 
-/// Builds an object store based on the specified scheme and configuration.
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ObjectStoreConfig {
+    Local(LocalConfig),
+    Memory,
+    #[serde(rename = "s3")]
+    AmazonS3(S3Config),
+    #[serde(rename = "gcs")]
+    GoogleCloudStorage(GCSConfig),
+}
+
+/// Creates an `ObjectStore` instance based on the provided configuration.
+///
+/// This function takes an `ObjectStoreConfig` reference and returns a `Result` containing
+/// an `Arc` to a dynamically-dispatched `ObjectStore` trait object. It matches on the
+/// provided configuration to determine the type of object store to create, and then calls
+/// the appropriate builder function to instantiate the store.
 ///
 /// # Arguments
 ///
-/// * `scheme` - The scheme to use for object storage, such as Memory, Local, AmazonS3, or GoogleCloudStorage.
-/// * `config` - A hash map containing configuration settings needed to build the object store.
+/// * `config` - A reference to an `ObjectStoreConfig` enum variant that specifies the
+///   type and configuration details of the object store to be created.
 ///
 /// # Returns
 ///
-/// Returns a `Result` that, on success, contains an Arc `ObjectStore` trait object. On failure, it returns an `object_store::Error`
-/// indicating what went wrong, such as an unsupported scheme.
+/// * `Result<Arc<dyn ObjectStore>, object_store::Error>` - A result containing an `Arc`
+///   pointing to the created object store on success, or an error if the creation fails.
+///
+/// # Supported Object Stores
+///
+/// * `ObjectStoreConfig::Memory` - Builds an in-memory object store.
+/// * `ObjectStoreConfig::Local` - Builds a local filesystem-backed object store using
+///   the provided local configuration.
+/// * `ObjectStoreConfig::AmazonS3` - Builds an Amazon S3 object store using the provided
+///   AWS configuration.
+/// * `ObjectStoreConfig::GoogleCloudStorage` - Builds a Google Cloud Storage object store
+///   using the provided Google Cloud configuration.
 ///
 /// # Errors
 ///
-/// * If the scheme is not supported or the configuration is invalid, an error is returned.
-pub fn build_object_store_from_config(
-    scheme: &ObjectStoreScheme,
-    config: StorageConfig,
+/// This function returns an error if the specified object store cannot be created,
+/// which might happen due to misconfiguration, invalid credentials, or other issues
+/// specific to the object store's backend.
+///
+/// # Examples
+///
+/// ```
+/// let config = ObjectStoreConfig::AmazonS3(s3_config);
+/// let object_store = build_object_store(&config)?;
+/// ```
+pub fn build_object_store(
+    config: &ObjectStoreConfig,
 ) -> Result<Arc<dyn ObjectStore>, object_store::Error> {
-    match scheme {
-        ObjectStoreScheme::Memory => memory::build_in_memory_storage(),
-        ObjectStoreScheme::Local => {
-            let file_config = local::LocalConfig::from_hashmap(&config)?;
-            local::build_local_storage(&file_config)
+    match config {
+        ObjectStoreConfig::Memory => memory::build_in_memory_storage(),
+        ObjectStoreConfig::Local(local_config) => {
+            local::build_local_storage(local_config)
         }
-        ObjectStoreScheme::AmazonS3 => {
-            let aws_config = aws::S3Config::from_hashmap(&config)?;
-            aws::build_amazon_s3_from_config(&aws_config)
+        ObjectStoreConfig::AmazonS3(aws_config) => {
+            aws::build_amazon_s3_from_config(aws_config)
         }
-        ObjectStoreScheme::GoogleCloudStorage => {
-            let google_config = google::GCSConfig::from_hashmap(&config)?;
-            google::build_google_cloud_storage_from_config(&google_config)
-        }
-        _ => {
-            warn!("Unsupported scheme: {:?}", scheme);
-            Err(object_store::Error::Generic {
-                store: "unsupported_url_scheme",
-                source: format!("Unsupported scheme: {:?}", scheme).into(),
-            })
+        ObjectStoreConfig::GoogleCloudStorage(google_config) => {
+            google::build_google_cloud_storage_from_config(google_config)
         }
     }
 }

--- a/object_store_factory/src/local.rs
+++ b/object_store_factory/src/local.rs
@@ -1,8 +1,9 @@
 use object_store::{local::LocalFileSystem, ObjectStore};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct LocalConfig {
     pub data_dir: String,
 }

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -182,6 +182,7 @@ pub async fn build_context(cfg: schema::SeafowlConfig) -> Result<SeafowlContext>
 
 #[cfg(test)]
 mod tests {
+    use object_store_factory::ObjectStoreConfig;
     use sqlx::sqlite::SqliteJournalMode;
 
     use super::*;
@@ -189,7 +190,7 @@ mod tests {
     #[tokio::test]
     async fn test_config_to_context() {
         let config = schema::SeafowlConfig {
-            object_store: Some(schema::ObjectStore::InMemory(schema::InMemory {})),
+            object_store: Some(ObjectStoreConfig::Memory),
             catalog: schema::Catalog::Sqlite(schema::Sqlite {
                 dsn: "sqlite::memory:".to_string(),
                 journal_mode: SqliteJournalMode::Wal,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -581,7 +581,6 @@ cache_control = "private, max-age=86400"
     type = "clade"
     dsn = "http://localhost:54321""#;
 
-    #[cfg(feature = "object-store-s3")]
     #[rstest]
     #[case::basic_s3(TEST_CONFIG_S3, None)]
     #[case::basic_s3_with_cache(
@@ -786,7 +785,6 @@ cache_control = "private, max-age=86400"
     fn test_parse_config_invalid_s3() {
         let error =
             load_config_from_string(TEST_CONFIG_INVALID_S3, false, None).unwrap_err();
-        println!("##### ERROR: {:?}", error.to_string());
         assert!(error.to_string().contains(
             "You need to supply either the region or the endpoint of the S3 object store"
         ))

--- a/src/context/delta.rs
+++ b/src/context/delta.rs
@@ -474,7 +474,6 @@ impl SeafowlContext {
 #[cfg(test)]
 mod tests {
     use super::super::test_utils::{in_memory_context, in_memory_context_with_test_db};
-    use crate::config::schema;
     use crate::context::delta::plan_to_object_store;
     use crate::object_store::wrapped::InternalObjectStore;
     use crate::testutils::assert_uploaded_objects;
@@ -487,6 +486,9 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
     use uuid::Uuid;
+
+    use object_store_factory::local::LocalConfig;
+    use object_store_factory::ObjectStoreConfig;
 
     const PART_0_FILE_NAME: &str =
         "part-00000-01020304-0506-4708-890a-0b0c0d0e0f10-c000.snappy.parquet";
@@ -522,7 +524,7 @@ mod tests {
             (
                 InternalObjectStore::new(
                     Arc::new(LocalFileSystem::new_with_prefix(tmp_dir.path()).unwrap()),
-                    schema::ObjectStore::Local(schema::Local {
+                    ObjectStoreConfig::Local(LocalConfig {
                         data_dir: tmp_dir.path().to_string_lossy().to_string(),
                     }),
                 ),
@@ -532,7 +534,7 @@ mod tests {
             (
                 InternalObjectStore::new(
                     Arc::new(InMemory::new()),
-                    schema::ObjectStore::InMemory(schema::InMemory {}),
+                    ObjectStoreConfig::Memory,
                 ),
                 None,
             )
@@ -695,7 +697,7 @@ mod tests {
 
         let object_store = Arc::new(InternalObjectStore::new(
             Arc::new(InMemory::new()),
-            schema::ObjectStore::InMemory(schema::InMemory {}),
+            ObjectStoreConfig::Memory,
         ));
         let adds = plan_to_object_store(
             &ctx.inner.state(),

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -217,8 +217,8 @@ impl SeafowlContext {
 #[cfg(test)]
 pub mod test_utils {
     use crate::config::context::build_context;
-    use crate::config::schema;
     use crate::config::schema::{Catalog, Sqlite};
+    use object_store_factory::ObjectStoreConfig;
     use sqlx::sqlite::SqliteJournalMode;
 
     use super::*;
@@ -226,7 +226,7 @@ pub mod test_utils {
     /// Build a real (not mocked) in-memory context that uses SQLite
     pub async fn in_memory_context() -> SeafowlContext {
         let config = SeafowlConfig {
-            object_store: Some(schema::ObjectStore::InMemory(schema::InMemory {})),
+            object_store: Some(ObjectStoreConfig::Memory),
             catalog: Catalog::Sqlite(Sqlite {
                 dsn: "sqlite://:memory:".to_string(),
                 journal_mode: SqliteJournalMode::Wal,

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -118,10 +118,10 @@ impl SeafowlContext {
                 // 2. Otherwise use the object store credentials from the config if it matches
                 //    the object store kind.
                 let table_path = ListingTableUrl::parse(&cmd.location)?;
-
+                
                 let url: &Url = table_path.as_ref();
-                let (scheme, _) = ObjectStoreScheme::parse(url).unwrap();
-                if matches!(
+                let parsed_result = ObjectStoreScheme::parse(url);
+                if let Ok((scheme, _)) = parsed_result && matches!(
                     scheme,
                     ObjectStoreScheme::AmazonS3 | ObjectStoreScheme::GoogleCloudStorage
                 ) {

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -1,7 +1,5 @@
 use super::delta::CreateDeltaTableDetails;
 use crate::catalog::{DEFAULT_SCHEMA, STAGING_SCHEMA};
-use crate::config::schema;
-use crate::config::schema::{GCS, S3};
 use crate::context::delta::plan_to_object_store;
 use crate::context::SeafowlContext;
 use crate::nodes::{
@@ -59,6 +57,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::info;
 use url::Url;
 
+use object_store::ObjectStoreScheme;
+use object_store_factory::aws::S3Config;
+use object_store_factory::google::GCSConfig;
+use object_store_factory::ObjectStoreConfig;
+
 /// Create an ExecutionPlan that doesn't produce any results.
 /// This is used for queries that are actually run before we produce the plan,
 /// since they have to manipulate catalog metadata or use async to write to it.
@@ -115,40 +118,71 @@ impl SeafowlContext {
                 // 2. Otherwise use the object store credentials from the config if it matches
                 //    the object store kind.
                 let table_path = ListingTableUrl::parse(&cmd.location)?;
-                let scheme = table_path.scheme();
+
                 let url: &Url = table_path.as_ref();
-                if matches!(scheme, "s3" | "gs" | "gcs") {
+                let (scheme, _) = ObjectStoreScheme::parse(url).unwrap();
+                if matches!(
+                    scheme,
+                    ObjectStoreScheme::AmazonS3 | ObjectStoreScheme::GoogleCloudStorage
+                ) {
                     let bucket = url
                         .host_str()
                         .ok_or_else(|| {
                             DataFusionError::Execution(format!(
-                                "Not able to parse bucket name from url: {}",
+                                "Unable to parse bucket name from URL: {}",
                                 url.as_str()
                             ))
                         })?
                         .to_string();
 
-                    let config = if scheme == "s3" {
-                        let s3 = if cmd.options.is_empty()
-                            && let schema::ObjectStore::S3(s3) =
-                                self.internal_object_store.config.clone()
-                        {
-                            S3 { bucket, ..s3 }
-                        } else {
-                            S3::from_bucket_and_options(bucket, &mut cmd.options)
-                                .map_err(|e| DataFusionError::Execution(e.to_string()))?
-                        };
-                        schema::ObjectStore::S3(s3)
-                    } else {
-                        let gcs = if cmd.options.is_empty()
-                            && let schema::ObjectStore::GCS(gcs) =
-                                self.internal_object_store.config.clone()
-                        {
-                            GCS { bucket, ..gcs }
-                        } else {
-                            GCS::from_bucket_and_options(bucket, &mut cmd.options)
-                        };
-                        schema::ObjectStore::GCS(gcs)
+                    let config = match scheme {
+                        ObjectStoreScheme::AmazonS3 => {
+                            let s3_config = if cmd.options.is_empty() {
+                                if let ObjectStoreConfig::AmazonS3(s3) =
+                                    &self.internal_object_store.config
+                                {
+                                    S3Config {
+                                        bucket: bucket.clone(),
+                                        ..s3.clone()
+                                    }
+                                } else {
+                                    return Err(DataFusionError::Execution(
+                                        "Expected AmazonS3 config".into(),
+                                    ));
+                                }
+                            } else {
+                                let mut s3_config = S3Config::from_hashmap(&cmd.options)
+                                    .map_err(|e| {
+                                        DataFusionError::Execution(e.to_string())
+                                    })?;
+                                s3_config.bucket = bucket.clone();
+                                s3_config
+                            };
+                            ObjectStoreConfig::AmazonS3(s3_config)
+                        }
+                        ObjectStoreScheme::GoogleCloudStorage => {
+                            let gcs_config = if cmd.options.is_empty() {
+                                if let ObjectStoreConfig::GoogleCloudStorage(gcs) =
+                                    &self.internal_object_store.config
+                                {
+                                    GCSConfig {
+                                        bucket: bucket.clone(),
+                                        ..gcs.clone()
+                                    }
+                                } else {
+                                    return Err(DataFusionError::Execution(
+                                        "Expected GoogleCloudStorage config".into(),
+                                    ));
+                                }
+                            } else {
+                                let mut gcs_config =
+                                    GCSConfig::from_hashmap(&cmd.options)?;
+                                gcs_config.bucket = bucket.clone();
+                                gcs_config
+                            };
+                            ObjectStoreConfig::GoogleCloudStorage(gcs_config)
+                        }
+                        _ => unreachable!(),
                     };
 
                     let object_store = build_object_store(

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -154,7 +154,10 @@ impl SeafowlContext {
                                     ));
                                 }
                             } else {
-                                S3Config::from_bucket_and_options(bucket, &mut cmd.options)?
+                                S3Config::from_bucket_and_options(
+                                    bucket,
+                                    &mut cmd.options,
+                                )?
                             };
                             ObjectStoreConfig::AmazonS3(s3_config)
                         }
@@ -173,7 +176,10 @@ impl SeafowlContext {
                                     ));
                                 }
                             } else {
-                                GCSConfig::from_bucket_and_options(bucket, &mut cmd.options)?
+                                GCSConfig::from_bucket_and_options(
+                                    bucket,
+                                    &mut cmd.options,
+                                )?
                             };
                             ObjectStoreConfig::GoogleCloudStorage(gcs_config)
                         }

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -151,12 +151,9 @@ impl SeafowlContext {
                                     ));
                                 }
                             } else {
-                                let mut s3_config = S3Config::from_hashmap(&cmd.options)
-                                    .map_err(|e| {
-                                        DataFusionError::Execution(e.to_string())
-                                    })?;
-                                s3_config.bucket = bucket.clone();
-                                s3_config
+                                let mut options = cmd.options.clone();
+                                options.insert("bucket".to_string(), bucket.clone());
+                                S3Config::from_hashmap(&options)?
                             };
                             ObjectStoreConfig::AmazonS3(s3_config)
                         }
@@ -175,10 +172,9 @@ impl SeafowlContext {
                                     ));
                                 }
                             } else {
-                                let mut gcs_config =
-                                    GCSConfig::from_hashmap(&cmd.options)?;
-                                gcs_config.bucket = bucket.clone();
-                                gcs_config
+                                let mut options = cmd.options.clone();
+                                options.insert("bucket".to_string(), bucket.clone());
+                                GCSConfig::from_hashmap(&options)?
                             };
                             ObjectStoreConfig::GoogleCloudStorage(gcs_config)
                         }

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -154,9 +154,7 @@ impl SeafowlContext {
                                     ));
                                 }
                             } else {
-                                let mut options = cmd.options.clone();
-                                options.insert("bucket".to_string(), bucket.clone());
-                                S3Config::from_hashmap(&options)?
+                                S3Config::from_bucket_and_options(bucket, &mut cmd.options)?
                             };
                             ObjectStoreConfig::AmazonS3(s3_config)
                         }
@@ -175,9 +173,7 @@ impl SeafowlContext {
                                     ));
                                 }
                             } else {
-                                let mut options = cmd.options.clone();
-                                options.insert("bucket".to_string(), bucket.clone());
-                                GCSConfig::from_hashmap(&options)?
+                                GCSConfig::from_bucket_and_options(bucket, &mut cmd.options)?
                             };
                             ObjectStoreConfig::GoogleCloudStorage(gcs_config)
                         }

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -118,13 +118,16 @@ impl SeafowlContext {
                 // 2. Otherwise use the object store credentials from the config if it matches
                 //    the object store kind.
                 let table_path = ListingTableUrl::parse(&cmd.location)?;
-                
+
                 let url: &Url = table_path.as_ref();
                 let parsed_result = ObjectStoreScheme::parse(url);
-                if let Ok((scheme, _)) = parsed_result && matches!(
-                    scheme,
-                    ObjectStoreScheme::AmazonS3 | ObjectStoreScheme::GoogleCloudStorage
-                ) {
+                if let Ok((scheme, _)) = parsed_result
+                    && matches!(
+                        scheme,
+                        ObjectStoreScheme::AmazonS3
+                            | ObjectStoreScheme::GoogleCloudStorage
+                    )
+                {
                     let bucket = url
                         .host_str()
                         .ok_or_else(|| {

--- a/src/object_store/wrapped.rs
+++ b/src/object_store/wrapped.rs
@@ -1,5 +1,3 @@
-use crate::config::schema;
-use crate::config::schema::{Local, GCS, S3};
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};
 use object_store::{
@@ -16,6 +14,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 use url::Url;
 
+use object_store_factory::ObjectStoreConfig;
+
 /// Wrapper around the object_store crate that holds on to the original config
 /// in order to provide a more efficient "upload" for the local object store (since it's
 /// stored on the local filesystem, we can just move the file to it instead).
@@ -23,39 +23,35 @@ use url::Url;
 pub struct InternalObjectStore {
     pub inner: Arc<dyn ObjectStore>,
     pub root_uri: Url,
-    pub config: schema::ObjectStore,
+    pub config: ObjectStoreConfig,
 }
 
 impl InternalObjectStore {
-    pub fn new(inner: Arc<dyn ObjectStore>, config: schema::ObjectStore) -> Self {
+    pub fn new(inner: Arc<dyn ObjectStore>, config: ObjectStoreConfig) -> Self {
         let mut root_uri = match config.clone() {
-            schema::ObjectStore::Local(Local { data_dir }) => {
-                let canonical_path = StdPath::new(&data_dir).canonicalize().unwrap();
+            ObjectStoreConfig::Local(local_config) => {
+                let canonical_path =
+                    StdPath::new(&local_config.data_dir).canonicalize().unwrap();
                 Url::from_directory_path(canonical_path).unwrap()
             }
-            schema::ObjectStore::InMemory(_) => Url::from_str("memory://").unwrap(),
-            schema::ObjectStore::S3(S3 {
-                bucket,
-                endpoint,
-                prefix,
-                ..
-            }) => {
-                let mut base_url = if let Some(endpoint) = endpoint {
+            ObjectStoreConfig::Memory => Url::from_str("memory://").unwrap(),
+            ObjectStoreConfig::AmazonS3(aws_config) => {
+                let mut base_url = if let Some(endpoint) = aws_config.endpoint {
                     // We're assuming here that the bucket isn't contained in the endpoint itself
-                    format!("{endpoint}/{bucket}")
+                    format!("{endpoint}/{}", aws_config.bucket)
                 } else {
-                    format!("s3://{bucket}")
+                    format!("s3://{}", aws_config.bucket)
                 };
 
-                if let Some(prefix) = prefix {
+                if let Some(prefix) = aws_config.prefix {
                     base_url = format!("{base_url}/{prefix}");
                 }
 
                 Url::from_str(&base_url).unwrap()
             }
-            schema::ObjectStore::GCS(GCS { bucket, prefix, .. }) => {
-                let mut base_url = format!("gs://{bucket}");
-                if let Some(prefix) = prefix {
+            ObjectStoreConfig::GoogleCloudStorage(google_config) => {
+                let mut base_url = format!("gs://{}", google_config.bucket);
+                if let Some(prefix) = google_config.prefix {
                     base_url = format!("{base_url}/{prefix}");
                 }
 
@@ -79,8 +75,8 @@ impl InternalObjectStore {
     // the full path to the table dir
     pub fn local_table_dir(&self, table_prefix: &str) -> Option<String> {
         match &self.config {
-            schema::ObjectStore::Local(Local { data_dir }) => {
-                Some(format!("{data_dir}/{table_prefix}"))
+            ObjectStoreConfig::Local(local_config) => {
+                Some(format!("{}/{table_prefix}", local_config.data_dir))
             }
             _ => None,
         }
@@ -89,16 +85,15 @@ impl InternalObjectStore {
     // Get the table prefix relative to the root of the internal object store.
     // This is either just a UUID, or potentially UUID prepended by some path.
     pub fn table_prefix(&self, table_prefix: &str) -> Path {
-        match self.config.clone() {
-            schema::ObjectStore::S3(S3 {
-                prefix: Some(prefix),
-                ..
-            })
-            | schema::ObjectStore::GCS(GCS {
-                prefix: Some(prefix),
-                ..
-            }) => Path::from(format!("{prefix}/{table_prefix}")),
-            _ => Path::from(table_prefix),
+        let prefix = match self.config.clone() {
+            ObjectStoreConfig::AmazonS3(aws_config) => aws_config.prefix,
+            ObjectStoreConfig::GoogleCloudStorage(google_config) => google_config.prefix,
+            _ => None,
+        };
+
+        match prefix {
+            Some(prefix) => Path::from(format!("{prefix}/{table_prefix}")),
+            None => Path::from(table_prefix),
         }
     }
 
@@ -247,7 +242,7 @@ impl ObjectStore for InternalObjectStore {
     ///
     /// Will return an error if the destination already has an object.
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        if let schema::ObjectStore::S3(_) = self.config {
+        if let ObjectStoreConfig::AmazonS3(_) = self.config {
             // TODO: AWS object store doesn't provide `copy_if_not_exists`, which gets called by the
             // the default implementation of this method, since it requires dynamodb lock to be
             // handled properly, so just do the unsafe thing for now.
@@ -261,11 +256,13 @@ impl ObjectStore for InternalObjectStore {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::schema::{ObjectStore, S3};
     use crate::object_store::factory::build_object_store;
     use crate::object_store::wrapped::InternalObjectStore;
     use datafusion::common::Result;
     use rstest::rstest;
+
+    use object_store_factory::aws::S3Config;
+    use object_store_factory::ObjectStoreConfig;
 
     #[rstest]
     #[case::bucket_root("test-bucket", None, "6bb9913e-0341-446d-bb58-b865803ce0ff")]
@@ -288,7 +285,7 @@ mod tests {
             String,
         >,
     ) -> Result<()> {
-        let config = ObjectStore::S3(S3 {
+        let config = ObjectStoreConfig::AmazonS3(S3Config {
             region: None,
             access_key_id: Some("access_key_id".to_string()),
             secret_access_key: Some("secret_access_key".to_string()),

--- a/tests/statements/mod.rs
+++ b/tests/statements/mod.rs
@@ -26,7 +26,6 @@ use uuid::Uuid;
 use rstest::rstest;
 use tempfile::TempDir;
 
-#[cfg(feature = "object-store-gcs")]
 use crate::fixtures::{fake_gcs_creds, FAKE_GCS_CREDS_PATH};
 use seafowl::config::context::build_context;
 use seafowl::config::schema::load_config_from_string;


### PR DESCRIPTION
This PR moves the object store configuration structs into the new crate `object_store_factory`. 