### PR TITLE
Index sync columns

### DIFF
--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -20,12 +20,10 @@ use tracing::{debug, error, info};
 use url::Url;
 
 use crate::context::SeafowlContext;
-use crate::frontend::flight::sync::schema::SyncSchema;
-use crate::frontend::flight::sync::writer::SeafowlDataSyncWriter;
-use crate::frontend::flight::sync::SyncResult;
+use crate::sync::schema::SyncSchema;
+use crate::sync::writer::SeafowlDataSyncWriter;
+use crate::sync::SyncResult;
 
-pub const SYNC_COMMIT_INFO: &str = "sync_commit_info";
-// Denoted the last sequence number that was fully committed
 pub const SEAFOWL_SYNC_CALL_MAX_ROWS: usize = 65536;
 
 lazy_static! {

--- a/src/frontend/flight/mod.rs
+++ b/src/frontend/flight/mod.rs
@@ -17,6 +17,8 @@ use crate::sync::flush_task;
 use crate::sync::writer::SeafowlDataSyncWriter;
 use tonic::transport::Server;
 
+const MAX_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
+
 pub async fn run_flight_server(
     context: Arc<SeafowlContext>,
     config: FlightFrontend,
@@ -35,7 +37,7 @@ pub async fn run_flight_server(
     tokio::spawn(flush_task(flush_interval, lock_timeout, sync_writer));
 
     let svc =
-        FlightServiceServer::new(handler).max_decoding_message_size(16 * 1024 * 1024);
+        FlightServiceServer::new(handler).max_decoding_message_size(MAX_MESSAGE_SIZE);
 
     let server = Server::builder();
     let mut server = server.layer(MetricsLayer {});

--- a/src/frontend/flight/mod.rs
+++ b/src/frontend/flight/mod.rs
@@ -1,8 +1,6 @@
 mod handler;
 mod metrics;
 mod sql;
-mod sync;
-
 use crate::config::schema::FlightFrontend;
 use crate::context::SeafowlContext;
 use crate::frontend::flight::handler::SeafowlFlightHandler;
@@ -15,8 +13,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
-use crate::frontend::flight::sync::flush_task;
-use crate::frontend::flight::sync::writer::SeafowlDataSyncWriter;
+use crate::sync::flush_task;
+use crate::sync::writer::SeafowlDataSyncWriter;
 use tonic::transport::Server;
 
 pub async fn run_flight_server(

--- a/src/frontend/flight/sql.rs
+++ b/src/frontend/flight/sql.rs
@@ -2,8 +2,8 @@ use crate::catalog::memory::MemoryStore;
 use crate::frontend::flight::handler::{
     SeafowlFlightHandler, SEAFOWL_SQL_DATA, SEAFOWL_SYNC_CALL_MAX_ROWS,
 };
-use crate::frontend::flight::sync::schema::SyncSchema;
-use crate::frontend::flight::sync::SyncError;
+use crate::sync::schema::SyncSchema;
+use crate::sync::SyncError;
 use arrow::record_batch::RecordBatch;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::encode::FlightDataEncoderBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod nodes;
 pub mod object_store;
 pub mod provider;
 pub mod repository;
+pub mod sync;
 pub mod system_tables;
 pub mod utils;
 pub mod version;

--- a/src/sync/metrics.rs
+++ b/src/sync/metrics.rs
@@ -1,4 +1,4 @@
-use crate::frontend::flight::sync::{Origin, SequenceNumber};
+use crate::sync::{Origin, SequenceNumber};
 use metrics::{
     counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram,
     Counter, Gauge, Histogram,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,4 +1,4 @@
-use crate::frontend::flight::sync::writer::SeafowlDataSyncWriter;
+use crate::sync::writer::SeafowlDataSyncWriter;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/sync/schema.rs
+++ b/src/sync/schema.rs
@@ -1,4 +1,4 @@
-use crate::frontend::flight::sync::SyncError;
+use crate::sync::SyncError;
 use arrow_schema::{DataType, FieldRef, SchemaRef};
 use clade::sync::{ColumnDescriptor, ColumnRole};
 use std::collections::HashSet;

--- a/src/sync/schema.rs
+++ b/src/sync/schema.rs
@@ -1,11 +1,13 @@
 use crate::sync::SyncError;
 use arrow_schema::{DataType, FieldRef, SchemaRef};
 use clade::sync::{ColumnDescriptor, ColumnRole};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SyncSchema {
     columns: Vec<SyncColumn>,
+    indices: HashMap<ColumnRole, HashMap<Arc<str>, usize>>,
 }
 
 impl SyncSchema {
@@ -75,27 +77,45 @@ impl SyncSchema {
             });
         }
 
+        let mut indices = HashMap::new();
         let columns = column_descriptors
-            .iter()
+            .into_iter()
             .zip(schema.fields())
-            .map(|(column_descriptor, field)| SyncColumn {
-                role: column_descriptor.role(),
-                name: column_descriptor.name.clone(),
-                field: field.clone(),
+            .enumerate()
+            .map(|(idx, (column_descriptor, field))| {
+                let role = column_descriptor.role();
+                let name: Arc<str> = Arc::from(column_descriptor.name.as_str());
+
+                let sync_column = SyncColumn {
+                    role,
+                    name: name.clone(),
+                    field: field.clone(),
+                };
+
+                indices
+                    .entry(role)
+                    .or_insert(HashMap::new())
+                    .insert(name.clone(), idx);
+
+                sync_column
             })
             .collect();
 
-        Ok(Self { columns })
+        Ok(Self { columns, indices })
     }
 
     pub fn empty() -> Self {
-        SyncSchema { columns: vec![] }
+        SyncSchema {
+            columns: vec![],
+            indices: Default::default(),
+        }
     }
 
     pub fn column(&self, name: &str, role: ColumnRole) -> Option<&SyncColumn> {
-        self.columns()
-            .iter()
-            .find(|col| col.name == name && col.role == role)
+        self.indices
+            .get(&role)
+            .and_then(|cols| cols.get(name))
+            .map(|idx| &self.columns[*idx])
     }
 
     pub fn columns(&self) -> &[SyncColumn] {
@@ -106,20 +126,24 @@ impl SyncSchema {
     pub fn map_columns<F, T>(&self, role: ColumnRole, f: F) -> Vec<T>
     where
         Self: Sized,
-        F: FnMut(&SyncColumn) -> T,
+        F: Fn(&SyncColumn) -> T,
     {
-        self.columns
-            .iter()
-            .filter(|sc| sc.role == role)
-            .map(f)
-            .collect::<Vec<T>>()
+        self.indices
+            .get(&role)
+            .map(|role_cols| {
+                role_cols
+                    .values()
+                    .map(|idx| f(&self.columns[*idx]))
+                    .collect::<Vec<T>>()
+            })
+            .unwrap_or_default()
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SyncColumn {
     role: ColumnRole,
-    name: String,
+    name: Arc<str>,
     field: FieldRef,
 }
 
@@ -134,8 +158,8 @@ impl SyncColumn {
     //
     // For all roles except `Changed`, the sync column refers to itself, but for `Changed` it refers
     // to a `Value` column whose field name is the same as this name.
-    pub fn name(&self) -> &String {
-        &self.name
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
     }
 
     // Get the field from the arrow schema
@@ -159,7 +183,7 @@ impl SyncColumn {
     pub fn column_descriptor(&self) -> ColumnDescriptor {
         ColumnDescriptor {
             role: self.role as _,
-            name: self.name.clone(),
+            name: self.name.to_string(),
         }
     }
 }

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -1,6 +1,6 @@
-use crate::frontend::flight::sync::schema::{SyncColumn, SyncSchema};
-use crate::frontend::flight::sync::writer::{DataSyncItem, LOWER_SYNC, UPPER_SYNC};
-use crate::frontend::flight::sync::SyncResult;
+use crate::sync::schema::{SyncColumn, SyncSchema};
+use crate::sync::writer::{DataSyncItem, LOWER_SYNC, UPPER_SYNC};
+use crate::sync::SyncResult;
 use arrow::array::{new_null_array, Array, ArrayRef, RecordBatch, Scalar, UInt64Array};
 use arrow::compute::kernels::cmp::{gt_eq, lt_eq};
 use arrow::compute::{and_kleene, bool_or, concat_batches, filter, is_not_null, take};
@@ -699,11 +699,9 @@ fn project_value_column(
 
 #[cfg(test)]
 mod tests {
-    use crate::frontend::flight::sync::schema::SyncSchema;
-    use crate::frontend::flight::sync::utils::{
-        construct_qualifier, get_prune_map, squash_batches,
-    };
-    use crate::frontend::flight::sync::writer::DataSyncItem;
+    use crate::sync::schema::SyncSchema;
+    use crate::sync::utils::{construct_qualifier, get_prune_map, squash_batches};
+    use crate::sync::writer::DataSyncItem;
     use arrow::array::{
         Array, ArrayRef, BooleanArray, Float64Array, Int32Array, RecordBatch,
         StringArray, UInt8Array,

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -419,7 +419,6 @@ pub(super) fn merge_schemas(
     let mut projection = vec![];
     let mut col_desc = IndexSet::new();
 
-    // TODO: implement sync role indexing in SyncSchema to make all the lookups below cheap
     // Project all sync columns from the lower schema
     for lower_sync_col in lower_schema.columns() {
         // Build the expression to project the combined column

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -236,7 +236,7 @@ pub(super) fn construct_qualifier(
         .filter(|col| col.role() == role)
         .map(|col| {
             Ok((
-                col.name().clone(),
+                col.name().to_string(),
                 (
                     MinAccumulator::try_new(col.field().data_type())?,
                     MaxAccumulator::try_new(col.field().data_type())?,
@@ -319,18 +319,14 @@ pub(super) fn get_prune_map(
 
         if let Some(min_vals) = maybe_min_vals {
             for file in 0..partition_count {
-                min_values.insert(
-                    (col.name().as_str(), file),
-                    Scalar::new(min_vals.slice(file, 1)),
-                );
+                min_values
+                    .insert((col.name(), file), Scalar::new(min_vals.slice(file, 1)));
             }
         }
         if let Some(max_vals) = maybe_max_vals {
             for file in 0..partition_count {
-                max_values.insert(
-                    (col.name().as_str(), file),
-                    Scalar::new(max_vals.slice(file, 1)),
-                );
+                max_values
+                    .insert((col.name(), file), Scalar::new(max_vals.slice(file, 1)));
             }
         }
     }
@@ -372,7 +368,7 @@ pub(super) fn get_prune_map(
                             continue;
                         }
 
-                        let col_file = (pk_col.name().as_str(), ind);
+                        let col_file = (pk_col.name(), ind);
                         let next_sync_prune_map = match (
                             min_values.get(&col_file),
                             max_values.get(&col_file),
@@ -635,7 +631,7 @@ fn project_value_column(
         // column that takes all the values from this sync and no value from the other sync
         col_desc.insert(ColumnDescriptor {
             role: ColumnRole::Changed as _,
-            name: this_value_col.name().clone(),
+            name: this_value_col.name().to_string(),
         });
         projection.push(when(col(this_sync).is_null(), lit(false)).otherwise(lit(true))?);
     }

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -763,7 +763,7 @@ impl SeafowlDataSyncWriter {
         // while logical column names are found in the arrow fields
         let (base_pk_cols, sync_pk_cols): (Vec<String>, Vec<String>) = sync_schema
             .map_columns(ColumnRole::OldPk, |c| {
-                (c.name().clone(), c.field().name().clone())
+                (c.name().to_string(), c.field().name().clone())
             })
             .into_iter()
             .unzip();


### PR DESCRIPTION
To make the lookups during logical sync squashing faster pre-index the sync schema columns by role and name.

Also do `git mv src/frontend/flight/sync/* src/sync`.