### PR TITLE
Improve Delta Table loading error message

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -98,7 +98,12 @@ impl SchemaProvider for SeafowlSchema {
             },
         };
 
-        delta_table.load().await?;
+        delta_table.load().await.map_err(|e| {
+            DataFusionError::Context(
+                format!("loading Delta Table {}.{}", self.name, name),
+                Box::new(DataFusionError::External(Box::new(e))),
+            )
+        })?;
 
         let table = Arc::from(delta_table) as Arc<dyn TableProvider>;
         self.tables.insert(Arc::from(name), table.clone());

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -146,7 +146,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
         .unwrap_err();
     assert_eq!(
         err.to_string(),
-        "External error: Not a Delta table: no log files".to_string()
+        "loading Delta Table public.replicated_table\ncaused by\nExternal error: Not a Delta table: no log files".to_string()
     );
 
     //


### PR DESCRIPTION
Inject context with the actual table name we were trying to load

Before:

```
External error: Not a Delta table: no log files
```

After:

```
loading Delta Table public.replicated_table
caused by
External error: Not a Delta table: no log files
```