### PR TITLE
Add an option to the local FS config to make all missing directories on the path

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -638,6 +638,7 @@ cache_control = "private, max-age=86400"
                 object_store: Some(ObjectStoreConfig::Local(LocalConfig {
                     data_dir: "./seafowl-data".to_string(),
                     disable_hardlinks: false,
+                    create_dir: false,
                 })),
                 catalog: Some(Catalog::Postgres(Postgres {
                     dsn: "postgresql://user:pass@localhost:5432/somedb".to_string(),
@@ -734,6 +735,7 @@ cache_control = "private, max-age=86400"
                 object_store: Some(ObjectStoreConfig::Local(LocalConfig {
                     data_dir: "some_other_path".to_string(),
                     disable_hardlinks: false,
+                    create_dir: false,
                 })),
                 catalog: Some(Catalog::Sqlite(Sqlite {
                     dsn: "sqlite://file.sqlite".to_string(),

--- a/src/context/delta.rs
+++ b/src/context/delta.rs
@@ -525,6 +525,7 @@ mod tests {
                     ObjectStoreConfig::Local(LocalConfig {
                         data_dir: tmp_dir.path().to_string_lossy().to_string(),
                         disable_hardlinks: false,
+                        create_dir: false,
                     }),
                 ),
                 Some(tmp_dir),

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -37,29 +37,6 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
         })
     }
 
-    let minio_options = HashMap::from([
-        (
-            AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
-            "http://127.0.0.1:9000".to_string(),
-        ),
-        (
-            AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
-            "minioadmin".to_string(),
-        ),
-        (
-            AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
-            "minioadmin".to_string(),
-        ),
-        (
-            // This has been removed from the config enum, but it can
-            // still be picked up via `AmazonS3ConfigKey::from_str`
-            AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp)
-                .as_ref()
-                .to_string(),
-            "true".to_string(),
-        ),
-    ]);
-
     ListSchemaResponse {
         schemas: vec![
             SchemaObject {
@@ -94,12 +71,12 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
             StorageLocation {
                 name: "minio".to_string(),
                 location: "s3://seafowl-test-bucket".to_string(),
-                options: minio_options.clone(),
+                options: minio_options(),
             },
             StorageLocation {
                 name: "minio-prefix".to_string(),
                 location: "s3://seafowl-test-bucket/test-data".to_string(),
-                options: minio_options,
+                options: minio_options(),
             },
             StorageLocation {
                 name: "fake-gcs".to_string(),
@@ -119,4 +96,29 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
             },
         ],
     }
+}
+
+pub fn minio_options() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
+            "http://127.0.0.1:9000".to_string(),
+        ),
+        (
+            AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
+            "minioadmin".to_string(),
+        ),
+        (
+            AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
+            "minioadmin".to_string(),
+        ),
+        (
+            // This has been removed from the config enum, but it can
+            // still be picked up via `AmazonS3ConfigKey::from_str`
+            AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp)
+                .as_ref()
+                .to_string(),
+            "true".to_string(),
+        ),
+    ])
 }

--- a/tests/flight/mod.rs
+++ b/tests/flight/mod.rs
@@ -76,6 +76,7 @@ bind_host = "127.0.0.1"
 bind_port = {}
 
 [misc.sync_conf]
+max_in_memory_bytes = 1000000
 max_replication_lag_s = 1
 flush_task_interval_s = 1"#,
         addr.port()

--- a/tests/flight/sync.rs
+++ b/tests/flight/sync.rs
@@ -1,5 +1,8 @@
+use crate::fixtures::minio_options;
 use crate::flight::*;
+use clade::schema::StorageLocation;
 use clade::sync::{ColumnDescriptor, ColumnRole};
+use tempfile::TempDir;
 
 pub(crate) fn sync_cmd_to_flight_data(
     cmd: DataSyncCommand,
@@ -486,6 +489,95 @@ async fn test_sync_happy_path() -> std::result::Result<(), Box<dyn std::error::E
     ];
 
     assert_batches_sorted_eq!(expected, &results);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sync_custom_store() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let (_ctx, mut client) = flight_server(TestServerType::Memory).await;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, true),
+        Field::new("b", DataType::Int32, true),
+        Field::new("c", DataType::Utf8, true),
+    ]));
+    let column_descriptors = vec![
+        ColumnDescriptor {
+            role: ColumnRole::OldPk as _,
+            name: "c1".to_string(),
+        },
+        ColumnDescriptor {
+            role: ColumnRole::NewPk as _,
+            name: "c1".to_string(),
+        },
+        ColumnDescriptor {
+            role: ColumnRole::Value as _,
+            name: "c2".to_string(),
+        },
+    ];
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::new_null(100_000)),
+            Arc::new(Int32Array::from((0..100_000).collect::<Vec<i32>>())),
+            Arc::new(StringArray::from(vec!["a"; 100_000])),
+        ],
+    )?;
+
+    // First sync a table to a local FS (temp table
+    let temp_dir = TempDir::new().unwrap();
+    let location = format!("file://{}", temp_dir.path().to_string_lossy());
+    let store = StorageLocation {
+        name: "local_fs".to_string(),
+        location,
+        options: Default::default(),
+    };
+
+    let cmd = DataSyncCommand {
+        path: "local_table".to_string(),
+        store: Some(store),
+        column_descriptors: column_descriptors.clone(),
+        origin: "42".to_string(),
+        sequence_number: Some(1000),
+    };
+
+    let sync_result = do_put_sync(cmd.clone(), batch.clone(), &mut client).await?;
+    assert_eq!(
+        sync_result,
+        DataSyncResponse {
+            accepted: true,
+            memory_sequence_number: Some(1000),
+            durable_sequence_number: Some(1000),
+            first: true,
+        }
+    );
+
+    let store = StorageLocation {
+        name: "minio".to_string(),
+        location: "s3://seafowl-test-bucket/some/path".to_string(),
+        options: minio_options(),
+    };
+
+    let cmd = DataSyncCommand {
+        path: "minio_table".to_string(),
+        store: Some(store),
+        column_descriptors,
+        origin: "42".to_string(),
+        sequence_number: Some(2000),
+    };
+
+    let sync_result = do_put_sync(cmd.clone(), batch, &mut client).await?;
+    assert_eq!(
+        sync_result,
+        DataSyncResponse {
+            accepted: true,
+            memory_sequence_number: Some(2000),
+            durable_sequence_number: Some(2000),
+            first: false,
+        }
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Also use that option in the replication interface (otherwise the object store creation may fail).

There is an alternative simpler change, which is also less flexible, and that is to simply do `LocalFileSystem::new()` in `LocalConfig::build_local_storage` and then wrap that in a `PrefixStore`. I don't particularly like that option due to the redundant wrapping, and for the fact that it doesn't do validation (which we may want in some cases).