### PR TITLE
Extend `S3Config` with `skip_signature` and `allow_http` attributes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ lazy_static = ">=1.4.0"
 metrics = { version = "0.22.1" }
 metrics-exporter-prometheus = { version = "0.13.1" }
 moka = { version = "0.12.5", default-features = false, features = ["future", "atomic64", "quanta"] }
-object_store = { version = "0.10.2", features = ["aws", "azure", "gcp"] }
+object_store = { version = "0.10.1", features = ["aws", "azure", "gcp"] }
 object_store_factory = { path = "object_store_factory" }
 percent-encoding = "2.2.0"
 prost = "0.12.1"

--- a/object_store_factory/src/aws.rs
+++ b/object_store_factory/src/aws.rs
@@ -299,7 +299,6 @@ mod tests {
 
         let store = result.unwrap();
         let debug_output = format!("{:?}", store);
-        println!("#### OUTPUT: {}", debug_output);
 
         assert!(debug_output.contains("region: \"us-west-2\""));
         assert!(debug_output.contains("bucket: \"my-bucket\""));

--- a/object_store_factory/src/aws.rs
+++ b/object_store_factory/src/aws.rs
@@ -237,7 +237,7 @@ mod tests {
         assert!(config.endpoint.is_none());
         assert_eq!(config.bucket, "my-bucket".to_string());
         assert!(config.prefix.is_none());
-        assert!(!config.skip_signature);
+        assert!(config.skip_signature);
         assert!(config.allow_http);
     }
 
@@ -259,7 +259,7 @@ mod tests {
             bucket: "my-bucket".to_string(),
             prefix: Some("my-prefix".to_string()),
             skip_signature: true,
-            allow_http: false,
+            allow_http: true,
         };
 
         let result = build_amazon_s3_from_config(&config);
@@ -275,8 +275,8 @@ mod tests {
         assert!(debug_output.contains("key_id: \"access_key\""));
         assert!(debug_output.contains("secret_key: \"secret_key\""));
         assert!(debug_output.contains("token: Some(\"session_token\")"));
-        assert!(debug_output.contains("skip_signature: true"));
-        assert!(debug_output.contains("allow_http: false"));
+        assert!(debug_output.contains("skip_signature: false")); //When access key / secret key is available, ski_signature is false.
+        assert!(debug_output.contains("allow_http: Parsed(true)"));
     }
 
     #[test]
@@ -299,6 +299,7 @@ mod tests {
 
         let store = result.unwrap();
         let debug_output = format!("{:?}", store);
+        println!("#### OUTPUT: {}", debug_output);
 
         assert!(debug_output.contains("region: \"us-west-2\""));
         assert!(debug_output.contains("bucket: \"my-bucket\""));
@@ -307,7 +308,7 @@ mod tests {
         assert!(!debug_output.contains("secret_key: \"\""));
         assert!(!debug_output.contains("token: \"\""));
         assert!(debug_output.contains("skip_signature: false"));
-        assert!(debug_output.contains("allow_http: true"));
+        assert!(debug_output.contains("allow_http: Parsed(true)"));
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -612,6 +612,8 @@ cache_control = "private, max-age=86400"
                 endpoint: Some("https://s3.amazonaws.com:9000".to_string()),
                 bucket: "seafowl".to_string(),
                 prefix: None,
+                skip_signature: false,
+                allow_http: false,
             }))
         );
     }

--- a/src/object_store/wrapped.rs
+++ b/src/object_store/wrapped.rs
@@ -296,6 +296,8 @@ mod tests {
             bucket: bucket.to_string(),
             prefix: prefix.map(|p| p.to_string()),
             endpoint: endpoint.clone(),
+            skip_signature: true,
+            allow_http: true,
         });
         // In principle for this test we could use any object store since we only exercise the
         // prefix/log store uri logic


### PR DESCRIPTION
The `metastore-agent` requires two other object store attributes that were not implemented on https://github.com/splitgraph/seafowl/pull/580. 

The attributes are `SkipSignature` and `AllowHttp`. 

This PR extends the `S3Config` struct with these two attributes. 