### PR TITLE
Align batch schema nullability during squashing

### DIFF
--- a/src/sync/schema/mod.rs
+++ b/src/sync/schema/mod.rs
@@ -28,7 +28,7 @@ impl SyncSchema {
         }
 
         // Validate field role's are parsable, we have the correct number of old/new PKs,
-        // and Changed role is non-nullable boolean type which points to an existing column
+        // and Changed role is a boolean type which points to an existing column
         // TODO: Validate a column can not be a PK and Value at the same time
         let mut old_pk_types = HashSet::new();
         let mut new_pk_types = HashSet::new();

--- a/src/sync/schema/mod.rs
+++ b/src/sync/schema/mod.rs
@@ -126,17 +126,18 @@ impl SyncSchema {
     pub fn with_fields(&mut self, fields: &Fields) -> SyncResult<()> {
         if fields.len() != self.columns.len() {
             return Err(SyncError::SchemaError {
-                reason: "New and old field count is different".to_string(),
+                reason: "New and old field counts are different".to_string(),
             });
         }
 
         for (col, field) in self.columns.iter_mut().zip(fields.iter()) {
-            if col.field.data_type() != field.data_type() {
+            let col_data_type = col.field.data_type();
+            let field_data_type = field.data_type();
+
+            if col_data_type != field_data_type {
                 return Err(SyncError::SchemaError {
                     reason: format!(
-                        "Expected {} but got {} for column {col:?}",
-                        col.field.data_type(),
-                        field.data_type()
+                        "Schema mismatch for column {col:?}: expected data type {col_data_type}, got {field_data_type}"
                     ),
                 });
             }

--- a/src/sync/schema/mod.rs
+++ b/src/sync/schema/mod.rs
@@ -1,5 +1,5 @@
-use crate::sync::SyncError;
-use arrow_schema::{DataType, FieldRef, SchemaRef};
+use crate::sync::{SyncError, SyncResult};
+use arrow_schema::{DataType, FieldRef, Fields, SchemaRef};
 use clade::sync::{ColumnDescriptor, ColumnRole};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
@@ -20,7 +20,7 @@ impl SyncSchema {
         column_descriptors: Vec<ColumnDescriptor>,
         schema: SchemaRef,
         validate_pks: bool,
-    ) -> Result<Self, SyncError> {
+    ) -> SyncResult<Self> {
         if column_descriptors.len() != schema.flattened_fields().len() {
             return Err(SyncError::SchemaError {
                 reason: "Column descriptors do not match the schema".to_string(),
@@ -120,6 +120,31 @@ impl SyncSchema {
             columns: vec![],
             indices: Default::default(),
         }
+    }
+
+    // Replace the existing field references for sync columns with new ones.
+    pub fn with_fields(&mut self, fields: &Fields) -> SyncResult<()> {
+        if fields.len() != self.columns.len() {
+            return Err(SyncError::SchemaError {
+                reason: "New and old field count is different".to_string(),
+            });
+        }
+
+        for (col, field) in self.columns.iter_mut().zip(fields.iter()) {
+            if col.field.data_type() != field.data_type() {
+                return Err(SyncError::SchemaError {
+                    reason: format!(
+                        "Expected {} but got {} for column {col:?}",
+                        col.field.data_type(),
+                        field.data_type()
+                    ),
+                });
+            }
+
+            col.field = field.clone();
+        }
+
+        Ok(())
     }
 
     pub fn column(&self, name: &str, role: ColumnRole) -> Option<&SyncColumn> {

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -320,7 +320,8 @@ impl SeafowlDataSyncWriter {
         Ok(())
     }
 
-    // Criteria for return the cached entry ready to be persisted to storage.
+    // Criteria for flushing a cached entry to object storage.
+    //
     // First flush any records that are explicitly beyond the configured max
     // lag, followed by further entries if we're still above max cache size.
     fn flush_ready(&mut self) -> SyncResult<Option<String>> {
@@ -372,7 +373,7 @@ impl SeafowlDataSyncWriter {
         Ok(None)
     }
 
-    // Flush the table containing the oldest sync in memory
+    // Flush the table with the provided url
     async fn flush_syncs(&mut self, url: String) -> SyncResult<()> {
         self.physical_squashing(&url)?;
         let entry = match self.syncs.get(&url) {

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -513,7 +513,7 @@ impl SeafowlDataSyncWriter {
                 let (old_size, old_rows) = get_size_and_rows(&item.data);
 
                 let start = Instant::now();
-                let batch = squash_batches(&item.sync_schema, &item.data)?;
+                let batch = squash_batches(&mut item.sync_schema, &item.data)?;
                 let duration = start.elapsed().as_millis();
 
                 // Get new size and row count


### PR DESCRIPTION
This prevents arrow `Column 'x' is declared as non-nullable but contains null values` errors during record batch creation.