### PR TITLE
Add no_hardlinks option to LocalConfig and fix error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-on:
-  push:
+on: [push, pull_request]
 
 jobs:
   CI:

--- a/object_store_factory/src/local.rs
+++ b/object_store_factory/src/local.rs
@@ -19,20 +19,26 @@ impl LocalConfig {
         map: &HashMap<String, String>,
     ) -> Result<Self, object_store::Error> {
         Ok(Self {
-          data_dir: map.get("data_dir")
-          .ok_or_else(|| object_store::Error::Generic {
-              store: "local",
-              source: "Missing data_dir".into(),
-          })?
-          .clone(),
-            disable_hardlinks: map.get("disable_hardlinks").map(|s| s == "true").unwrap_or(false),
+            data_dir: map
+                .get("data_dir")
+                .ok_or_else(|| object_store::Error::Generic {
+                    store: "local",
+                    source: "Missing data_dir".into(),
+                })?
+                .clone(),
+            disable_hardlinks: map
+                .get("disable_hardlinks")
+                .map(|s| s == "true")
+                .unwrap_or(false),
         })
     }
 
     pub fn to_hashmap(&self) -> HashMap<String, String> {
         let mut map = HashMap::new();
         map.insert("data_dir".to_string(), self.data_dir.clone());
-        map.insert("disable_hardlinks".to_string(), self.disable_hardlinks.to_string());
+        map.insert(
+            "disable_hardlinks".to_string(), 
+            self.disable_hardlinks.to_string());
         map
     }
 
@@ -57,7 +63,7 @@ mod tests {
         let config = LocalConfig::from_hashmap(&map)
             .expect("Failed to create config from hashmap");
         assert_eq!(config.data_dir, "/tmp/data".to_string());
-        assert_eq!(config.disable_hardlinks, false); // Default value
+        assert!(!config.disable_hardlinks); // Default value
     }
 
     #[test]
@@ -69,7 +75,7 @@ mod tests {
         let config = LocalConfig::from_hashmap(&map)
             .expect("Failed to create config from hashmap");
         assert_eq!(config.data_dir, "/tmp/data".to_string());
-        assert_eq!(config.disable_hardlinks, true);
+        assert!(config.disable_hardlinks);
     }
 
     #[test]
@@ -81,7 +87,7 @@ mod tests {
         let config = LocalConfig::from_hashmap(&map)
             .expect("Failed to create config from hashmap");
         assert_eq!(config.data_dir, "/tmp/data".to_string());
-        assert_eq!(config.disable_hardlinks, false);
+        assert!(!config.disable_hardlinks);
     }
 
     #[test]
@@ -133,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_default_false() {
-        assert_eq!(default_false(), false);
+        assert!(!default_false());
     }
 
     #[test]
@@ -146,7 +152,7 @@ mod tests {
 
         let config: LocalConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.data_dir, "/tmp/data");
-        assert_eq!(config.disable_hardlinks, false);
+        assert!(!config.disable_hardlinks);
     }
 
     #[test]
@@ -160,6 +166,6 @@ mod tests {
 
         let config: LocalConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.data_dir, "/tmp/data");
-        assert_eq!(config.disable_hardlinks, true);
+        assert!(config.disable_hardlinks);
     }
 }

--- a/object_store_factory/src/local.rs
+++ b/object_store_factory/src/local.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 pub struct LocalConfig {
     pub data_dir: String,
     #[serde(default = "default_false")]
-    pub no_hardlinks: bool,
+    pub disable_hardlinks: bool,
 }
 
 fn default_false() -> bool {
@@ -25,14 +25,14 @@ impl LocalConfig {
               source: "Missing data_dir".into(),
           })?
           .clone(),
