### PR TITLE
Logical inter-sync squashing

### DIFF
--- a/clade/build.rs
+++ b/clade/build.rs
@@ -7,6 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .file_descriptor_set_path(out_dir.join("clade_descriptor.bin"))
         .build_server(true)
         .build_client(true)
+        .type_attribute("clade.sync.ColumnDescriptor", "#[derive(Eq, Hash)]")
         .compile(&["proto/schema.proto", "proto/sync.proto"], &["proto"])?;
 
     Ok(())

--- a/src/frontend/flight/sync/schema.rs
+++ b/src/frontend/flight/sync/schema.rs
@@ -39,11 +39,6 @@ impl SyncSchema {
                             "Field for column with `Changed` role must be of type boolean: {}",
                             field.name()
                         )
-                    } else if field.is_nullable() {
-                        format!(
-                            "Field for column with `Changed` role can not be nullable: {}",
-                            field.name()
-                        )
                     } else if !column_descriptors.iter().any(|other_cd| {
                         col_desc.name == other_cd.name
                             && other_cd.role == ColumnRole::Value as i32
@@ -146,5 +141,17 @@ impl SyncColumn {
     // Get the field from the arrow schema
     pub fn field(&self) -> &FieldRef {
         &self.field
+    }
+
+    // Returns a canonical `SyncColumn` field (logical) name, used to name columns in a projection
+    pub fn canonical_field_name(column_descriptor: &ColumnDescriptor) -> String {
+        format!(
+            "{}_{}",
+            ColumnRole::try_from(column_descriptor.role)
+                .unwrap()
+                .as_str_name()
+                .to_lowercase(),
+            column_descriptor.name
+        )
     }
 }

--- a/src/frontend/flight/sync/schema.rs
+++ b/src/frontend/flight/sync/schema.rs
@@ -154,4 +154,12 @@ impl SyncColumn {
             column_descriptor.name
         )
     }
+
+    // Returns a corresponding `ColumnDescriptor` for this column
+    pub fn column_descriptor(&self) -> ColumnDescriptor {
+        ColumnDescriptor {
+            role: self.role as _,
+            name: self.name.clone(),
+        }
+    }
 }

--- a/src/frontend/flight/sync/utils.rs
+++ b/src/frontend/flight/sync/utils.rs
@@ -448,10 +448,7 @@ pub(super) fn merge_schemas(
 
     // Now project any missing sync columns from the upper schema
     for upper_sync_col in upper_schema.columns() {
-        let cd = ColumnDescriptor {
-            role: upper_sync_col.role() as _,
-            name: upper_sync_col.name().clone(),
-        };
+        let cd = upper_sync_col.column_descriptor();
 
         if col_desc.contains(&cd) {
             // We've already projected this column from the lower schema

--- a/src/frontend/flight/sync/writer.rs
+++ b/src/frontend/flight/sync/writer.rs
@@ -706,19 +706,18 @@ impl SeafowlDataSyncWriter {
             .unzip();
 
         // TODO merge syncs using a union if schemas match
-        let merged_sync = upper_df.with_column(UPPER_SYNC, lit(true))?.join(
-            lower_df.with_column(LOWER_SYNC, lit(true))?,
+   let merged_sync = {
+        let upper_df = upper_df.with_column(UPPER_SYNC, lit(true))?;
+        let lower_df = lower_df.with_column(LOWER_SYNC, lit(true))?;
+        
+        upper_df.join(
+            lower_df,
             JoinType::Full,
-            &upper_join_cols
-                .iter()
-                .map(|pk| pk.as_str())
-                .collect::<Vec<_>>(),
-            &lower_join_cols
-                .iter()
-                .map(|pk| pk.as_str())
-                .collect::<Vec<_>>(),
+            &upper_join_cols.iter().map(String::as_str).collect::<Vec<_>>(),
+            &lower_join_cols.iter().map(String::as_str).collect::<Vec<_>>(),
             None,
-        )?;
+        )?
+    };
 
         // Build the merged projection and column descriptors
         let (col_desc, projection) = merge_schemas(lower_schema, upper_schema)?;

--- a/tests/flight/sync_fail.rs
+++ b/tests/flight/sync_fail.rs
@@ -58,41 +58,5 @@ async fn test_sync_errors() -> std::result::Result<(), Box<dyn std::error::Error
         r#"status: InvalidArgument, message: "Invalid sync schema: Change requested but batches do not contain old/new PK columns"#
     ).await;
 
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("old_c1", DataType::Int32, true),
-        Field::new("new_c1", DataType::Int32, true),
-        Field::new("changed_c2", DataType::Boolean, true),
-    ]));
-    cmd.column_descriptors = vec![
-        ColumnDescriptor {
-            role: ColumnRole::OldPk as i32,
-            name: "c1".to_string(),
-        },
-        ColumnDescriptor {
-            role: ColumnRole::NewPk as i32,
-            name: "c1".to_string(),
-        },
-        ColumnDescriptor {
-            role: ColumnRole::Changed as i32,
-            name: "c2".to_string(),
-        },
-    ];
-    let batch = RecordBatch::try_new(
-        schema.clone(),
-        vec![
-            Arc::new(Int32Array::from(vec![1, 2])),
-            Arc::new(Int32Array::from(vec![2, 1])),
-            Arc::new(BooleanArray::from(vec![true, false])),
-        ],
-    )?;
-
-    // Missing upsert/delete column
-    assert_sync_error(
-        cmd.clone(),
-        batch.clone(),
-        &mut client,
-        r#"status: InvalidArgument, message: "Invalid sync schema: Field for column with `Changed` role can not be nullable: changed_c2""#
-    ).await;
-
     Ok(())
 }


### PR DESCRIPTION
# What
Implement logical inter-sync squashing during flushing in the `SeafowlDataSyncWriter`, such that the resulting stream is the equivalent combined/total sync batch to be applied to the base scan.

# How
Instead of starting of with a base scan of parquet files to re-write, and applying each sync batch iteratively on top of it, flip it around and first do logical squashing of sync batches and only then do a single join with the base scan.

# Why
- This greatly improves the efficiency of the plan execution and therefore writes at the expense of code complexity. 
- The perf improvement is especially pronounced in case of UPDATEs that touch many partition files, since we avoid doing K joins for N base rows when applying each sync. 
- Instead we have only 1 join with N base rows, whereas the sync joins grow in size linearly (up to `max_syncs_per_url` * `SEAFOWL_SYNC_CALL_MAX_ROWS` ~= 3 M rows by deafult).
- This will also be useful when we transition from CoW to MoR, since we'll need sync-squashing to be able to dump the super-sync batch to Delta Lake (and which the optimizer/compactor can then unravel into proper Adds)

# Tests
Present ones are passing, but needs new ones too