### PR TITLE
Use the new public method for getting Add stats from the logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,16 +2349,16 @@ dependencies = [
 
 [[package]]
 name = "deltalake"
-version = "0.19.0"
-source = "git+https://github.com/delta-io/delta-rs?rev=d3a796709a4bc9ee8a0fdc4ea16f8c607c0daf19#d3a796709a4bc9ee8a0fdc4ea16f8c607c0daf19"
+version = "0.19.1"
+source = "git+https://github.com/delta-io/delta-rs?rev=46b38d20f4c0e79c5ff8e47bd420bc5ac2caa9e2#46b38d20f4c0e79c5ff8e47bd420bc5ac2caa9e2"
 dependencies = [
  "deltalake-core",
 ]
 
 [[package]]
 name = "deltalake-core"
-version = "0.19.0"
-source = "git+https://github.com/delta-io/delta-rs?rev=d3a796709a4bc9ee8a0fdc4ea16f8c607c0daf19#d3a796709a4bc9ee8a0fdc4ea16f8c607c0daf19"
+version = "0.19.1"
+source = "git+https://github.com/delta-io/delta-rs?rev=46b38d20f4c0e79c5ff8e47bd420bc5ac2caa9e2#46b38d20f4c0e79c5ff8e47bd420bc5ac2caa9e2"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -2382,6 +2382,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-physical-expr",
+ "datafusion-physical-plan",
  "datafusion-proto",
  "datafusion-sql",
  "delta_kernel",
@@ -2409,7 +2410,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "sqlparser 0.49.0",
+ "sqlparser 0.50.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -6279,6 +6280,15 @@ checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
 dependencies = [
  "log",
  "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e5b515a2bd5168426033e9efbfd05500114833916f1d5c268f938b4ee130ac"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ datafusion-expr = { workspace = true }
 
 datafusion-remote-tables = { path = "./datafusion_remote_tables", optional = true }
 
-deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "d3a796709a4bc9ee8a0fdc4ea16f8c607c0daf19", features = ["datafusion"] }
+deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "46b38d20f4c0e79c5ff8e47bd420bc5ac2caa9e2", features = ["datafusion"] }
 
 futures = "0.3"
 hex = ">=0.4.0"

--- a/object_store_factory/src/aws.rs
+++ b/object_store_factory/src/aws.rs
@@ -1,8 +1,8 @@
-use object_store::aws::S3ConditionalPut;
-use object_store::{
-    aws::resolve_bucket_region, aws::AmazonS3Builder, aws::AmazonS3ConfigKey, path::Path,
-    ClientConfigKey, ClientOptions, ObjectStore,
+use object_store::aws::{
+    resolve_bucket_region, AmazonS3Builder, AmazonS3ConfigKey, S3ConditionalPut,
 };
+use object_store::path::Path;
+use object_store::{ClientConfigKey, ClientOptions, ObjectStore};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;

--- a/object_store_factory/src/aws.rs
+++ b/object_store_factory/src/aws.rs
@@ -211,6 +211,10 @@ pub async fn add_amazon_s3_specific_options(
         let region = detect_region(url).await.unwrap();
         options.insert(AmazonS3ConfigKey::Region, region.to_string());
     }
+
+    options
+        .entry(AmazonS3ConfigKey::ConditionalPut)
+        .or_insert_with(|| S3ConditionalPut::ETagMatch.to_string());
 }
 
 pub fn add_amazon_s3_environment_variables(

--- a/object_store_factory/src/aws.rs
+++ b/object_store_factory/src/aws.rs
@@ -1,3 +1,4 @@
+use object_store::aws::S3ConditionalPut;
 use object_store::{
     aws::resolve_bucket_region, aws::AmazonS3Builder, aws::AmazonS3ConfigKey, path::Path,
     ClientConfigKey, ClientOptions, ObjectStore,
@@ -141,7 +142,8 @@ impl S3Config {
         let mut builder = AmazonS3Builder::new()
             .with_region(self.region.clone().unwrap_or_default())
             .with_bucket_name(self.bucket.clone())
-            .with_allow_http(self.allow_http);
+            .with_allow_http(self.allow_http)
+            .with_conditional_put(S3ConditionalPut::ETagMatch);
 
         if let Some(endpoint) = &self.endpoint {
             builder = builder.with_endpoint(endpoint.clone());

--- a/src/object_store/wrapped.rs
+++ b/src/object_store/wrapped.rs
@@ -18,9 +18,10 @@ use object_store_factory::aws::S3Config;
 use object_store_factory::google::GCSConfig;
 use object_store_factory::ObjectStoreConfig;
 
-/// Wrapper around the object_store crate that holds on to the original config
-/// in order to provide a more efficient "upload" for the local object store (since it's
-/// stored on the local filesystem, we can just move the file to it instead).
+// Wrapper around the object_store crate that holds on to the original config
+// in order to provide a more efficient "upload" for the local object store
+// (since it's stored on the local filesystem, we can just move the file to
+// it instead).
 #[derive(Debug, Clone)]
 pub struct InternalObjectStore {
     pub inner: Arc<dyn ObjectStore>,


### PR DESCRIPTION
Instead of the previous one which is empty for adds obtained via `DeltaTableState::file_actions`, use the from https://github.com/delta-io/delta-rs/pull/2822.

This allows us to trigger the fine-grained pruning routine.