### PR TITLE
Add concurency to the partition writing routine

### DIFF
--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -315,6 +315,7 @@ impl SeafowlContext {
                         object_store,
                         local_table_dir,
                         self.config.misc.max_partition_size,
+                        None,
                     )
                     .await?;
 
@@ -427,6 +428,7 @@ impl SeafowlContext {
                                 object_store,
                                 local_table_dir,
                                 self.config.misc.max_partition_size,
+                                None,
                             )
                             .await?;
 

--- a/src/frontend/flight/sync/writer.rs
+++ b/src/frontend/flight/sync/writer.rs
@@ -454,6 +454,10 @@ impl SeafowlDataSyncWriter {
             })
             .collect::<Vec<_>>();
 
+        // Guesstimate the number of new partition files that will be produced
+        let max_size = self.context.config.misc.max_partition_size as usize;
+        let min_file_count_hint = files.len() + (entry.rows + max_size - 1) / max_size;
+
         // Create a special Delta table provider that will only hit the above partition files
         let base_scan = Arc::new(
             DeltaTableProvider::try_new(
@@ -505,6 +509,7 @@ impl SeafowlDataSyncWriter {
             log_store.object_store(),
             local_data_dir,
             self.context.config.misc.max_partition_size,
+            Some(min_file_count_hint),
         )
         .await?;
 


### PR DESCRIPTION
This PR introduces a new modality that allows for concurrent pulling and flushing into temp files from input plan's streams, while preserving the former sequential/non-concurrent modality as well (achieved by setting `min_file_count_hint` to `None`).

The actual speedup from this is quite modest:
![image](https://github.com/user-attachments/assets/05893a5c-d0cf-410c-8144-e21c8fbb4ee8)
