### PR TITLE
Add support for TRUNCATE command

### DIFF
--- a/src/context/logical.rs
+++ b/src/context/logical.rs
@@ -2,6 +2,7 @@ use crate::catalog::DEFAULT_SCHEMA;
 use crate::context::SeafowlContext;
 use crate::datafusion::parser::{DFParser, Statement as DFStatement, CONVERT_TO_DELTA};
 use crate::datafusion::utils::build_schema;
+use crate::nodes::Truncate;
 use crate::wasm_udf::data_types::CreateFunctionDetails;
 use crate::{
     nodes::{
@@ -245,7 +246,7 @@ impl SeafowlContext {
                         })),
                     }))
                 },
-                Statement::Truncate { table_name, partitions, .. } => {
+                Statement::Truncate { table: false, table_name, partitions, .. } => {
                     let table_name = if partitions.is_none() {
                         Some(table_name.to_string())
                     } else {
@@ -263,6 +264,14 @@ impl SeafowlContext {
                         node: Arc::new(SeafowlExtensionNode::Vacuum(Vacuum {
                             database,
                             table_name,
+                            output_schema: Arc::new(DFSchema::empty())
+                        })),
+                    }))
+                }
+                Statement::Truncate { table: true, table_name, .. } => {
+                    Ok(LogicalPlan::Extension(Extension {
+                        node: Arc::new(SeafowlExtensionNode::Truncate(Truncate {
+                            table_name: table_name.to_string(),
                             output_schema: Arc::new(DFSchema::empty())
                         })),
                     }))

--- a/src/context/physical.rs
+++ b/src/context/physical.rs
@@ -4,7 +4,7 @@ use crate::context::delta::plan_to_object_store;
 use crate::context::SeafowlContext;
 use crate::nodes::{
     ConvertTable, CreateFunction, CreateTable, DropFunction, RenameTable,
-    SeafowlExtensionNode, Vacuum,
+    SeafowlExtensionNode, Truncate, Vacuum,
 };
 use crate::object_store::factory::build_object_store;
 use crate::object_store::http::try_prepare_http_url;
@@ -649,6 +649,42 @@ impl SeafowlContext {
                                     &resolved_new_ref.table,
                                 )
                                 .await?;
+                            Ok(make_dummy_exec())
+                        }
+                        SeafowlExtensionNode::Truncate(Truncate {
+                            table_name, ..
+                        }) => {
+                            let mut table =
+                                self.try_get_delta_table(table_name.clone()).await?;
+                            table.load().await?;
+                            let snapshot = table.snapshot()?;
+                            let removes = snapshot.file_actions()?;
+                            let deletion_timestamp = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap()
+                                .as_millis()
+                                as i64;
+                            let actions: Vec<Action> = removes
+                                .into_iter()
+                                .map(|remove| {
+                                    Action::Remove(Remove {
+                                        path: remove.path,
+                                        deletion_timestamp: Some(deletion_timestamp),
+                                        data_change: true,
+                                        extended_file_metadata: Some(true),
+                                        partition_values: Some(remove.partition_values),
+                                        size: Some(remove.size),
+                                        tags: None,
+                                        deletion_vector: None,
+                                        base_row_id: None,
+                                        default_row_commit_version: None,
+                                    })
+                                })
+                                .collect();
+
+                            let op = DeltaOperation::Delete { predicate: None };
+                            self.commit(actions, &table, op).await?;
+
                             Ok(make_dummy_exec())
                         }
                         SeafowlExtensionNode::Vacuum(Vacuum {

--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -159,6 +159,10 @@ impl<'a> DFParser<'a> {
                         self.parser.next_token();
                         self.parse_vacuum()
                     }
+                    Keyword::TRUNCATE => {
+                        self.parser.next_token();
+                        self.parse_truncate()
+                    }
                     _ => {
                         // use the native parser
                         Ok(Statement::Statement(Box::from(
@@ -216,6 +220,20 @@ impl<'a> DFParser<'a> {
             table_name,
             partitions,
             table: false,
+        })))
+    }
+
+    pub fn parse_truncate(&mut self) -> Result<Statement, ParserError> {
+        let table_name: ObjectName = if self.parser.parse_keyword(Keyword::TABLE) {
+            self.parser.parse_object_name(true)?
+        } else {
+            return self.expected("TABLE as a TRUNCATE target", self.parser.peek_token());
+        };
+
+        Ok(Statement::Statement(Box::new(SQLStatement::Truncate {
+            table_name,
+            partitions: None,
+            table: true,
         })))
     }
 

--- a/src/datafusion/parser.rs
+++ b/src/datafusion/parser.rs
@@ -224,11 +224,11 @@ impl<'a> DFParser<'a> {
     }
 
     pub fn parse_truncate(&mut self) -> Result<Statement, ParserError> {
-        let table_name: ObjectName = if self.parser.parse_keyword(Keyword::TABLE) {
-            self.parser.parse_object_name(true)?
-        } else {
+        if !self.parser.parse_keyword(Keyword::TABLE) {
             return self.expected("TABLE as a TRUNCATE target", self.parser.peek_token());
-        };
+        }
+
+        let table_name = self.parser.parse_object_name(true)?;
 
         Ok(Statement::Statement(Box::new(SQLStatement::Truncate {
             table_name,

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -69,6 +69,14 @@ pub struct Vacuum {
     pub output_schema: DFSchemaRef,
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct Truncate {
+    /// If the vacuum target are not the partitions or the db, denotes which table it applies to
+    pub table_name: String,
+    /// Dummy result schema for the plan (empty)
+    pub output_schema: DFSchemaRef,
+}
+
 #[derive(AsRefStr, Debug, Clone, Hash, PartialEq, Eq)]
 pub enum SeafowlExtensionNode {
     ConvertTable(ConvertTable),
@@ -76,6 +84,7 @@ pub enum SeafowlExtensionNode {
     CreateFunction(CreateFunction),
     DropFunction(DropFunction),
     RenameTable(RenameTable),
+    Truncate(Truncate),
     Vacuum(Vacuum),
 }
 
@@ -120,6 +129,9 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
             SeafowlExtensionNode::RenameTable(RenameTable { output_schema, .. }) => {
                 output_schema
             }
+            SeafowlExtensionNode::Truncate(Truncate { output_schema, .. }) => {
+                output_schema
+            }
             SeafowlExtensionNode::Vacuum(Vacuum { output_schema, .. }) => output_schema,
         }
     }
@@ -152,6 +164,9 @@ impl UserDefinedLogicalNode for SeafowlExtensionNode {
                 old_name, new_name, ..
             }) => {
                 write!(f, "RenameTable: {} to {}", old_name, new_name)
+            }
+            SeafowlExtensionNode::Truncate(Truncate { table_name, .. }) => {
+                write!(f, "Truncate: {table_name}")
             }
             SeafowlExtensionNode::Vacuum(Vacuum { database, .. }) => {
                 write!(

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -71,7 +71,6 @@ pub struct Vacuum {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Truncate {
-    /// If the vacuum target are not the partitions or the db, denotes which table it applies to
     pub table_name: String,
     /// Dummy result schema for the plan (empty)
     pub output_schema: DFSchemaRef,

--- a/tests/statements/mod.rs
+++ b/tests/statements/mod.rs
@@ -44,6 +44,7 @@ mod convert;
 #[path = "../../src/testutils.rs"]
 mod testutils;
 mod time_travel;
+mod truncate;
 mod vacuum;
 
 enum ObjectStoreType {

--- a/tests/statements/truncate.rs
+++ b/tests/statements/truncate.rs
@@ -25,8 +25,7 @@ async fn test_truncate_table() -> Result<()> {
     // Check that table_1 no longer contains data
     let plan = context.plan_query("SELECT * FROM table_1").await.unwrap();
     let results = context.collect(plan).await.unwrap();
-    let expected = ["++", "++"];
-    assert_batches_eq!(expected, &results);
+    assert!(results.is_empty());
 
     Ok(())
 }

--- a/tests/statements/truncate.rs
+++ b/tests/statements/truncate.rs
@@ -1,0 +1,34 @@
+use crate::statements::*;
+
+#[tokio::test]
+async fn test_truncate_table() -> Result<()> {
+    let (context, _) = make_context_with_pg(ObjectStoreType::Local).await;
+
+    // Create table_1 and make tombstone by replacing the first file
+    create_table_and_insert(&context, "table_1").await;
+
+    // Check that table contains data
+    let plan = context.plan_query("SELECT * FROM table_1").await.unwrap();
+    let results = context.collect(plan).await.unwrap();
+    let expected = [
+        "+---------------------+------------+------------------+-----------------+----------------+",
+        "| some_time           | some_value | some_other_value | some_bool_value | some_int_value |",
+        "+---------------------+------------+------------------+-----------------+----------------+",
+        "| 2022-01-01T20:01:01 | 42.0       | 1.0000000000     |                 | 1111           |",
+        "| 2022-01-01T20:02:02 | 43.0       | 1.0000000000     |                 | 2222           |",
+        "| 2022-01-01T20:03:03 | 44.0       | 1.0000000000     |                 | 3333           |",
+        "+---------------------+------------+------------------+-----------------+----------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    // Execute TRUNCATE command
+    context.plan_query("TRUNCATE TABLE table_1").await.unwrap();
+
+    // Check that data was truncated
+    let plan = context.plan_query("SELECT * FROM table_1").await.unwrap();
+    let results = context.collect(plan).await.unwrap();
+    let expected = ["++", "++"];
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
+}

--- a/tests/statements/truncate.rs
+++ b/tests/statements/truncate.rs
@@ -4,10 +4,8 @@ use crate::statements::*;
 async fn test_truncate_table() -> Result<()> {
     let (context, _) = make_context_with_pg(ObjectStoreType::Local).await;
 
-    // Create table_1 and make tombstone by replacing the first file
+    // Create table_1 and check that it contains data
     create_table_and_insert(&context, "table_1").await;
-
-    // Check that table contains data
     let plan = context.plan_query("SELECT * FROM table_1").await.unwrap();
     let results = context.collect(plan).await.unwrap();
     let expected = [
@@ -24,7 +22,7 @@ async fn test_truncate_table() -> Result<()> {
     // Execute TRUNCATE command
     context.plan_query("TRUNCATE TABLE table_1").await.unwrap();
 
-    // Check that data was truncated
+    // Check that table_1 no longer contains data
     let plan = context.plan_query("SELECT * FROM table_1").await.unwrap();
     let results = context.collect(plan).await.unwrap();
     let expected = ["++", "++"];


### PR DESCRIPTION
## What
- Add support for `TRUNCATE TABLE x`
- This is equivalent to `DELETE FROM x`, but it also works with inline metastore

## How
- Skip updating `table_versions` to ensure it works with inline metastore