### PR TITLE
Allow running Seafowl without an object store / catalog config.

### DIFF
--- a/src/catalog/empty.rs
+++ b/src/catalog/empty.rs
@@ -1,0 +1,36 @@
+/// Empty metastore that raises errors if the API caller didn't pass an inline metastore
+/// over the Flight gRPC interface.
+use crate::catalog::{
+    CatalogResult, CatalogStore, FunctionStore, SchemaStore, TableStore,
+};
+use crate::repository::interface::AllDatabaseFunctionsResult;
+use async_trait::async_trait;
+use clade::schema::ListSchemaResponse;
+
+use super::CatalogError;
+
+#[derive(Clone)]
+pub struct EmptyStore {}
+
+#[async_trait]
+impl CatalogStore for EmptyStore {}
+
+#[async_trait]
+impl SchemaStore for EmptyStore {
+    async fn list(&self, _catalog_name: &str) -> CatalogResult<ListSchemaResponse> {
+        Err(CatalogError::NoInlineMetastore)
+    }
+}
+
+#[async_trait]
+impl TableStore for EmptyStore {}
+
+#[tonic::async_trait]
+impl FunctionStore for EmptyStore {
+    async fn list(
+        &self,
+        _catalog_name: &str,
+    ) -> CatalogResult<Vec<AllDatabaseFunctionsResult>> {
+        Ok(vec![])
+    }
+}

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -11,6 +11,7 @@ use datafusion_common::DataFusionError;
 use tonic::Status;
 use uuid::Uuid;
 
+mod empty;
 pub mod external;
 pub mod memory;
 pub mod metastore;
@@ -81,6 +82,14 @@ pub enum CatalogError {
 
     #[error("Failed parsing URL: {0}")]
     UrlParseError(#[from] url::ParseError),
+
+    #[error(
+        "Object store not configured and no object store for table {name:?} passed in"
+    )]
+    NoTableStoreInInlineMetastore { name: String },
+
+    #[error("No inline metastore passed in")]
+    NoInlineMetastore,
 }
 
 /// Implement a global converter into a DataFusionError from the catalog error type.

