### PR TITLE
Make sure that local FS url points only to the root storage location

### DIFF
--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -37,29 +37,6 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
         })
     }
 
-    let minio_options = HashMap::from([
-        (
-            AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
-            "http://127.0.0.1:9000".to_string(),
-        ),
-        (
-            AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
-            "minioadmin".to_string(),
-        ),
-        (
-            AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
-            "minioadmin".to_string(),
-        ),
-        (
-            // This has been removed from the config enum, but it can
-            // still be picked up via `AmazonS3ConfigKey::from_str`
-            AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp)
-                .as_ref()
-                .to_string(),
-            "true".to_string(),
-        ),
-    ]);
-
     ListSchemaResponse {
         schemas: vec![
             SchemaObject {
@@ -94,12 +71,12 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
             StorageLocation {
                 name: "minio".to_string(),
                 location: "s3://seafowl-test-bucket".to_string(),
-                options: minio_options.clone(),
+                options: minio_options(),
             },
             StorageLocation {
                 name: "minio-prefix".to_string(),
                 location: "s3://seafowl-test-bucket/test-data".to_string(),
-                options: minio_options,
+                options: minio_options(),
             },
             StorageLocation {
                 name: "fake-gcs".to_string(),
@@ -119,4 +96,29 @@ pub fn schemas(include_file_without_store: bool) -> ListSchemaResponse {
             },
         ],
     }
+}
+
+pub fn minio_options() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            AmazonS3ConfigKey::Endpoint.as_ref().to_string(),
+            "http://127.0.0.1:9000".to_string(),
+        ),
+        (
+            AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
+            "minioadmin".to_string(),
+        ),
+        (
+            AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
+            "minioadmin".to_string(),
+        ),
+        (
+            // This has been removed from the config enum, but it can
+            // still be picked up via `AmazonS3ConfigKey::from_str`
+            AmazonS3ConfigKey::Client(ClientConfigKey::AllowHttp)
+                .as_ref()
+                .to_string(),
+            "true".to_string(),
+        ),
+    ])
 }

--- a/tests/flight/mod.rs
+++ b/tests/flight/mod.rs
@@ -76,6 +76,7 @@ bind_host = "127.0.0.1"
 bind_port = {}
 
 [misc.sync_conf]
+max_in_memory_bytes = 1000000
 max_replication_lag_s = 1
 flush_task_interval_s = 1"#,
         addr.port()


### PR DESCRIPTION
The root storage location should always exist, and if it doesn't it'll error out with `Unable to canonicalize filesystem root`.

The additional table path should be wired in by a separate prefix store.