### PR TITLE
Replace the old vergen crate with a newer version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cap-fs-ext"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1335,29 @@ dependencies = [
  "once_cell",
  "rustix",
  "winx",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1914,6 +1946,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2549,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "derive_utils"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,26 +2711,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-iterator"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.74",
-]
 
 [[package]]
 name = "equivalent"
@@ -3062,18 +3140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,19 +3148,6 @@ dependencies = [
  "fallible-iterator 0.3.0",
  "indexmap 2.5.0",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "git2"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "libgit2-sys",
- "log",
- "url",
 ]
 
 [[package]]
@@ -3500,6 +3553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,18 +3827,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.14.2+1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,7 +3870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4234,15 +4280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +4393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -4948,7 +4994,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check",
 ]
 
@@ -5931,7 +5976,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid 1.10.0",
- "vergen",
+ "vergen-gitcl",
  "warp",
  "wasi-common",
  "wasmtime",
@@ -6617,20 +6662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.27.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6762,7 +6793,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -7365,20 +7398,43 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "349ed9e45296a581f455bc18039878f409992999bc1d5da12a6800eb18c8752f"
 dependencies = [
  "anyhow",
- "cfg-if",
- "enum-iterator",
- "getset",
- "git2",
+ "cargo_metadata",
+ "derive_builder",
+ "regex",
  "rustc_version",
  "rustversion",
- "sysinfo",
- "thiserror",
  "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3a7f91caabecefc3c249fd864b11d4abe315c166fbdb568964421bccfd2b7a"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229eaddb0050920816cf051e619affaf18caa3dd512de8de5839ccbc8e53abb0"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ wiremock = "0.6"
 
 [build-dependencies]
 anyhow = "1.0.89"  # for build.rs
-vergen = "7"
+vergen-gitcl = { version = "1", features = ["build", "cargo", "rustc"] }
 
 [profile.release]
 codegen-units = 1

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,23 @@
 use anyhow::Result;
-use vergen::{vergen, Config, ShaKind};
+use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
 
 fn main() -> Result<()> {
-    // Generate the default 'cargo:' instruction output
-    let mut config = Config::default();
-    // Change the SHA output to the short variant
-    *config.git_mut().sha_kind_mut() = ShaKind::Short;
-    // Add a `-dirty` flag to the SEMVER output
-    *config.git_mut().semver_dirty_mut() = Some("-dirty");
+    let build = BuildBuilder::all_build()?;
+    let cargo = CargoBuilder::all_cargo()?;
 
-    vergen(Config::default())
+    let gitcl = GitclBuilder::default()
+        .all()
+        // Change the SHA output to the short variant
+        .sha(true)
+        // Add a `-dirty` flag to the SEMVER output
+        .dirty(true)
+        .build()?;
+    let rustc = RustcBuilder::all_rustc()?;
+
+    Emitter::default()
+        .add_instructions(&build)?
+        .add_instructions(&cargo)?
+        .add_instructions(&gitcl)?
+        .add_instructions(&rustc)?
+        .emit()
 }

--- a/src/frontend/flight/handler.rs
+++ b/src/frontend/flight/handler.rs
@@ -29,7 +29,7 @@ lazy_static! {
         let mut builder = SqlInfoDataBuilder::new();
         // Server information
         builder.append(SqlInfo::FlightSqlServerName, "Seafowl Flight SQL Server");
-        builder.append(SqlInfo::FlightSqlServerVersion, env!("VERGEN_GIT_SEMVER"));
+        builder.append(SqlInfo::FlightSqlServerVersion, env!("VERGEN_RUSTC_SEMVER"));
         // 1.3 comes from https://github.com/apache/arrow/blob/f9324b79bf4fc1ec7e97b32e3cce16e75ef0f5e3/format/Schema.fbs#L24
         builder.append(SqlInfo::FlightSqlServerArrowVersion, "1.3");
         builder.build().unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn print_version_info(f: &mut impl std::io::Write) -> std::io::Result<()> {
     writeln!(
         f,
         "Seafowl {} ({} {})",
-        env!("VERGEN_GIT_SEMVER"),
+        env!("VERGEN_GIT_DESCRIBE"),
         env!("VERGEN_GIT_SHA"),
         env!("VERGEN_GIT_COMMIT_TIMESTAMP")
     )?;
@@ -100,12 +100,8 @@ fn print_version_info(f: &mut impl std::io::Write) -> std::io::Result<()> {
         env!("VERGEN_RUSTC_HOST_TRIPLE"),
         env!("VERGEN_BUILD_TIMESTAMP")
     )?;
-    writeln!(
-        f,
-        "Target: {} {}",
-        env!("VERGEN_CARGO_PROFILE"),
-        env!("VERGEN_CARGO_TARGET_TRIPLE"),
-    )?;
+    writeln!(f, "Target: {}", env!("VERGEN_CARGO_TARGET_TRIPLE"),)?;
+    writeln!(f, "Opt level: {}", env!("VERGEN_CARGO_OPT_LEVEL"))?;
     writeln!(f, "Features: {}", env!("VERGEN_CARGO_FEATURES"))?;
 
     Ok(())
@@ -124,7 +120,7 @@ async fn main() {
         prepare_tracing(args.json_logs)
     }
 
-    info!("Starting Seafowl {}", env!("VERGEN_BUILD_SEMVER"));
+    info!("Starting Seafowl {}", env!("CARGO_PKG_VERSION"));
 
     let config_path = &args.config_path;
 

--- a/src/object_store/http.rs
+++ b/src/object_store/http.rs
@@ -152,7 +152,7 @@ impl HttpObjectStore {
     fn request_builder(&self, path: &Path) -> RequestBuilder {
         self.client.get(self.get_uri(path)).header(
             "User-Agent",
-            format!("Seafowl/{}", env!("VERGEN_GIT_SEMVER")),
+            format!("Seafowl/{}", env!("VERGEN_RUSTC_SEMVER")),
         )
     }
 
@@ -391,7 +391,7 @@ impl ObjectStore for HttpObjectStore {
         let response = self
             .send(self.client.head(&uri).header(
                 "User-Agent",
-                format!("Seafowl/{}", env!("VERGEN_GIT_SEMVER")),
+                format!("Seafowl/{}", env!("VERGEN_RUSTC_SEMVER")),
             ))
             .await;
 


### PR DESCRIPTION
The signature is slightly changed and goes from
```
Seafowl v0.5.5-311-g4eaf0be (4eaf0bee53eb42a8401d3e791356c5a5b2061c78 2024-09-16T15:14:22Z)

Built by rustc 1.83.0-nightly on aarch64-apple-darwin at 2024-09-18T15:16:25.255082Z
Target: release aarch64-apple-darwin
Features: catalog_postgres,convergence,convergence_arrow,default,frontend_arrow_flight,frontend_postgres,remote_tables
```

to

```
Seafowl v0.5.5-311-g4eaf0be (4eaf0be 2024-09-16T17:14:22.000000000+02:00)

Built by rustc 1.83.0-nightly on aarch64-apple-darwin at 2024-09-19T12:42:57.988564000Z
Target: aarch64-apple-darwin
Opt level: 0
Features: catalog_postgres,convergence,convergence_arrow,default,frontend_arrow_flight,frontend_postgres,remote_tables
```

The `VERGEN_CARGO_PROFILE` var is no longer available, and the [recommended](https://github.com/rustyhorde/vergen/issues/171) replacement is `VERGEN_CARGO_OPT_LEVEL`