### PR TITLE
Make replication idempotent against commited rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5888,6 +5888,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-functions-nested",
  "datafusion-remote-tables",
  "deltalake",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = "0.1.82"
 datafusion = "41.0.0"
 datafusion-common = "41.0.0"
 datafusion-expr = "41.0.0"
+datafusion-functions-nested = "41.0.0"
 
 futures = "0.3"
 
@@ -90,6 +91,7 @@ dashmap = "6.1.0"
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
+datafusion-functions-nested = { workspace = true }
 
 datafusion-remote-tables = { path = "./datafusion_remote_tables", optional = true }
 

--- a/src/context/delta.rs
+++ b/src/context/delta.rs
@@ -48,11 +48,7 @@ const PARTITION_FILE_BUFFER_SIZE: usize = 128 * 1024;
 // This denotes the threshold size for an individual multipart request payload prior to upload.
 // It dictates the memory usage, as we'll need to to keep each part in memory until sent.
 const PARTITION_FILE_MIN_PART_SIZE: usize = 5 * 1024 * 1024;
-// Controls how many multipart upload tasks we let run in parallel; this is in part dictated by the
-// fact that object store concurrently uploads parts for each of our tasks. That concurrency in
-// turn is hard coded to 8 (https://github.com/apache/arrow-rs/blob/master/object_store/src/aws/mod.rs#L145)
-// meaning that with 2 partition upload tasks x 8 part upload tasks x 5MB we have 80MB of memory usage
-const PARTITION_FILE_UPLOAD_MAX_CONCURRENCY: usize = 2;
+const PARTITION_FILE_UPLOAD_MAX_CONCURRENCY: usize = 5;
 
 #[cfg(test)]
 fn get_uuid() -> Uuid {

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -24,8 +24,6 @@ use crate::sync::schema::SyncSchema;
 use crate::sync::writer::SeafowlDataSyncWriter;
 use crate::sync::SyncResult;
 
-pub const SEAFOWL_SYNC_CALL_MAX_ROWS: usize = 65536;
-
 lazy_static! {
     pub static ref SEAFOWL_SQL_DATA: SqlInfoData = {
         let mut builder = SqlInfoDataBuilder::new();

--- a/src/frontend/flight/sql.rs
+++ b/src/frontend/flight/sql.rs
@@ -202,6 +202,7 @@ impl FlightSqlService for SeafowlFlightHandler {
             SyncSchema::try_new(
                 cmd.column_descriptors.clone(),
                 batches.first().unwrap().schema(),
+                true,
             )
             .map_err(|err| {
                 warn!("{err}");

--- a/src/frontend/flight/sql.rs
+++ b/src/frontend/flight/sql.rs
@@ -1,7 +1,5 @@
 use crate::catalog::memory::MemoryStore;
-use crate::frontend::flight::handler::{
-    SeafowlFlightHandler, SEAFOWL_SQL_DATA, SEAFOWL_SYNC_CALL_MAX_ROWS,
-};
+use crate::frontend::flight::handler::{SeafowlFlightHandler, SEAFOWL_SQL_DATA};
 use crate::sync::schema::SyncSchema;
 use crate::sync::SyncError;
 use arrow::record_batch::RecordBatch;
@@ -201,17 +199,6 @@ impl FlightSqlService for SeafowlFlightHandler {
         .await?;
 
         let sync_schema = if !batches.is_empty() {
-            // Validate row count under prescribed limit
-            if batches
-                .iter()
-                .fold(0, |rows, batch| rows + batch.num_rows())
-                > SEAFOWL_SYNC_CALL_MAX_ROWS
-            {
-                let err = format!("Change contains more than max allowed {SEAFOWL_SYNC_CALL_MAX_ROWS} rows");
-                warn!(err);
-                return Err(Status::invalid_argument(err));
-            }
-
             SyncSchema::try_new(
                 cmd.column_descriptors.clone(),
                 batches.first().unwrap().schema(),

--- a/src/sync/metrics.rs
+++ b/src/sync/metrics.rs
@@ -10,7 +10,7 @@ const IN_MEMORY_BYTES: &str = "seafowl_changeset_writer_in_memory_bytes_current"
 const IN_MEMORY_ROWS: &str = "seafowl_changeset_writer_in_memory_rows_current";
 const IN_MEMORY_OLDEST: &str =
     "seafowl_changeset_writer_in_memory_oldest_timestamp_seconds";
-const SQUASH_TIME: &str = "seafowl_changeset_writer_squash_time_seconds";
+const SQUASH_TIME: &str = "seafowl_changeset_writer_squash_time_milliseconds";
 const SQUASHED_BYTES: &str = "seafowl_changeset_writer_squashed_bytes_total";
 const SQUASHED_ROWS: &str = "seafowl_changeset_writer_squashed_rows_total";
 const PRUNING_TIME: &str = "seafowl_changeset_writer_pruning_time_milliseconds";

--- a/src/sync/schema/merge.rs
+++ b/src/sync/schema/merge.rs
@@ -1,4 +1,4 @@
-use crate::sync::planner::LOWER_SYNC;
+use crate::sync::planner::LOWER_REL;
 use crate::sync::schema::join::{
     join_changed_column, join_new_pk_column, join_old_pk_column, join_value_column,
 };
@@ -180,8 +180,10 @@ pub(crate) fn merge_schemas(
     // Wrap the final projection expression in a qualified alias, since it will act as a new lower
     // sync in the subsequent merge
     let qual_as_lower = |(expr, cd): (&mut Expr, &ColumnDescriptor)| {
-        *expr = std::mem::take(expr)
-            .alias_qualified(Some(LOWER_SYNC), SyncColumn::canonical_field_name(cd));
+        *expr = std::mem::take(expr).alias_qualified(
+            Some(LOWER_REL),
+            SyncColumn::canonical_field_name(cd.role(), &cd.name),
+        );
     };
 
     match &mut merge {

--- a/src/sync/schema/mod.rs
+++ b/src/sync/schema/mod.rs
@@ -2,6 +2,7 @@ use crate::sync::SyncError;
 use arrow_schema::{DataType, FieldRef, SchemaRef};
 use clade::sync::{ColumnDescriptor, ColumnRole};
 use std::collections::{HashMap, HashSet};
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 pub(super) mod join;
@@ -147,6 +148,26 @@ impl SyncSchema {
                     .collect::<Vec<T>>()
             })
             .unwrap_or_default()
+    }
+}
+
+impl Display for SyncSchema {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.columns()
+                .iter()
+                .map(|sync_col| format!(
+                    "{{{}, {}, {}, {}}}",
+                    sync_col.name,
+                    sync_col.role.as_str_name(),
+                    sync_col.field.data_type(),
+                    sync_col.field.name(),
+                ))
+                .collect::<Vec<String>>()
+                .join(", "),
+        )
     }
 }
 

--- a/src/sync/schema/mod.rs
+++ b/src/sync/schema/mod.rs
@@ -173,15 +173,8 @@ impl SyncColumn {
     }
 
     // Returns a canonical `SyncColumn` field (logical) name, used to name columns in a projection
-    pub fn canonical_field_name(column_descriptor: &ColumnDescriptor) -> String {
-        format!(
-            "{}_{}",
-            ColumnRole::try_from(column_descriptor.role)
-                .unwrap()
-                .as_str_name()
-                .to_lowercase(),
-            column_descriptor.name
-        )
+    pub fn canonical_field_name(role: ColumnRole, name: &str) -> String {
+        format!("{}_{name}", role.as_str_name().to_lowercase())
     }
 
     // Returns a corresponding `ColumnDescriptor` for this column

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -83,7 +83,8 @@ pub(super) fn squash_batches(
     // columns. There are 3 categories of columns for which we track row ids: old PKs, new PKs, and
     // changed columns.
     let mut chain_count = 0;
-    let mut column_rows: Vec<(u64, u64, Vec<u64>)> = vec![];
+    let mut column_rows: Vec<(u64, u64, Vec<u64>)> =
+        Vec::with_capacity(old_pks.num_rows());
     let mut temp_rows = HashSet::new();
     let mut pk_chains: HashMap<Row, usize> = HashMap::new();
 

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -257,7 +257,7 @@ impl SeafowlDataSyncWriter {
             self.metrics.squash_time.record(duration as f64);
             self.metrics
                 .squashed_bytes
-                .increment((sync_size - size) as u64);
+                .increment((sync_size.saturating_sub(size)) as u64);
             self.metrics
                 .squashed_rows
                 .increment((sync_rows - rows) as u64);
@@ -624,7 +624,7 @@ mod tests {
     use crate::sync::schema::{arrow_to_sync_schema, SyncSchema};
     use crate::sync::writer::{SeafowlDataSyncWriter, SequenceNumber};
     use crate::sync::{SyncCommitInfo, SyncResult};
-    use arrow::array::{BooleanArray, Float32Array, Int32Array};
+    use arrow::array::{BooleanArray, Float32Array, Int32Array, StringArray};
     use arrow::{array::RecordBatch, util::data_gen::create_random_batch};
     use arrow_schema::{DataType, Field, Schema, SchemaRef};
     use datafusion_common::assert_batches_eq;
@@ -1080,29 +1080,34 @@ mod tests {
         assert_batches_eq!(expected, &results);
     }
 
+    type OldNewVal = (Vec<i32>, Vec<i32>, Option<Vec<&'static str>>);
+
     #[rstest]
-    #[case(vec![(vec![1, 2], vec![1, 2])])]
-    #[case(vec![(vec![1, 2], vec![2, 1]), (vec![1, 2], vec![2, 1])])]
+    #[case(vec![(vec![1, 2], vec![1, 2], None)])]
+    #[should_panic(expected = "assertion `left == right` failed")]
     #[case(vec![
-        (vec![2], vec![3]),
-        (vec![1], vec![2]),
-        (vec![3], vec![1]),
-        (vec![2], vec![3]),
-        (vec![1], vec![2]),
-        (vec![3], vec![1])])
+        (vec![1, 2], vec![2, 1], Some(vec!["a", "b"])),
+        (vec![2, 1], vec![1, 2], Some(vec!["a", "b"]))
+    ])]
+    #[case(vec![
+        (vec![2], vec![3], Some(vec!["b"])),
+        (vec![1], vec![2], Some(vec!["a"])),
+        (vec![3], vec![1], Some(vec!["b"])),
+        (vec![2], vec![3], Some(vec!["a"])),
+        (vec![1], vec![2], Some(vec!["b"])),
+        (vec![3], vec![1], Some(vec!["a"]))])
     ]
     #[tokio::test]
-    async fn test_sync_pk_cycles(
-        #[case] pk_cycle: Vec<(Vec<i32>, Vec<i32>)>,
-    ) -> SyncResult<()> {
+    async fn test_sync_pk_cycles(#[case] pk_cycle: Vec<OldNewVal>) {
         let ctx = Arc::new(in_memory_context().await);
         let mut sync_mgr = SeafowlDataSyncWriter::new(ctx.clone());
 
         ctx.plan_query(
-            "CREATE TABLE test_table(c1 INT, c2 INT) AS VALUES (1, 1), (2, 2)",
+            "CREATE TABLE test_table(c1 INT, c2 TEXT) AS VALUES (1, 'a'), (2, 'b')",
         )
-        .await?;
-        let table_uuid = ctx.get_table_uuid("test_table").await?;
+        .await
+        .unwrap();
+        let table_uuid = ctx.get_table_uuid("test_table").await.unwrap();
 
         // Ensure original content
         let plan = ctx.plan_query("SELECT * FROM test_table").await.unwrap();
@@ -1112,8 +1117,8 @@ mod tests {
             "+----+----+",
             "| c1 | c2 |",
             "+----+----+",
-            "| 1  | 1  |",
-            "| 2  | 2  |",
+            "| 1  | a  |",
+            "| 2  | b  |",
             "+----+----+",
         ];
         assert_batches_eq!(expected, &results);
@@ -1122,9 +1127,9 @@ mod tests {
             Field::new("old_pk_c1", DataType::Int32, true),
             Field::new("new_pk_c1", DataType::Int32, true),
             Field::new("changed_c2", DataType::Boolean, true),
-            Field::new("value_c2", DataType::Int32, true),
+            Field::new("value_c2", DataType::Utf8, true),
         ]));
-        let sync_schema = arrow_to_sync_schema(schema.clone())?;
+        let sync_schema = arrow_to_sync_schema(schema.clone()).unwrap();
 
         // Enqueue all syncs
         let log_store = ctx
@@ -1133,25 +1138,34 @@ mod tests {
             .get_log_store(&table_uuid.to_string());
 
         // Cycle through the PKs, to end up in the same place as at start
-        for (old_pks, new_pks) in pk_cycle {
-            sync_mgr.enqueue_sync(
-                log_store.clone(),
-                None,
-                A.to_string(),
-                sync_schema.clone(),
-                vec![RecordBatch::try_new(
-                    schema.clone(),
-                    vec![
-                        Arc::new(Int32Array::from(old_pks.clone())),
-                        Arc::new(Int32Array::from(new_pks)),
-                        Arc::new(BooleanArray::from(vec![false; old_pks.len()])),
-                        Arc::new(Int32Array::from(vec![None; old_pks.len()])),
-                    ],
-                )?],
-            )?;
+        for (old_pks, new_pks, value) in pk_cycle {
+            sync_mgr
+                .enqueue_sync(
+                    log_store.clone(),
+                    None,
+                    A.to_string(),
+                    sync_schema.clone(),
+                    vec![RecordBatch::try_new(
+                        schema.clone(),
+                        vec![
+                            Arc::new(Int32Array::from(old_pks.clone())),
+                            Arc::new(Int32Array::from(new_pks)),
+                            Arc::new(BooleanArray::from(vec![
+                                value.is_some();
+                                old_pks.len()
+                            ])),
+                            Arc::new(
+                                value
+                                    .map(StringArray::from)
+                                    .unwrap_or(StringArray::new_null(old_pks.len())),
+                            ),
+                        ],
+                    )
+                    .unwrap()],
+                )
+                .unwrap();
         }
-
-        sync_mgr.flush_syncs(log_store.root_uri()).await?;
+        sync_mgr.flush_syncs(log_store.root_uri()).await.unwrap();
 
         // Ensure updated content is the same as original
         let plan = ctx
@@ -1164,12 +1178,10 @@ mod tests {
             "+----+----+",
             "| c1 | c2 |",
             "+----+----+",
-            "| 1  | 1  |",
-            "| 2  | 2  |",
+            "| 1  | a  |",
+            "| 2  | b  |",
             "+----+----+",
         ];
         assert_batches_eq!(expected, &results);
-
-        Ok(())
     }
 }

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -1084,10 +1084,9 @@ mod tests {
 
     #[rstest]
     #[case(vec![(vec![1, 2], vec![1, 2], None)])]
-    #[should_panic(expected = "assertion `left == right` failed")]
     #[case(vec![
-        (vec![1, 2], vec![2, 1], Some(vec!["a", "b"])),
-        (vec![2, 1], vec![1, 2], Some(vec!["a", "b"]))
+        (vec![1, 2, 3], vec![3, 1, 2], Some(vec!["a", "b", "a"])),
+        (vec![1, 2, 3], vec![3, 1, 2], Some(vec!["b", "a", "b"])),
     ])]
     #[case(vec![
         (vec![2], vec![3], Some(vec!["b"])),

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -224,11 +224,15 @@ impl SeafowlDataSyncWriter {
             self.metrics.request_rows.increment(sync_rows as u64);
             let start = Instant::now();
             let batch = squash_batches(&sync_schema, batches)?;
-            let duration = start.elapsed().as_secs();
+            let duration = start.elapsed().as_millis();
 
             // Get new size and row count
             let size = batch.get_array_memory_size();
             let rows = batch.num_rows();
+            debug!(
+                "Physical squashing removed {} rows in {duration} ms for batch with schema \n{sync_schema}",
+                sync_rows - rows,
+            );
 
             let item = DataSyncItem {
                 tx_id,

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -312,6 +312,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
         cd2.clone(),
         cd3.clone(),
         cd4.clone(),
+        cd5.clone(),
         cd6.clone(),
         cd7.clone(),
     ];
@@ -321,6 +322,7 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
         f2.clone(),
         f3.clone(),
         f4.clone(),
+        f5.clone(),
         f6.clone(),
         f7.clone(),
     ]));
