### PR TITLE
Add fine-grained flush pruning

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -357,7 +357,7 @@ impl Default for DataSyncConfig {
         Self {
             max_in_memory_bytes: 3 * 1024 * 1024 * 1024,
             max_replication_lag_s: 600,
-            max_syncs_per_url: 100,
+            max_syncs_per_url: 50,
             write_lock_timeout_s: 3,
             flush_task_interval_s: 900,
         }

--- a/src/frontend/flight/sync/metrics.rs
+++ b/src/frontend/flight/sync/metrics.rs
@@ -13,6 +13,8 @@ const IN_MEMORY_OLDEST: &str =
 const SQUASH_TIME: &str = "seafowl_changeset_writer_squash_time_seconds";
 const SQUASHED_BYTES: &str = "seafowl_changeset_writer_squashed_bytes_total";
 const SQUASHED_ROWS: &str = "seafowl_changeset_writer_squashed_rows_total";
+const PRUNING_TIME: &str = "seafowl_changeset_writer_pruning_time_milliseconds";
+const PRUNING_FILES: &str = "seafowl_changeset_writer_pruning_files_total";
 const FLUSH_TIME: &str = "seafowl_changeset_writer_flush_time_seconds";
 const FLUSH_BYTES: &str = "seafowl_changeset_writer_flush_bytes_total";
 const FLUSH_ROWS: &str = "seafowl_changeset_writer_flush_rows_total";
@@ -32,6 +34,8 @@ pub struct SyncMetrics {
     pub squash_time: Histogram,
     pub squashed_bytes: Counter,
     pub squashed_rows: Counter,
+    pub pruning_time: Histogram,
+    pub pruning_files: Histogram,
     pub flush_time: Histogram,
     pub flush_bytes: Counter,
     pub flush_rows: Counter,
@@ -79,6 +83,14 @@ impl SyncMetrics {
             SQUASHED_ROWS,
             "The reduction in row count due to batch squashing"
         );
+        describe_histogram!(
+            PRUNING_TIME,
+            "The time taken to prune partition files to re-write"
+        );
+        describe_histogram!(
+            PRUNING_FILES,
+            "The file count that partition pruning identified"
+        );
         describe_histogram!(FLUSH_TIME, "The time taken to flush a collections of syncs");
         describe_counter!(FLUSH_BYTES, "The total byte size flushed");
         describe_counter!(FLUSH_ROWS, "The total row count flushed");
@@ -99,6 +111,8 @@ impl SyncMetrics {
             squash_time: histogram!(SQUASH_TIME),
             squashed_bytes: counter!(SQUASHED_BYTES),
             squashed_rows: counter!(SQUASHED_ROWS),
+            pruning_time: histogram!(PRUNING_TIME),
+            pruning_files: histogram!(PRUNING_FILES),
             flush_time: histogram!(FLUSH_TIME),
             flush_bytes: counter!(FLUSH_BYTES),
             flush_rows: counter!(FLUSH_ROWS),

--- a/src/frontend/flight/sync/writer.rs
+++ b/src/frontend/flight/sync/writer.rs
@@ -32,7 +32,9 @@ use crate::context::SeafowlContext;
 use crate::frontend::flight::handler::SYNC_COMMIT_INFO;
 use crate::frontend::flight::sync::metrics::SyncMetrics;
 use crate::frontend::flight::sync::schema::SyncSchema;
-use crate::frontend::flight::sync::utils::{construct_qualifier, squash_batches};
+use crate::frontend::flight::sync::utils::{
+    construct_qualifier, get_prune_map, squash_batches,
+};
 use crate::frontend::flight::sync::{
     Origin, SequenceNumber, SyncCommitInfo, SyncError, SyncResult,
 };
@@ -422,25 +424,12 @@ impl SeafowlDataSyncWriter {
         // that any of the entries has the full column list.
         let full_schema = TableProvider::schema(&table);
 
-        // Generate a qualifier expression for pruning partition files to include in the base scan.
-        // First construct the qualifier for old PKs; we definitely need to overwrite those in case
-        // of PK-changing UPDATEs or DELETEs. Note that this can be `None` if it's an all-INSERT
-        // syncs vec.
         let prune_start = Instant::now();
-        let old_pk_qualifier = construct_qualifier(syncs, ColumnRole::OldPk)?;
-        // Next construct the qualifier for new PKs; these are only needed for idempotence.
-        let new_pk_qualifier = construct_qualifier(syncs, ColumnRole::NewPk)?;
-        let qualifier = match (old_pk_qualifier, new_pk_qualifier) {
-            (Some(old_pk_q), Some(new_pk_q)) => old_pk_q.or(new_pk_q),
-            (Some(old_pk_q), None) => old_pk_q,
-            (None, Some(new_pk_q)) => new_pk_q,
-            _ => panic!("There can be no situation without either old or new PKs"),
-        };
-
         // Gather previous Add files that (might) need to be re-written.
-        let files = self.get_partitions(&qualifier, full_schema.clone(), &table)?;
+        let files = self.prune_partitions(syncs, full_schema.clone(), &table)?;
         info!(
-            "Partition pruning done in {} ms with qualifier {qualifier}",
+            "Partition pruning found {} files in {} ms",
+            files.len(),
             prune_start.elapsed().as_millis()
         );
         // Create removes to prune away files that are refuted by the qualifier
@@ -768,25 +757,70 @@ impl SeafowlDataSyncWriter {
         Ok(DataFrame::new(session_state, sync_plan))
     }
 
-    // Get a list of files that need to be scanned and removed based on the pruning qualifier.
-    fn get_partitions(
+    // Get a list of files that need to be scanned, re-written and removed based on the PK values in
+    // the sync items.
+    fn prune_partitions(
         &self,
-        predicate: &Expr,
+        syncs: &[DataSyncItem],
         full_schema: SchemaRef,
         table: &DeltaTable,
-    ) -> Result<Vec<Add>> {
+    ) -> SyncResult<Vec<Add>> {
+        let snapshot = table.snapshot()?;
+        let files = snapshot.file_actions()?;
+
+        // First perform coarse-grained pruning, by only looking at global min-max in the syncs.
+        // Generate a qualifier expression for old PKs; we definitely need to overwrite those in case
+        // of PK-changing UPDATEs or DELETEs. Note that this can be `None` if it's an all-INSERT
+        // syncs vec.
+        let old_pk_qualifier = construct_qualifier(syncs, ColumnRole::OldPk)?;
+        // Next construct the qualifier for new PKs; these are only needed for idempotence.
+        let new_pk_qualifier = construct_qualifier(syncs, ColumnRole::NewPk)?;
+        let qualifier = match (old_pk_qualifier, new_pk_qualifier) {
+            (Some(old_pk_q), Some(new_pk_q)) => old_pk_q.or(new_pk_q),
+            (Some(old_pk_q), None) => old_pk_q,
+            (None, Some(new_pk_q)) => new_pk_q,
+            _ => panic!("There can be no situation without either old or new PKs"),
+        };
+
         let prune_expr = create_physical_expr(
-            predicate,
+            &qualifier,
             &full_schema.clone().to_dfschema()?,
             &ExecutionProps::new(),
         )?;
         let pruning_predicate =
             PruningPredicate::try_new(prune_expr, full_schema.clone())?;
-        let snapshot = table.snapshot()?;
-        let prune_map = pruning_predicate.prune(snapshot)?;
 
-        Ok(snapshot
-            .file_actions()?
+        let mut prune_map = pruning_predicate.prune(snapshot)?;
+
+        let partition_count = prune_map.iter().filter(|p| **p).count();
+        let total_rows = files
+            .iter()
+            .zip(&prune_map)
+            .filter_map(|(add, keep)| {
+                if *keep && let Ok(Some(stats)) = add.get_stats_parsed() {
+                    Some(stats.num_records)
+                } else {
+                    None
+                }
+            })
+            .sum::<i64>();
+        debug!("Coarse-grained pruning found {partition_count} partitions with {total_rows} rows in total to re-write");
+
+        // TODO: think of a better heuristic to trigger granular pruning
+        // Try granular pruning if total row count is higher than 3M
+        if total_rows > 3_000_000 {
+            let prune_start = Instant::now();
+            let new_prune_map = get_prune_map(syncs, snapshot)?;
+            let new_partition_count = new_prune_map.iter().filter(|p| **p).count();
+            info!(
+                "Fine-grained pruning scoped out {} partitions in {} ms",
+                partition_count - new_partition_count,
+                prune_start.elapsed().as_millis()
+            );
+            prune_map = new_prune_map;
+        }
+
+        Ok(files
             .iter()
             .zip(prune_map)
             .filter_map(|(add, keep)| if keep { Some(add.clone()) } else { None })

--- a/src/frontend/flight/sync/writer.rs
+++ b/src/frontend/flight/sync/writer.rs
@@ -427,11 +427,13 @@ impl SeafowlDataSyncWriter {
         let prune_start = Instant::now();
         // Gather previous Add files that (might) need to be re-written.
         let files = self.prune_partitions(syncs, full_schema.clone(), &table)?;
+        let prune_time = prune_start.elapsed().as_millis();
         info!(
-            "Partition pruning found {} files in {} ms",
+            "Partition pruning found {} files in {prune_time} ms",
             files.len(),
-            prune_start.elapsed().as_millis()
         );
+        self.metrics.pruning_time.record(prune_time as f64);
+        self.metrics.pruning_files.record(files.len() as f64);
         // Create removes to prune away files that are refuted by the qualifier
         let removes = files
             .iter()


### PR DESCRIPTION
Also use a heuristic to trigger it if coarse-grained pruning is deemed inadequate (current criteria is coarse-grained pruning is finding more than 3M rows to re-write).

This strikes a balance between faster but more imprecise coarse-grained pruning, which is ideal for append-only replication (or UPDATE syncs with tightly grouped PKs), and slower but exact fine-grained pruning which should be good in the general case.

Also add pruning metrics.