### PR TITLE
Downgrade object_store dependency to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ datafusion-expr = "40.0.0"
 futures = "0.3"
 
 itertools = ">=0.10.0"
-object_store = { version = "0.10.2", features = ["aws", "azure", "gcp"] }
+object_store = { version = "0.10.1", features = ["aws", "azure", "gcp"] }
 
 serde = "1.0.156"
 tempfile = "3"
@@ -114,7 +114,7 @@ lazy_static = ">=1.4.0"
 metrics = { version = "0.22.1" }
 metrics-exporter-prometheus = { version = "0.13.1" }
 moka = { version = "0.12.5", default-features = false, features = ["future", "atomic64", "quanta"] }
-object_store = { version = "0.10.2", features = ["aws", "azure", "gcp"] }
+object_store = { version = "0.10.1", features = ["aws", "azure", "gcp"] }
 object_store_factory = { path = "object_store_factory" }
 percent-encoding = "2.2.0"
 prost = "0.12.1"


### PR DESCRIPTION
This PR downgrade the `object_store` dependency to `0.10.1`. The reason for this is to match delta lake object store version.  