### PR TITLE
Remove bucket from options

### DIFF
--- a/object_store_factory/src/aws.rs
+++ b/object_store_factory/src/aws.rs
@@ -121,10 +121,6 @@ impl S3Config {
             );
         }
         map.insert(
-            AmazonS3ConfigKey::Bucket.as_ref().to_string(),
-            self.bucket.clone(),
-        );
-        map.insert(
             AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp)
                 .as_ref()
                 .to_string(),
@@ -536,10 +532,6 @@ mod tests {
             Some(&"https://s3.amazonaws.com".to_string())
         );
         assert_eq!(
-            hashmap.get(AmazonS3ConfigKey::Bucket.as_ref()),
-            Some(&"my_bucket".to_string())
-        );
-        assert_eq!(
             hashmap.get(AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp).as_ref()),
             Some(&"true".to_string())
         );
@@ -573,10 +565,6 @@ mod tests {
         );
         assert_eq!(hashmap.get(AmazonS3ConfigKey::Token.as_ref()), None);
         assert_eq!(hashmap.get(AmazonS3ConfigKey::Endpoint.as_ref()), None);
-        assert_eq!(
-            hashmap.get(AmazonS3ConfigKey::Bucket.as_ref()),
-            Some(&"my_bucket".to_string())
-        );
         assert_eq!(
             hashmap.get(AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp).as_ref()),
             Some(&"true".to_string())

--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -297,14 +297,12 @@ impl<'a> DFParser<'a> {
             Token::SingleQuotedString(s) => Ok(Value::SingleQuotedString(s)),
             Token::DoubleQuotedString(s) => Ok(Value::DoubleQuotedString(s)),
             Token::EscapedStringLiteral(s) => Ok(Value::EscapedStringLiteral(s)),
-            Token::Number(ref n, l) => match n.parse() {
-                Ok(n) => Ok(Value::Number(n, l)),
-                // The tokenizer should have ensured `n` is an integer
-                // so this should not be possible
-                Err(e) => parser_err!(format!(
-                    "Unexpected error: could not parse '{n}' as number: {e}"
-                )),
-            },
+            Token::Number(ref n, l) => {
+                let n = n
+                    .parse()
+                    .expect("Token::Number should always contain a valid number");
+                Ok(Value::Number(n, l))
+            }
             _ => self.parser.expected("string or numeric value", next_token),
         }
     }


### PR DESCRIPTION
Remove the bucket from the key-value config as it is already expected the bucket to be in the URL.  The object store is uniquely determined by the URL + options).