### PR TITLE
Add flag denoting first sync response

### DIFF
--- a/clade/proto/sync.proto
+++ b/clade/proto/sync.proto
@@ -40,7 +40,7 @@ message DataSyncCommand {
   optional uint64 sequence_number = 5;
 }
 
-message DataSyncResult {
+message DataSyncResponse {
   // If false, Seafowl is overloaded and can't accept the change (e.g.
   // can't flush fast enough). The client should wait and retry.
   // TODO: also schema mismatch errors
@@ -51,4 +51,8 @@ message DataSyncResult {
 
   // Sequence number up to which the changes are in Delta Lake.
   optional uint64 durable_sequence_number = 3;
+
+  // Flag denoting whether this is the first response, and thus indicating
+  // that Seafowl has just (re)started.
+  bool first = 4;
 }

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -4,13 +4,14 @@ use arrow::record_batch::RecordBatch;
 use arrow_flight::sql::metadata::{SqlInfoData, SqlInfoDataBuilder};
 use arrow_flight::sql::{ProstMessageExt, SqlInfo, TicketStatementQuery};
 use arrow_flight::{FlightDescriptor, FlightEndpoint, FlightInfo, Ticket};
-use clade::sync::{DataSyncCommand, DataSyncResult};
+use clade::sync::{DataSyncCommand, DataSyncResponse};
 use dashmap::DashMap;
 use datafusion::common::Result;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion_common::DataFusionError;
 use lazy_static::lazy_static;
 use prost::Message;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
@@ -47,6 +48,8 @@ pub(super) struct SeafowlFlightHandler {
     pub context: Arc<SeafowlContext>,
     pub results: Arc<DashMap<String, Mutex<SendableRecordBatchStream>>>,
     sync_writer: Arc<RwLock<SeafowlDataSyncWriter>>,
+    // Denotes whether we're past the first sync reponse, thus indicating Seafowl (re)starts
+    first_sync: Arc<AtomicBool>,
 }
 
 impl SeafowlFlightHandler {
@@ -58,6 +61,7 @@ impl SeafowlFlightHandler {
             context: context.clone(),
             results: Arc::new(Default::default()),
             sync_writer,
+            first_sync: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -137,7 +141,31 @@ impl SeafowlFlightHandler {
         cmd: DataSyncCommand,
         sync_schema: SyncSchema,
         batches: Vec<RecordBatch>,
-    ) -> SyncResult<DataSyncResult> {
+    ) -> SyncResult<DataSyncResponse> {
+        let first = self.first_sync.load(Ordering::SeqCst);
+        if first {
+            // We're past first response
+            self.first_sync.store(false, Ordering::SeqCst);
+        }
+
+        let num_rows = batches
+            .iter()
+            .fold(0, |rows, batch| rows + batch.num_rows());
+
+        // Short-circuit the "probing" request
+        if num_rows == 0 && cmd.sequence_number.is_none() {
+            // Get the current volatile and durable sequence numbers
+            debug!("Received empty batches with no sequence number, returning current sequence numbers");
+            let (mem_seq, dur_seq) =
+                self.sync_writer.read().await.stored_sequences(&cmd.origin);
+            return Ok(DataSyncResponse {
+                accepted: true,
+                memory_sequence_number: mem_seq,
+                durable_sequence_number: dur_seq,
+                first,
+            });
+        }
+
         let log_store = match cmd.store {
             None => self.context.internal_object_store.get_log_store(&cmd.path),
             Some(store_loc) => {
@@ -156,23 +184,7 @@ impl SeafowlFlightHandler {
                     .await?
             }
         };
-
         let url = log_store.root_uri();
-        let num_rows = batches
-            .iter()
-            .fold(0, |rows, batch| rows + batch.num_rows());
-
-        if num_rows == 0 && cmd.sequence_number.is_none() {
-            // Get the current volatile and durable sequence numbers
-            debug!("Received empty batches, returning current sequence numbers");
-            let (mem_seq, dur_seq) =
-                self.sync_writer.read().await.stored_sequences(&cmd.origin);
-            return Ok(DataSyncResult {
-                accepted: true,
-                memory_sequence_number: mem_seq,
-                durable_sequence_number: dur_seq,
-            });
-        }
 
         debug!("Processing data change with {num_rows} rows for url {url} from origin {:?} at position {:?}",
 	       cmd.origin,
@@ -195,18 +207,20 @@ impl SeafowlFlightHandler {
                 sync_writer.flush().await?;
 
                 let (mem_seq, dur_seq) = sync_writer.stored_sequences(&cmd.origin);
-                Ok(DataSyncResult {
+                Ok(DataSyncResponse {
                     accepted: true,
                     memory_sequence_number: mem_seq,
                     durable_sequence_number: dur_seq,
+                    first,
                 })
             }
             Err(_) => {
                 debug!("Timeout waiting for data sync write lock for url {url}");
-                Ok(DataSyncResult {
+                Ok(DataSyncResponse {
                     accepted: false,
                     memory_sequence_number: None,
                     durable_sequence_number: None,
+                    first,
                 })
             }
         }

--- a/tests/flight/mod.rs
+++ b/tests/flight/mod.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 use warp::hyper::Client;
 
 use clade::schema::{InlineMetastoreCommandStatementQuery, ListSchemaResponse};
-use clade::sync::{DataSyncCommand, DataSyncResult};
+use clade::sync::{DataSyncCommand, DataSyncResponse};
 
 use crate::fixtures::schemas;
 use crate::http::{get_metrics, response_text};

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -15,11 +15,11 @@ async fn do_put_sync(
     cmd: DataSyncCommand,
     batch: RecordBatch,
     client: &mut FlightClient,
-) -> Result<DataSyncResult> {
+) -> Result<DataSyncResponse> {
     let flight_data = sync_cmd_to_flight_data(cmd.clone(), batch);
     let response = client.do_put(flight_data).await?.next().await.unwrap()?;
 
-    Ok(DataSyncResult::decode(response.app_metadata).expect("DataSyncResult"))
+    Ok(DataSyncResponse::decode(response.app_metadata).expect("DataSyncResponse"))
 }
 
 #[tokio::test]
@@ -118,10 +118,11 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     let sync_result = do_put_sync(cmd.clone(), batch, &mut client).await?;
     assert_eq!(
         sync_result,
-        DataSyncResult {
+        DataSyncResponse {
             accepted: true,
             memory_sequence_number: None, // sequence not in memory because of  `last: false`
             durable_sequence_number: None,
+            first: true,
         }
     );
 
@@ -211,10 +212,11 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     let sync_result = do_put_sync(cmd.clone(), batch, &mut client).await?;
     assert_eq!(
         sync_result,
-        DataSyncResult {
+        DataSyncResponse {
             accepted: true,
             memory_sequence_number: Some(1234),
             durable_sequence_number: None,
+            first: false,
         }
     );
 
@@ -249,10 +251,11 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
         do_put_sync(cmd.clone(), RecordBatch::new_empty(schema), &mut client).await?;
     assert_eq!(
         sync_result,
-        DataSyncResult {
+        DataSyncResponse {
             accepted: true,
             memory_sequence_number: Some(1234),
             durable_sequence_number: Some(1234),
+            first: false,
         }
     );
 
@@ -291,10 +294,11 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     let sync_result = do_put_sync(cmd.clone(), batch, &mut client).await?;
     assert_eq!(
         sync_result,
-        DataSyncResult {
+        DataSyncResponse {
             accepted: true,
             memory_sequence_number: Some(5600),
             durable_sequence_number: Some(1234),
+            first: false,
         }
     );
 
@@ -354,10 +358,11 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     let sync_result = do_put_sync(cmd.clone(), batch, &mut client).await?;
     assert_eq!(
         sync_result,
-        DataSyncResult {
+        DataSyncResponse {
             accepted: true,
             memory_sequence_number: Some(5600), // again 78910 not in memory since `last = false`
             durable_sequence_number: Some(1234),
+            first: false,
         }
     );
 
@@ -370,10 +375,11 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
         do_put_sync(cmd.clone(), RecordBatch::new_empty(schema), &mut client).await?;
     assert_eq!(
         sync_result,
-        DataSyncResult {
+        DataSyncResponse {
             accepted: true,
             memory_sequence_number: Some(5600),
             durable_sequence_number: Some(1234),
+            first: false,
         }
     );
 
@@ -444,10 +450,11 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     let sync_result = do_put_sync(cmd.clone(), batch, &mut client).await?;
     assert_eq!(
         sync_result,
-        DataSyncResult {
+        DataSyncResponse {
             accepted: true,
             memory_sequence_number: Some(78910),
             durable_sequence_number: Some(78910),
+            first: false,
         }
     );
 


### PR DESCRIPTION
The flag is tracked in `SeafowlFlightHandler` since it is the one that actually construct the response (not `SeafowlDataSyncWriter`), and in addition it has short-circuiting for the "probing" request.