### PR TITLE
Fix prefix swallowing when creating the object store

### DIFF
--- a/ci/clippy.sh
+++ b/ci/clippy.sh
@@ -7,4 +7,4 @@
 # https://users.rust-lang.org/t/pre-commit-clippy-fix/66584
 
 cargo clippy --all-targets --workspace --fix --allow-dirty --allow-staged --allow-no-vcs
-cargo clippy --all-targets --workspace -- -D warnings
+cargo clippy --all-targets --workspace -- -D warnings --allow clippy::needless_return  # remove once 13458 is resolved

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -228,13 +228,13 @@ impl<'de> Deserialize<'de> for AccessSettings {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(d)?;
-        return match s.as_str() {
+        match s.as_str() {
             "any" => Ok(AccessSettings::Any),
             "off" => Ok(AccessSettings::Off),
             s => Ok(AccessSettings::Password {
                 sha256_hash: s.to_string(),
             }),
-        };
+        }
     }
 }
 

--- a/src/object_store/factory.rs
+++ b/src/object_store/factory.rs
@@ -148,7 +148,12 @@ impl ObjectStoreFactory {
 
         // This is the least surprising way to extend the path, and make the url point to the table
         // root: https://github.com/servo/rust-url/issues/333
-        url.path_segments_mut().unwrap().push(&table_path);
+        url.path_segments_mut()
+            .map_err(|_| object_store::Error::Generic {
+                store: "object_store_factory",
+                source: "The provided URL is a cannot-be-a-base URL".into(),
+            })?
+            .push(&table_path);
 
         let prefixed_store: PrefixStore<Arc<dyn ObjectStore>> =
             PrefixStore::new(store, prefix);

--- a/src/wasm_udf/data_types.rs
+++ b/src/wasm_udf/data_types.rs
@@ -150,7 +150,6 @@ pub struct CreateFunctionDetails {
 }
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
 

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -37,6 +37,29 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
         })
     }
 
+    let minio_options = HashMap::from([
+        (
+            AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
+            "http://127.0.0.1:9000".to_string(),
+        ),
+        (
+            AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
+            "minioadmin".to_string(),
+        ),
+        (
+            AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
+            "minioadmin".to_string(),
+        ),
+        (
+            // This has been removed from the config enum, but it can
+            // still be picked up via `AmazonS3ConfigKey::from_str`
+            AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp)
+                .as_ref()
+                .to_string(),
+            "true".to_string(),
+        ),
+    ]);
+
     ListSchemaResponse {
         schemas: vec![
             SchemaObject {
@@ -45,11 +68,18 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
             },
             SchemaObject {
                 name: "s3".to_string(),
-                tables: vec![TableObject {
-                    name: "minio".to_string(),
-                    path: "test-data/delta-0.8.0-partitioned".to_string(),
-                    store: Some("minio".to_string()),
-                }],
+                tables: vec![
+                    TableObject {
+                        name: "minio".to_string(),
+                        path: "test-data/delta-0.8.0-partitioned".to_string(),
+                        store: Some("minio".to_string()),
+                    },
+                    TableObject {
+                        name: "minio_prefix".to_string(),
+                        path: "delta-0.8.0-partitioned".to_string(),
+                        store: Some("minio-prefix".to_string()),
+                    },
+                ],
             },
             SchemaObject {
                 name: "gcs".to_string(),
@@ -64,28 +94,12 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
             StorageLocation {
                 name: "minio".to_string(),
                 location: "s3://seafowl-test-bucket".to_string(),
-                options: HashMap::from([
-                    (
-                        AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
-                        "http://127.0.0.1:9000".to_string(),
-                    ),
-                    (
-                        AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
-                        "minioadmin".to_string(),
-                    ),
-                    (
-                        AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
-                        "minioadmin".to_string(),
-                    ),
-                    (
-                        // This has been removed from the config enum, but it can
-                        // still be picked up via `AmazonS3ConfigKey::from_str`
-                        AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp)
-                            .as_ref()
-                            .to_string(),
-                        "true".to_string(),
-                    ),
-                ]),
+                options: minio_options.clone(),
+            },
+            StorageLocation {
+                name: "minio-prefix".to_string(),
+                location: "s3://seafowl-test-bucket/test-data".to_string(),
+                options: minio_options,
             },
             StorageLocation {
                 name: "fake-gcs".to_string(),

--- a/tests/flight/inline_metastore.rs
+++ b/tests/flight/inline_metastore.rs
@@ -21,6 +21,7 @@ use crate::flight::*;
 // Testing with properly sent inline metastore
 #[case("local.file_with_store", TestServerType::InlineOnly, false)]
 #[case("s3.minio", TestServerType::InlineOnly, false)]
+#[case("s3.minio_prefix", TestServerType::InlineOnly, false)]
 #[case("gcs.fake", TestServerType::InlineOnly, false)]
 #[tokio::test]
 async fn test_inline_query(

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -55,6 +55,7 @@ impl TestSeafowl {
 }
 
 // Actual Seafowl target running in a separate process
+#[allow(clippy::zombie_processes)]
 #[fixture]
 pub async fn test_seafowl() -> TestSeafowl {
     // Pick free ports for the frontends


### PR DESCRIPTION
Append the table path to the pre-existing url path instead of replacing it.