### PR TITLE
Separate qualifier for new and old sync pks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "0.18.2"
-source = "git+https://github.com/delta-io/delta-rs?rev=e75a0b49b40f35ed361444bbea0e5720f359d732#e75a0b49b40f35ed361444bbea0e5720f359d732"
+source = "git+https://github.com/delta-io/delta-rs?rev=b8162c0fb967b3f3d9409d84f08605440dbad13b#b8162c0fb967b3f3d9409d84f08605440dbad13b"
 dependencies = [
  "deltalake-core",
 ]
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "0.18.2"
-source = "git+https://github.com/delta-io/delta-rs?rev=e75a0b49b40f35ed361444bbea0e5720f359d732#e75a0b49b40f35ed361444bbea0e5720f359d732"
+source = "git+https://github.com/delta-io/delta-rs?rev=b8162c0fb967b3f3d9409d84f08605440dbad13b#b8162c0fb967b3f3d9409d84f08605440dbad13b"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -2401,7 +2401,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "sqlparser 0.47.0",
+ "sqlparser 0.49.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -6340,6 +6340,15 @@ checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "log",
  "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ datafusion-expr = { workspace = true }
 
 datafusion-remote-tables = { path = "./datafusion_remote_tables", optional = true }
 
-deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "e75a0b49b40f35ed361444bbea0e5720f359d732", features = ["datafusion"] }
+deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "b8162c0fb967b3f3d9409d84f08605440dbad13b", features = ["datafusion"] }
 
 futures = "0.3"
 hex = ">=0.4.0"

