### PR TITLE
Optional sync sequence number

### DIFF
--- a/clade/proto/sync.proto
+++ b/clade/proto/sync.proto
@@ -35,13 +35,9 @@ message DataSyncCommand {
   // Integer identifying data source
   string origin = 4;
 
-  // Monotonically-increasing transaction number
-  uint64 sequence_number = 5;
-
-  // True if this is the last command in the transaction denoted
-  // by this sequence number which might then become durable after
-  // the next flush.
-  bool last = 6;
+  // Monotonically-increasing transaction number.
+  // Only specified in the last message of a transaction
+  optional uint64 sequence_number = 5;
 }
 
 message DataSyncResult {

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -21,14 +21,10 @@ use url::Url;
 use crate::context::SeafowlContext;
 use crate::frontend::flight::sync::schema::SyncSchema;
 use crate::frontend::flight::sync::writer::SeafowlDataSyncWriter;
+use crate::frontend::flight::sync::SyncResult;
 
 pub const SYNC_COMMIT_INFO: &str = "sync_commit_info";
 // Denoted the last sequence number that was fully committed
-pub const SYNC_COMMIT_FULL_SEQUENCE: &str = "sequence";
-// Denotes the last origin that was fully committed
-pub const SYNC_COMMIT_FULL_ORIGIN: &str = "origin";
-// Denotes whether there have been any commits past the last sequence/origin that was fully committed
-pub const SYNC_COMMIT_NEW_SEQUENCE: &str = "new_sequence";
 pub const SEAFOWL_SYNC_CALL_MAX_ROWS: usize = 65536;
 
 lazy_static! {
@@ -141,7 +137,7 @@ impl SeafowlFlightHandler {
         cmd: DataSyncCommand,
         sync_schema: Option<SyncSchema>,
         batches: Vec<RecordBatch>,
-    ) -> Result<DataSyncResult> {
+    ) -> SyncResult<DataSyncResult> {
         let log_store = match cmd.store {
             None => self.context.internal_object_store.get_log_store(&cmd.path),
             Some(store_loc) => {

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -162,7 +162,7 @@ impl SeafowlFlightHandler {
             .iter()
             .fold(0, |rows, batch| rows + batch.num_rows());
 
-        if num_rows == 0 {
+        if num_rows == 0 && cmd.sequence_number.is_none() {
             // Get the current volatile and durable sequence numbers
             debug!("Received empty batches, returning current sequence numbers");
             let (mem_seq, dur_seq) =

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -22,7 +22,13 @@ use crate::context::SeafowlContext;
 use crate::frontend::flight::sync::schema::SyncSchema;
 use crate::frontend::flight::sync::writer::SeafowlDataSyncWriter;
 
-pub const SEAFOWL_SYNC_DATA_SEQUENCE_NUMBER: &str = "sequence";
+pub const SYNC_COMMIT_INFO: &str = "sync_commit_info";
+// Denoted the last sequence number that was fully committed
+pub const SYNC_COMMIT_FULL_SEQUENCE: &str = "sequence";
+// Denotes the last origin that was fully committed
+pub const SYNC_COMMIT_FULL_ORIGIN: &str = "origin";
+// Denotes whether there have been any commits past the last sequence/origin that was fully committed
+pub const SYNC_COMMIT_NEW_SEQUENCE: &str = "new_sequence";
 pub const SEAFOWL_SYNC_CALL_MAX_ROWS: usize = 65536;
 
 lazy_static! {
@@ -185,7 +191,6 @@ impl SeafowlFlightHandler {
                     cmd.sequence_number,
                     cmd.origin.clone(),
                     sync_schema.expect("Schema available"),
-                    cmd.last,
                     batches,
                 )?;
 

--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -1,4 +1,4 @@
-use crate::frontend::flight::sync::writer::{Origin, SequenceNumber};
+use crate::frontend::flight::sync::{Origin, SequenceNumber};
 use metrics::{
     counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram,
     Counter, Gauge, Histogram,

--- a/src/frontend/flight/sync/mod.rs
+++ b/src/frontend/flight/sync/mod.rs
@@ -1,4 +1,5 @@
 use crate::frontend::flight::sync::writer::SeafowlDataSyncWriter;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -9,10 +10,46 @@ pub mod schema;
 mod utils;
 pub(crate) mod writer;
 
+pub(super) type Origin = String;
+pub(super) type SequenceNumber = u64;
+
 #[derive(Debug, thiserror::Error)]
 pub enum SyncError {
     #[error("Invalid sync schema: {reason}")]
     SchemaError { reason: String },
+
+    #[error("Invalid sync message: {reason}")]
+    InvalidMessage { reason: String },
+
+    #[error(transparent)]
+    ArrowError(#[from] arrow_schema::ArrowError),
+
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    DataFusionError(#[from] datafusion::error::DataFusionError),
+
+    #[error(transparent)]
+    DeltaTableError(#[from] deltalake::errors::DeltaTableError),
+
+    #[error(transparent)]
+    ObjectStoreError(#[from] object_store::Error),
+}
+
+pub type SyncResult<T, E = SyncError> = Result<T, E>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(super) struct SyncCommitInfo {
+    // Internal version number
+    version: u8,
+    // The origin for which the last complete transaction was fully persisted
+    origin: Origin,
+    // The sequence number for which the last complete transaction was fully persisted
+    sequence: SequenceNumber,
+    // Flag denoting whether we've started flushing changes from a new (in-complete)
+    // transaction
+    new_tx: bool,
 }
 
 pub async fn flush_task(

--- a/src/frontend/flight/sync/mod.rs
+++ b/src/frontend/flight/sync/mod.rs
@@ -39,7 +39,7 @@ pub enum SyncError {
 
 pub type SyncResult<T, E = SyncError> = Result<T, E>;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub(super) struct SyncCommitInfo {
     // Internal version number
     version: u8,
@@ -50,6 +50,25 @@ pub(super) struct SyncCommitInfo {
     // Flag denoting whether we've started flushing changes from a new (in-complete)
     // transaction
     new_tx: bool,
+}
+
+impl SyncCommitInfo {
+    pub(super) fn new(
+        origin: impl Into<Origin>,
+        sequence: impl Into<SequenceNumber>,
+    ) -> Self {
+        SyncCommitInfo {
+            version: 0,
+            origin: origin.into(),
+            sequence: sequence.into(),
+            new_tx: false,
+        }
+    }
+
+    pub(super) fn with_new_tx(mut self, new_tx: bool) -> Self {
+        self.new_tx = new_tx;
+        self
+    }
 }
 
 pub async fn flush_task(

--- a/src/frontend/flight/sync/schema.rs
+++ b/src/frontend/flight/sync/schema.rs
@@ -3,7 +3,7 @@ use arrow_schema::{DataType, FieldRef, SchemaRef};
 use clade::sync::{ColumnDescriptor, ColumnRole};
 use std::collections::HashSet;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SyncSchema {
     columns: Vec<SyncColumn>,
 }
@@ -117,7 +117,7 @@ impl SyncSchema {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SyncColumn {
     role: ColumnRole,
     name: String,

--- a/src/frontend/flight/sync/utils.rs
+++ b/src/frontend/flight/sync/utils.rs
@@ -621,13 +621,13 @@ mod tests {
         let expr = construct_qualifier(&[
             DataSyncItem {
                 origin: "0".to_string(),
-                sequence_number: 0,
+                sequence_number: Some(0),
                 sync_schema: sync_schema.clone(),
                 batch: batch_1,
             },
             DataSyncItem {
                 origin: "0".to_string(),
-                sequence_number: 0,
+                sequence_number: Some(0),
                 sync_schema,
                 batch: batch_2,
             },

--- a/src/frontend/flight/sync/utils.rs
+++ b/src/frontend/flight/sync/utils.rs
@@ -298,6 +298,7 @@ mod tests {
     use rand::Rng;
     use std::collections::HashSet;
     use std::sync::Arc;
+    use uuid::Uuid;
 
     #[test]
     fn test_batch_compaction() -> Result<(), Box<dyn std::error::Error>> {
@@ -620,14 +621,12 @@ mod tests {
 
         let expr = construct_qualifier(&[
             DataSyncItem {
-                origin: "0".to_string(),
-                sequence_number: Some(0),
+                tx_id: Uuid::new_v4(),
                 sync_schema: sync_schema.clone(),
                 batch: batch_1,
             },
             DataSyncItem {
-                origin: "0".to_string(),
-                sequence_number: Some(0),
+                tx_id: Uuid::new_v4(),
                 sync_schema,
                 batch: batch_2,
             },

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -111,8 +111,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
         store: None,
         column_descriptors,
         origin: "42".to_string(),
-        sequence_number: 1234,
-        last: false,
+        sequence_number: None,
     };
 
     // Changes are still in memory
@@ -167,7 +166,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
         cd1.clone(),
         cd6.clone(),
     ];
-    cmd.last = true;
+    cmd.sequence_number = Some(1234);
 
     // Update row 1 such that we omit the float column and so it should inherit the old value from
     // the previous sync.
@@ -260,8 +259,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     // Sync #3; this will be held in memory
     //
 
-    cmd.sequence_number = 5600;
-    cmd.last = true;
+    cmd.sequence_number = Some(5600);
     cmd.column_descriptors = vec![
         cd5.clone(),
         cd4.clone(),
@@ -303,8 +301,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     // Sync #4
     //
 
-    cmd.sequence_number = 78910;
-    cmd.last = false;
+    cmd.sequence_number = None;
     cmd.column_descriptors = vec![
         cd1.clone(),
         cd2.clone(),
@@ -383,7 +380,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     // Sync #5 to flush the previous 2 syncs due to max size threshold
     //
 
-    cmd.last = true;
+    cmd.sequence_number = Some(78910);
     cmd.column_descriptors = vec![
         cd2.clone(),
         cd1.clone(),

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -243,6 +243,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     // Check empty payload shows the first flush
     //
 
+    cmd.sequence_number = None;
     cmd.column_descriptors = vec![];
     let sync_result =
         do_put_sync(cmd.clone(), RecordBatch::new_empty(schema), &mut client).await?;

--- a/tests/flight/sync_fail.rs
+++ b/tests/flight/sync_fail.rs
@@ -35,8 +35,7 @@ async fn test_sync_errors() -> std::result::Result<(), Box<dyn std::error::Error
         store: None,
         column_descriptors: vec![],
         origin: "1".to_string(),
-        sequence_number: 42,
-        last: true,
+        sequence_number: Some(42),
     };
 
     // No column descriptors provided


### PR DESCRIPTION
Make sequence numbers optional in the protocol, and don't rely on their presence for the flushing mechanism to work. The reason for this is that PGD might not know the sequence number until the very end (last message) of the transaction.

This is achieved with a single queue of pending transactions, whereby with bookkeeping we:

1. track which txs are complete (as soon as they have `Some` sequence number)
2. track which txs have all tables/locations flushed out
3. make sure to mark a tx as durable only if all preceding txs are also durable