### PR TITLE
Fix build after dependencies updates. 

### DIFF
--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -298,9 +298,11 @@ impl<'a> DFParser<'a> {
             Token::DoubleQuotedString(s) => Ok(Value::DoubleQuotedString(s)),
             Token::EscapedStringLiteral(s) => Ok(Value::EscapedStringLiteral(s)),
             Token::Number(ref n, l) => {
-                let n = n.parse().expect("Token::Number should always contain a valid number");
+                let n = n
+                    .parse()
+                    .expect("Token::Number should always contain a valid number");
                 Ok(Value::Number(n, l))
-            },
+            }
             _ => self.parser.expected("string or numeric value", next_token),
         }
     }

--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -297,13 +297,9 @@ impl<'a> DFParser<'a> {
             Token::SingleQuotedString(s) => Ok(Value::SingleQuotedString(s)),
             Token::DoubleQuotedString(s) => Ok(Value::DoubleQuotedString(s)),
             Token::EscapedStringLiteral(s) => Ok(Value::EscapedStringLiteral(s)),
-            Token::Number(ref n, l) => match n.parse() {
-                Ok(n) => Ok(Value::Number(n, l)),
-                // The tokenizer should have ensured `n` is an integer
-                // so this should not be possible
-                Err(e) => parser_err!(format!(
-                    "Unexpected error: could not parse '{n}' as number: {e}"
-                )),
+            Token::Number(ref n, l) => {
+                let n = n.parse().expect("Token::Number should always contain a valid number");
+                Ok(Value::Number(n, l))
             },
             _ => self.parser.expected("string or numeric value", next_token),
         }


### PR DESCRIPTION
After updating these dependencies, the build started to fail:
https://github.com/splitgraph/seafowl/commit/24958e2dc4a4104a2f8b097b51b5610ecd526f84
https://github.com/splitgraph/seafowl/commit/cae3903ddc7fcf846de3a0c40308f1a2d314640f
https://github.com/splitgraph/seafowl/commit/b30f998e89d20a2a4955c93f7699dc1ffee6f08c

The reason for is: 

- `Token::Number(ref n, l)`: When matching this token, `n.parse()` is expected to always succeed, so instead of handling an `Err`, I'm using `.expect()` to panic with a message if the invariant is somehow violated.

- Removed Err(e) match arm: Since `std::convert::Infallible` makes it impossible for an error to occur, the match arm is removed.