--- a/src/context/delta.rs
+++ b/src/context/delta.rs
@@ -492,9 +492,9 @@ mod tests {
     use object_store_factory::ObjectStoreConfig;
 
     const PART_0_FILE_NAME: &str =
-        "part-00000-01020304-0506-4708-890a-0b0c0d0e0f10-c000.snappy.parquet";
+        "part-00000-00000000-0000-0000-0000-000000000001-c000.snappy.parquet";
     const PART_1_FILE_NAME: &str =
-        "part-00001-01020304-0506-4708-890a-0b0c0d0e0f10-c000.snappy.parquet";
+        "part-00001-00000000-0000-0000-0000-000000000001-c000.snappy.parquet";
 
     #[rstest]
     #[case::in_memory_object_store_standard(false)]

--- a/src/context/delta.rs
+++ b/src/context/delta.rs
@@ -109,6 +109,7 @@ pub async fn plan_to_object_store(
 
     // Iterate over Datafusion partitions and re-chunk them, since we want to enforce a pre-defined
     // partition size limit, which is not guaranteed by DF.
+    info!("Persisting data into temporary partition objects on disk");
     for i in 0..plan.output_partitioning().partition_count() {
         let task_ctx = Arc::new(TaskContext::from(state));
         let mut stream = plan.execute(i, task_ctx)?;

--- a/src/frontend/flight/sync/utils.rs
+++ b/src/frontend/flight/sync/utils.rs
@@ -215,7 +215,10 @@ pub(super) fn squash_batches(
 // Generate a qualifier expression that, when applied to the table, will only return
 // rows whose primary keys are affected by the changes in `entry`. This is so that
 // we can only read the partitions from Delta Lake that we need to rewrite.
-pub(super) fn construct_qualifier(syncs: &[DataSyncItem]) -> Result<Expr> {
+pub(super) fn construct_qualifier(
+    syncs: &[DataSyncItem],
+    role: ColumnRole,
+) -> Result<Option<Expr>> {
     // Initialize the min/max accumulators for the primary key columns needed to prune the table
     // files.
     // The assumption here is that the primary key columns are the same across all syncs.
@@ -225,7 +228,7 @@ pub(super) fn construct_qualifier(syncs: &[DataSyncItem]) -> Result<Expr> {
         .sync_schema
         .columns()
         .iter()
-        .filter(|col| col.role() == ColumnRole::OldPk)
+        .filter(|col| col.role() == role)
         .map(|col| {
             Ok((
                 col.name().clone(),
@@ -242,24 +245,9 @@ pub(super) fn construct_qualifier(syncs: &[DataSyncItem]) -> Result<Expr> {
         min_max_values
             .iter_mut()
             .try_for_each(|(pk_col, (min_value, max_value))| {
-                let old_field = sync
-                    .sync_schema
-                    .column(pk_col, ColumnRole::OldPk)
-                    .unwrap()
-                    .field();
+                let field = sync.sync_schema.column(pk_col, role).unwrap().field();
 
-                if let Some(pk_array) = sync.batch.column_by_name(old_field.name()) {
-                    min_value.update_batch(&[pk_array.clone()])?;
-                    max_value.update_batch(&[pk_array.clone()])?;
-                }
-
-                let new_field = sync
-                    .sync_schema
-                    .column(pk_col, ColumnRole::NewPk)
-                    .unwrap()
-                    .field();
-
-                if let Some(pk_array) = sync.batch.column_by_name(new_field.name()) {
+                if let Some(pk_array) = sync.batch.column_by_name(field.name()) {
                     min_value.update_batch(&[pk_array.clone()])?;
                     max_value.update_batch(&[pk_array.clone()])?;
                 }
@@ -270,14 +258,24 @@ pub(super) fn construct_qualifier(syncs: &[DataSyncItem]) -> Result<Expr> {
     // Combine the statistics into a single qualifier expression
     Ok(min_max_values
         .iter_mut()
-        .map(|(pk_col, (min_value, max_value))| {
-            Ok(col(pk_col.as_str())
-                .between(lit(min_value.evaluate()?), lit(max_value.evaluate()?)))
+        .filter_map(|(pk_col, (min_value, max_value))| {
+            let min_value = min_value.evaluate().ok()?;
+            let max_value = max_value.evaluate().ok()?;
+            if !min_value.is_null() && !max_value.is_null() {
+                Some(Ok(
+                    col(pk_col.as_str()).between(lit(min_value), lit(max_value))
+                ))
+            } else {
+                // There shouldn't be a situation where a max is NULL but min isn't and vice-versa.
+                // Moreover, it should be the case that if one column has NULL min/max values, all
+                // columns do (i.e. we're processing an all INSERT/DELETE changeset).
+                assert!(min_value.is_null() && max_value.is_null());
+                None
+            }
         })
         .collect::<Result<Vec<Expr>>>()?
         .into_iter()
-        .reduce(|e1: Expr, e2| e1.and(e2))
-        .unwrap())
+        .reduce(|e1: Expr, e2| e1.and(e2)))
 }
 
 #[cfg(test)]
@@ -599,6 +597,7 @@ mod tests {
 
         let sync_schema = SyncSchema::try_new(column_descriptors, schema.clone())?;
 
+        // UPDATE, INSERT
         let batch_1 = RecordBatch::try_new(
             schema.clone(),
             vec![
@@ -609,17 +608,18 @@ mod tests {
             ],
         )?;
 
+        // DELETE, UPDATE
         let batch_2 = RecordBatch::try_new(
             schema.clone(),
             vec![
                 Arc::new(Int32Array::from(vec![0, 4])),
                 Arc::new(Float64Array::from(vec![3.1, 3.2])),
-                Arc::new(Int32Array::from(vec![1, 3])),
-                Arc::new(Float64Array::from(vec![4.1, 0.1])),
+                Arc::new(Int32Array::from(vec![None, Some(3)])),
+                Arc::new(Float64Array::from(vec![None, Some(0.1)])),
             ],
         )?;
 
-        let expr = construct_qualifier(&[
+        let syncs = &[
             DataSyncItem {
                 tx_id: Uuid::new_v4(),
                 sync_schema: sync_schema.clone(),
@@ -630,13 +630,27 @@ mod tests {
                 sync_schema,
                 batch: batch_2,
             },
-        ])?;
+        ];
+
+        let old_pk_expr = construct_qualifier(syncs, ColumnRole::OldPk)?;
+        let new_pk_expr = construct_qualifier(syncs, ColumnRole::NewPk)?;
 
         assert_eq!(
-            expr,
-            col("c1")
-                .between(lit(0), lit(6))
-                .and(col("c2").between(lit(0.1), lit(4.1))),
+            old_pk_expr,
+            Some(
+                col("c1")
+                    .between(lit(0), lit(4))
+                    .and(col("c2").between(lit(1.1), lit(3.2)))
+            ),
+        );
+
+        assert_eq!(
+            new_pk_expr,
+            Some(
+                col("c1")
+                    .between(lit(2), lit(6))
+                    .and(col("c2").between(lit(0.1), lit(2.2)))
+            ),
         );
 
         Ok(())

--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -670,10 +670,8 @@ pub mod tests {
     use std::fmt::Display;
     use std::{collections::HashMap, sync::Arc};
 
-    use rand::{rngs::mock::StepRng, Rng};
     use std::cell::RefCell;
-    use uuid::Builder;
-    thread_local!(static STEP_RNG: RefCell<StepRng> = RefCell::new(StepRng::new(1, 1)));
+    thread_local!(static UUID_SEED: RefCell<u128> = const { RefCell::new(0) });
 
     use rstest::rstest;
     use uuid::Uuid;
@@ -797,16 +795,17 @@ pub mod tests {
     const SELECT_QUERY_HASH: &str =
         "7fbbf7dddfd330d03e5e08cc5885ad8ca823e1b56e7cbadd156daa0e21c288f6";
     const V1_ETAG: &str =
-        "1230e7ce41e2f7c2050b75e36b6f313f5cc4dd99b255f2761f589d60a44eee00";
+        "37ff2380efb2e1ba86ad7204998cb7541b32196f4604c85e03cf74f6f9fd75b0";
     const V2_ETAG: &str =
-        "b17259a6a4e10c9a8b42ce23e683b919ada82b2ed1fafbbcd10ff42c63ff2443";
+        "35a334f8ea79ff5e8c79ed3c8083ec2910a9404d56b71cf853b44f979fc0b7fa";
 
     pub fn deterministic_uuid() -> Uuid {
         // A crude hack to get reproducible bytes as source for table UUID generation, to enable
         // transparent etag asserts
-        STEP_RNG.with(|rng| {
-            let bytes: [u8; 16] = rng.borrow_mut().gen();
-            Builder::from_random_bytes(bytes).into_uuid()
+        UUID_SEED.with(|uuid_seed| {
+            let mut seed = uuid_seed.borrow_mut();
+            *seed += 1;
+            Uuid::from_u128(*seed)
         })
     }
 


### PR DESCRIPTION
This removes one pathological scenario, and that is when the changeset contains very small old pks and very large new pks (or vice-versa), such that the whole range basically encompasses all partition files, so we end up re-writing everything.

In addition it fixes a bug whereby the sync base scan does both partition and row pruning, but the former is inclusive (which we want) while the later is exclusive (which we don't). The fix is to use [a new API](https://github.com/splitgraph/delta-rs/commit/98fa4cc99a7a84c482082baf942e6a29797639d0) for creating a Delta `TableProvider` based on a particular set of files, which can then be converted to `TableSource` to be used in logical planning.