@@ -345,13 +347,17 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
                 Some("eight"),
                 Some("two"),
             ])),
+            // As per the rules during PK-changing updates all columns must be emitted, even if they're
+            // empty
+            Arc::new(Float64Array::from(vec![None, None, None, None])),
             Arc::new(StringArray::from(vec![
                 Some("seven"),
                 Some("six in sync #4"),
                 None,
-                None,
+                // As per the rules during PK-changing updates the TOASTed columns must be re-emitted
+                Some("four"),
             ])),
-            Arc::new(BooleanArray::from(vec![false, true, true, false])),
+            Arc::new(BooleanArray::from(vec![false, true, true, true])),
         ],
     )?;
 


### PR DESCRIPTION
## What

To make replication robust in the face of failures and crashes we need to be able to apply the same messages multiple times without the state deviating from the expected one. This should hold in general, i.e. for INSERTs, DELETEs, and UPDATEs (whether they change the PK or not).

## How

Split up PK-changing UPDATEs into DELETEs + INSERTs, which makes them idempotent, assuming all columns (TOASTed or not) are supplied for such cases (since otherwise the INSERT has no idea where to pull the old values from).

## Why

Ultimately this is the fastest method method to get only-once semantics working, with alternatives such as aggregation/grouping/distinct-on etc. being much slower.