-            no_hardlinks: map.get("no_hardlinks").map(|s| s == "true").unwrap_or(false),
+            disable_hardlinks: map.get("disable_hardlinks").map(|s| s == "true").unwrap_or(false),
         })
     }
 
     pub fn to_hashmap(&self) -> HashMap<String, String> {
         let mut map = HashMap::new();
         map.insert("data_dir".to_string(), self.data_dir.clone());
-        map.insert("no_hardlinks".to_string(), self.no_hardlinks.to_string());
+        map.insert("disable_hardlinks".to_string(), self.disable_hardlinks.to_string());
         map
     }
 
@@ -57,31 +57,31 @@ mod tests {
         let config = LocalConfig::from_hashmap(&map)
             .expect("Failed to create config from hashmap");
         assert_eq!(config.data_dir, "/tmp/data".to_string());
-        assert_eq!(config.no_hardlinks, false); // Default value
+        assert_eq!(config.disable_hardlinks, false); // Default value
     }
 
     #[test]
-    fn test_config_from_hashmap_with_no_hardlinks() {
+    fn test_config_from_hashmap_with_disable_hardlinks() {
         let mut map = HashMap::new();
         map.insert("data_dir".to_string(), "/tmp/data".to_string());
-        map.insert("no_hardlinks".to_string(), "true".to_string());
+        map.insert("disable_hardlinks".to_string(), "true".to_string());
 
         let config = LocalConfig::from_hashmap(&map)
             .expect("Failed to create config from hashmap");
         assert_eq!(config.data_dir, "/tmp/data".to_string());
-        assert_eq!(config.no_hardlinks, true);
+        assert_eq!(config.disable_hardlinks, true);
     }
 
     #[test]
-    fn test_config_from_hashmap_with_no_hardlinks_false() {
+    fn test_config_from_hashmap_with_disable_hardlinks_false() {
         let mut map = HashMap::new();
         map.insert("data_dir".to_string(), "/tmp/data".to_string());
-        map.insert("no_hardlinks".to_string(), "false".to_string());
+        map.insert("disable_hardlinks".to_string(), "false".to_string());
 
         let config = LocalConfig::from_hashmap(&map)
             .expect("Failed to create config from hashmap");
         assert_eq!(config.data_dir, "/tmp/data".to_string());
-        assert_eq!(config.no_hardlinks, false);
+        assert_eq!(config.disable_hardlinks, false);
     }
 
     #[test]
@@ -102,7 +102,7 @@ mod tests {
 
         let result = LocalConfig {
             data_dir: data_dir.to_string(),
-            no_hardlinks: false,
+            disable_hardlinks: false,
         }
         .build_local_storage();
         assert!(result.is_ok(), "Expected Ok, got Err: {:?}", result);
@@ -112,7 +112,7 @@ mod tests {
     fn test_build_local_storage_with_invalid_path() {
         let result = LocalConfig {
             data_dir: "".to_string(),
-            no_hardlinks: false,
+            disable_hardlinks: false,
         }
         .build_local_storage();
         assert!(result.is_err(), "Expected Err due to invalid path, got Ok");
@@ -122,13 +122,13 @@ mod tests {
     fn test_to_hashmap() {
         let local_config = LocalConfig {
             data_dir: "path/to/data".to_string(),
-            no_hardlinks: true,
+            disable_hardlinks: true,
         };
 
         let hashmap = local_config.to_hashmap();
 
         assert_eq!(hashmap.get("data_dir"), Some(&"path/to/data".to_string()));
-        assert_eq!(hashmap.get("no_hardlinks"), Some(&"true".to_string()));
+        assert_eq!(hashmap.get("disable_hardlinks"), Some(&"true".to_string()));
     }
 
     #[test]
@@ -146,20 +146,20 @@ mod tests {
 
         let config: LocalConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.data_dir, "/tmp/data");
-        assert_eq!(config.no_hardlinks, false);
+        assert_eq!(config.disable_hardlinks, false);
     }
 
     #[test]
-    fn test_deserialize_with_no_hardlinks() {
+    fn test_deserialize_with_disable_hardlinks() {
         let json = r#"
         {
             "data_dir": "/tmp/data",
-            "no_hardlinks": true
+            "disable_hardlinks": true
         }
         "#;
 
         let config: LocalConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.data_dir, "/tmp/data");
-        assert_eq!(config.no_hardlinks, true);
+        assert_eq!(config.disable_hardlinks, true);
     }
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -637,6 +637,7 @@ cache_control = "private, max-age=86400"
             SeafowlConfig {
                 object_store: Some(ObjectStoreConfig::Local(LocalConfig {
                     data_dir: "./seafowl-data".to_string(),
+                    no_hardlinks: false,
                 })),
                 catalog: Some(Catalog::Postgres(Postgres {
                     dsn: "postgresql://user:pass@localhost:5432/somedb".to_string(),
@@ -732,6 +733,7 @@ cache_control = "private, max-age=86400"
             SeafowlConfig {
                 object_store: Some(ObjectStoreConfig::Local(LocalConfig {
                     data_dir: "some_other_path".to_string(),
+                    no_hardlinks: false,
                 })),
                 catalog: Some(Catalog::Sqlite(Sqlite {
                     dsn: "sqlite://file.sqlite".to_string(),

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -637,7 +637,7 @@ cache_control = "private, max-age=86400"
             SeafowlConfig {
                 object_store: Some(ObjectStoreConfig::Local(LocalConfig {
                     data_dir: "./seafowl-data".to_string(),
-                    no_hardlinks: false,
+                    disable_hardlinks: false,
                 })),
                 catalog: Some(Catalog::Postgres(Postgres {
                     dsn: "postgresql://user:pass@localhost:5432/somedb".to_string(),
@@ -733,7 +733,7 @@ cache_control = "private, max-age=86400"
             SeafowlConfig {
                 object_store: Some(ObjectStoreConfig::Local(LocalConfig {
                     data_dir: "some_other_path".to_string(),
-                    no_hardlinks: false,
+                    disable_hardlinks: false,
                 })),
                 catalog: Some(Catalog::Sqlite(Sqlite {
                     dsn: "sqlite://file.sqlite".to_string(),

--- a/src/context/delta.rs
+++ b/src/context/delta.rs
@@ -528,7 +528,7 @@ mod tests {
                     Arc::new(LocalFileSystem::new_with_prefix(tmp_dir.path()).unwrap()),
                     ObjectStoreConfig::Local(LocalConfig {
                         data_dir: tmp_dir.path().to_string_lossy().to_string(),
-                        no_hardlinks: false,
+                        disable_hardlinks: false,
                     }),
                 ),
                 Some(tmp_dir),

--- a/src/context/delta.rs
+++ b/src/context/delta.rs
@@ -528,6 +528,7 @@ mod tests {
                     Arc::new(LocalFileSystem::new_with_prefix(tmp_dir.path()).unwrap()),
                     ObjectStoreConfig::Local(LocalConfig {
                         data_dir: tmp_dir.path().to_string_lossy().to_string(),
+                        no_hardlinks: false,
                     }),
                 ),
                 Some(tmp_dir),

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use seafowl::{
 
 use tokio::time::{interval, Duration};
 use tracing::level_filters::LevelFilter;
-use tracing::{error, info, debug, subscriber, warn};
+use tracing::{debug, error, info, subscriber, warn};
 use tracing_log::LogTracer;
 use tracing_subscriber::filter::EnvFilter;
 

--- a/src/object_store/wrapped.rs
+++ b/src/object_store/wrapped.rs
@@ -16,8 +16,8 @@ use url::Url;
 
 use object_store_factory::aws::S3Config;
 use object_store_factory::google::GCSConfig;
-use object_store_factory::ObjectStoreConfig;
 use object_store_factory::local::LocalConfig;
+use object_store_factory::ObjectStoreConfig;
 
 // Wrapper around the object_store crate that holds on to the original config
 // in order to provide a more efficient "upload" for the local object store
@@ -152,8 +152,21 @@ impl ObjectStore for InternalObjectStore {
         payload: PutPayload,
         opts: PutOptions,
     ) -> Result<PutResult> {
-        if let  ObjectStoreConfig::Local(LocalConfig { disable_hardlinks: true, .. }) = self.config {
-          return self.inner.put_opts(location, payload, PutOptions{mode: object_store::PutMode::Overwrite, ..opts}).await
+        if let ObjectStoreConfig::Local(LocalConfig { 
+            disable_hardlinks: true, 
+            .. 
+        }) = self.config 
+        {
+          return self
+              .inner
+              .put_opts(
+                  location, 
+                  payload, 
+                  PutOptions{
+                      mode: object_store::PutMode::Overwrite, 
+                      ..opts
+                  },
+              ).await;
         };
         self.inner.put_opts(location, payload, opts).await
     }
@@ -243,7 +256,11 @@ impl ObjectStore for InternalObjectStore {
     ///
     /// Will return an error if the destination already has an object.
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        if let  ObjectStoreConfig::Local(LocalConfig { disable_hardlinks: true, .. }) = self.config {
+        if let ObjectStoreConfig::Local(LocalConfig { 
+            disable_hardlinks: true, 
+            .. 
+        }) = self.config 
+        {
             return self.inner.copy(from, to).await;
         }
         self.inner.copy_if_not_exists(from, to).await
@@ -261,7 +278,11 @@ impl ObjectStore for InternalObjectStore {
             // this with a lock too, so look into using that down the line instead.
             return self.inner.rename(from, to).await;
         }
-        if let ObjectStoreConfig::Local(LocalConfig { disable_hardlinks: true, .. }) = self.config {
+        if let ObjectStoreConfig::Local(LocalConfig { 
+            disable_hardlinks: true, 
+            .. 
+        }) = self.config 
+        {
             return self.inner.rename(from, to).await;
         }
         self.inner.rename_if_not_exists(from, to).await

--- a/src/object_store/wrapped.rs
+++ b/src/object_store/wrapped.rs
@@ -240,7 +240,7 @@ impl ObjectStore for InternalObjectStore {
     ///
     /// Will return an error if the destination already has an object.
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-      if let  ObjectStoreConfig::Local(LocalConfig { no_hardlinks: true, .. }) = self.config {
+      if let  ObjectStoreConfig::Local(LocalConfig { disable_hardlinks: true, .. }) = self.config {
         return self.inner.copy(from, to).await;
       }
         self.inner.copy_if_not_exists(from, to).await
@@ -258,7 +258,7 @@ impl ObjectStore for InternalObjectStore {
             // this with a lock too, so look into using that down the line instead.
             return self.inner.rename(from, to).await;
         }
-        if let ObjectStoreConfig::Local(LocalConfig { no_hardlinks: true, .. }) = self.config {
+        if let ObjectStoreConfig::Local(LocalConfig { disable_hardlinks: true, .. }) = self.config {
             return self.inner.rename(from, to).await;
         }
         self.inner.rename_if_not_exists(from, to).await


### PR DESCRIPTION
## What
Add `no_hardlinks` option to `LocalConfig` for object store operations. Try to resolve [this issue](https://github.com/splitgraph/seafowl/issues/641).

## How
- Added `no_hardlinks` boolean field to `LocalConfig` struct
- Updated `from_hashmap` and `to_hashmap` methods to handle the new field
- Modified `copy_if_not_exists` and `rename_if_not_exists` methods in `InternalObjectStore` to use `no_hardlinks` option
- Added necessary imports in relevant files

## Why
- This change allows users to disable hardlink creation in local object store operations
- Improves flexibility for systems where hardlinks are not supported or desired
- Enables more efficient file operations in certain scenarios, potentially improving performance
- Addresses compatibility issues with network drives and certain CSI (Container Storage Interface) implementations
  - Some network drives and CSI providers (e.g., Azure Blob CSI) do not support hardlinks
  - This option ensures smooth operation in environments where hardlink creation is not possible or not allowed

## Tests
- Added new unit tests to verify the behavior of `no_hardlinks` option
- Updated existing tests to cover the new functionality
- All existing tests are passing with the new changes