--- a/src/context/logical.rs
+++ b/src/context/logical.rs
@@ -357,7 +357,7 @@ impl SeafowlContext {
             // We only support datetime DeltaTable version specification for start
             let table_uuid = self.get_table_uuid(resolved_ref.clone()).await?;
             let table_log_store = self
-                .internal_object_store
+                .get_internal_object_store()?
                 .get_log_store(&table_uuid.to_string());
             let datetime = TableVersionProcessor::version_to_datetime(version)?;
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -28,7 +28,7 @@ pub struct SeafowlContext {
     pub config: SeafowlConfig,
     pub inner: SessionContext,
     pub metastore: Arc<Metastore>,
-    pub internal_object_store: Arc<InternalObjectStore>,
+    pub internal_object_store: Option<Arc<InternalObjectStore>>,
     pub default_catalog: String,
     pub default_schema: String,
 }
@@ -227,11 +227,11 @@ pub mod test_utils {
     pub async fn in_memory_context() -> SeafowlContext {
         let config = SeafowlConfig {
             object_store: Some(ObjectStoreConfig::Memory),
-            catalog: Catalog::Sqlite(Sqlite {
+            catalog: Some(Catalog::Sqlite(Sqlite {
                 dsn: "sqlite://:memory:".to_string(),
                 journal_mode: SqliteJournalMode::Wal,
                 read_only: false,
-            }),
+            })),
             frontend: Default::default(),
             runtime: Default::default(),
             misc: Default::default(),

--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -297,14 +297,12 @@ impl<'a> DFParser<'a> {
             Token::SingleQuotedString(s) => Ok(Value::SingleQuotedString(s)),
             Token::DoubleQuotedString(s) => Ok(Value::DoubleQuotedString(s)),
             Token::EscapedStringLiteral(s) => Ok(Value::EscapedStringLiteral(s)),
-            Token::Number(ref n, l) => match n.parse() {
-                Ok(n) => Ok(Value::Number(n, l)),
-                // The tokenizer should have ensured `n` is an integer
-                // so this should not be possible
-                Err(e) => parser_err!(format!(
-                    "Unexpected error: could not parse '{n}' as number: {e}"
-                )),
-            },
+            Token::Number(ref n, l) => {
+                let n = n
+                    .parse()
+                    .expect("Token::Number should always contain a valid number");
+                Ok(Value::Number(n, l))
+            }
             _ => self.parser.expected("string or numeric value", next_token),
         }
     }

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -167,7 +167,10 @@ impl SeafowlFlightHandler {
         }
 
         let log_store = match cmd.store {
-            None => self.context.internal_object_store.get_log_store(&cmd.path),
+            None => self
+                .context
+                .get_internal_object_store()?
+                .get_log_store(&cmd.path),
             Some(store_loc) => {
                 self.context
                     .metastore

--- a/src/frontend/flight/sync/writer.rs
+++ b/src/frontend/flight/sync/writer.rs
@@ -964,7 +964,10 @@ mod tests {
                 continue;
             }
 
-            let log_store = ctx.internal_object_store.get_log_store(table_name);
+            let log_store = ctx
+                .get_internal_object_store()
+                .unwrap()
+                .get_log_store(table_name);
             let origin: String = (*origin).to_owned();
 
             sync_mgr
@@ -1068,7 +1071,10 @@ mod tests {
 
         // Enqueue all syncs
         for (table_name, origin, sequence) in syncs {
-            let log_store = ctx.internal_object_store.get_log_store(table_name);
+            let log_store = ctx
+                .get_internal_object_store()
+                .unwrap()
+                .get_log_store(table_name);
 
             sync_mgr
                 .enqueue_sync(
@@ -1097,7 +1103,10 @@ mod tests {
         let (arrow_schema, sync_schema) = sync_schema();
 
         // Enqueue all syncs
-        let log_store = ctx.internal_object_store.get_log_store("test_table");
+        let log_store = ctx
+            .get_internal_object_store()
+            .unwrap()
+            .get_log_store("test_table");
 
         // Add first non-empty sync
         sync_mgr

--- a/tests/clade/mod.rs
+++ b/tests/clade/mod.rs
@@ -74,7 +74,7 @@ async fn run_clade_server(addr: SocketAddr) {
     // Setup a test metastore with some fake tables in test object stores.
     let metastore = TestCladeMetastore {
         catalog: DEFAULT_DB.to_string(),
-        schemas: schemas(),
+        schemas: schemas(true),
     };
 
     let svc = SchemaStoreServiceServer::new(metastore);

--- a/tests/clade/query.rs
+++ b/tests/clade/query.rs
@@ -1,7 +1,9 @@
 use crate::clade::*;
 
 #[rstest]
-#[should_panic(expected = "External(NotATable(\"no log files\"))")]
+#[should_panic(
+    expected = "Plan(\"Object store not configured and no object store for table \\\"file\\\" passed in\")"
+)]
 #[case("local.file", false)]
 #[case("local.file", true)]
 #[case("s3.minio", true)]

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -22,23 +22,26 @@ pub fn fake_gcs_creds() -> String {
 }
 
 // Return a list of schemas with actual tables and object store configs that are used in testing
-pub fn schemas() -> ListSchemaResponse {
+pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
+    let mut local_schema_tables = vec![TableObject {
+        name: "file_with_store".to_string(),
+        path: "delta-0.8.0-partitioned".to_string(),
+        store: Some("local_fs".to_string()),
+    }];
+
+    if include_file_without_store {
+        local_schema_tables.push(TableObject {
+            name: "file".to_string(),
+            path: "delta-0.8.0-partitioned".to_string(),
+            store: None,
+        })
+    }
+
     ListSchemaResponse {
         schemas: vec![
             SchemaObject {
                 name: "local".to_string(),
-                tables: vec![
-                    TableObject {
-                        name: "file".to_string(),
-                        path: "delta-0.8.0-partitioned".to_string(),
-                        store: None,
-                    },
-                    TableObject {
-                        name: "file_with_store".to_string(),
-                        path: "delta-0.8.0-partitioned".to_string(),
-                        store: Some("local_fs".to_string()),
-                    },
-                ],
+                tables: local_schema_tables,
             },
             SchemaObject {
                 name: "s3".to_string(),

--- a/tests/flight/client.rs
+++ b/tests/flight/client.rs
@@ -2,7 +2,7 @@ use crate::flight::*;
 
 #[tokio::test]
 async fn test_basic_queries() -> Result<()> {
-    let (context, mut client) = flight_server(false).await;
+    let (context, mut client) = flight_server(TestServerType::Memory).await;
     create_table_and_insert(context.as_ref(), "flight_table").await;
 
     // Test the handshake works
@@ -28,7 +28,7 @@ async fn test_basic_queries() -> Result<()> {
 
 #[tokio::test]
 async fn test_ddl_types_roundtrip() -> Result<()> {
-    let (_context, mut client) = flight_server(false).await;
+    let (_context, mut client) = flight_server(TestServerType::Memory).await;
 
     let all_types_query = r#"
 SELECT

--- a/tests/flight/inline_metastore.rs
+++ b/tests/flight/inline_metastore.rs
@@ -1,20 +1,39 @@
 use crate::flight::*;
 
 #[rstest]
+// Errors out because the path for the table `file` doesn't exist
 #[should_panic(expected = "External error: Not a Delta table: no log files")]
-#[case("local.file", false)]
-#[case("local.file_with_store", false)]
-#[case("local.file", true)]
-#[case("s3.minio", true)]
-#[case("gcs.fake", true)]
+#[case("local.file", TestServerType::Memory, true)]
+// Errors out because the metastore entry for `file` doesn't have an object store
+#[should_panic(
+    expected = "Error during planning: Object store not configured and no object store for table \\\"file\\\" passed in"
+)]
+#[case("local.file", TestServerType::InlineOnly, true)]
+// path for the table `file` contains a real Delta tables and the metastore is pre-configured
+#[case("local.file", TestServerType::LocalWithData, true)]
+// Errors out because even though we're querying the `file_with_store` table that does have
+// an object store reference in the inline metastore, the inline metastore also contains
+// the `file` table which is broken.
+#[should_panic(
+    expected = "Error during planning: Object store not configured and no object store for table \\\"file\\\" passed in"
+)]
+#[case("local.file_with_store", TestServerType::InlineOnly, true)]
+// Testing with properly sent inline metastore
+#[case("local.file_with_store", TestServerType::InlineOnly, false)]
+#[case("s3.minio", TestServerType::InlineOnly, false)]
+#[case("gcs.fake", TestServerType::InlineOnly, false)]
 #[tokio::test]
-async fn test_inline_query(#[case] table: &str, #[case] local_store: bool) -> () {
-    let (_context, mut client) = flight_server(local_store).await;
+async fn test_inline_query(
+    #[case] table: &str,
+    #[case] test_server_type: TestServerType,
+    #[case] include_file_without_store: bool,
+) -> () {
+    let (_context, mut client) = flight_server(test_server_type).await;
 
     let batches = get_flight_batches_inlined(
         &mut client,
         format!("SELECT * FROM {table} ORDER BY value"),
-        schemas(),
+        schemas(include_file_without_store),
     )
     .await
     .unwrap();

--- a/tests/flight/search_path.rs
+++ b/tests/flight/search_path.rs
@@ -3,7 +3,7 @@ use crate::flight::*;
 #[tokio::test]
 async fn test_default_schema_override(
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let (context, mut client) = flight_server(false).await;
+    let (context, mut client) = flight_server(TestServerType::Memory).await;
 
     context.plan_query("CREATE SCHEMA some_schema").await?;
     create_table_and_insert(context.as_ref(), "some_schema.flight_table").await;

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -24,7 +24,7 @@ async fn do_put_sync(
 
 #[tokio::test]
 async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let (ctx, mut client) = flight_server(false).await;
+    let (ctx, mut client) = flight_server(TestServerType::Memory).await;
 
     //
     // Sync #1 that creates the table, and dictates the full schema for following syncs

--- a/tests/flight/sync_fail.rs
+++ b/tests/flight/sync_fail.rs
@@ -17,7 +17,7 @@ async fn assert_sync_error(
 
 #[tokio::test]
 async fn test_sync_errors() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let (_ctx, mut client) = flight_server(false).await;
+    let (_ctx, mut client) = flight_server(TestServerType::Memory).await;
 
     let schema = Arc::new(Schema::new(vec![Field::new(
         "old_c1",

--- a/tests/statements/convert.rs
+++ b/tests/statements/convert.rs
@@ -71,7 +71,8 @@ async fn test_convert_from_flat_parquet_table() -> Result<()> {
     // Also check the final directory state
     testutils::assert_uploaded_objects(
         context
-            .internal_object_store
+            .get_internal_object_store()
+            .unwrap()
             .get_log_store(&table_uuid.to_string())
             .object_store(),
         vec![

--- a/tests/statements/ddl.rs
+++ b/tests/statements/ddl.rs
@@ -361,7 +361,8 @@ async fn test_create_table_drop_schema(
     for table_uuid in [table_1_uuid, table_2_uuid, table_3_uuid] {
         testutils::assert_uploaded_objects(
             context
-                .internal_object_store
+                .get_internal_object_store()
+                .unwrap()
                 .get_log_store(&table_uuid.to_string())
                 .object_store(),
             vec![],
@@ -381,7 +382,8 @@ async fn test_create_table_drop_schema(
 
         testutils::assert_uploaded_objects(
             context
-                .internal_object_store
+                .get_internal_object_store()
+                .unwrap()
                 .get_log_store(&table_uuid.to_string())
                 .object_store(),
             vec![

--- a/tests/statements/vacuum.rs
+++ b/tests/statements/vacuum.rs
@@ -58,7 +58,8 @@ async fn test_vacuum_table() -> Result<()> {
     // Check initial directory state
     testutils::assert_uploaded_objects(
         context
-            .internal_object_store
+            .get_internal_object_store()
+            .unwrap()
             .get_log_store(&table_1_uuid.to_string())
             .object_store(),
         vec![
@@ -98,7 +99,8 @@ async fn test_vacuum_table() -> Result<()> {
     // `VACUUM END` operations.
     testutils::assert_uploaded_objects(
         context
-            .internal_object_store
+            .get_internal_object_store()
+            .unwrap()
             .get_log_store(&table_1_uuid.to_string())
             .object_store(),
         vec![
@@ -139,7 +141,8 @@ async fn test_vacuum_table() -> Result<()> {
     // referenced by the latest table version.
     testutils::assert_uploaded_objects(
         context
-            .internal_object_store
+            .get_internal_object_store()
+            .unwrap()
             .get_log_store(&table_2_uuid.to_string())
             .object_store(),
         vec![


### PR DESCRIPTION
In this case, Seafowl expects the metastore and the object store settings to be passed to it over the Flight RPC endpoint (when querying or writing) and will error out otherwise.

This required some weird refactoring because so many things assume there is a "default" object store and a metastore, so all SeafowlContext methods that want to access the internal default object store for writes now do it through a method that errors out if it's not set up. For the metastore, this change defines an EmptyMetastore that errors if Seafowl actually tries to use it.